### PR TITLE
feat: 将推理模型默认配置改成智谱API

### DIFF
--- a/frontend/src/routes/chat.tsx
+++ b/frontend/src/routes/chat.tsx
@@ -173,12 +173,12 @@ function ChatComponent() {
   const [showApiKey, setShowApiKey] = useState(false);
   const [showDecisionApiKey, setShowDecisionApiKey] = useState(false);
   const [tempConfig, setTempConfig] = useState({
-    base_url: '',
-    model_name: '',
+    base_url: VISION_PRESETS[0].config.base_url as string,
+    model_name: VISION_PRESETS[0].config.model_name as string,
     api_key: '',
     dual_model_enabled: false,
-    decision_base_url: '',
-    decision_model_name: '',
+    decision_base_url: DECISION_PRESETS[0].config.base_url as string,
+    decision_model_name: DECISION_PRESETS[0].config.model_name as string,
     decision_api_key: '',
     agent_type: 'glm',
     agent_config_params: {} as Record<string, unknown>,
@@ -199,19 +199,27 @@ function ChatComponent() {
           agent_type: data.agent_type || 'glm',
           agent_config_params: data.agent_config_params || undefined,
         });
+        // 当后端返回空配置时，使用智谱预设作为默认值
+        const useDefault = !data.base_url;
         setTempConfig({
-          base_url: data.base_url,
-          model_name: data.model_name,
+          base_url: useDefault
+            ? VISION_PRESETS[0].config.base_url
+            : data.base_url,
+          model_name: useDefault
+            ? VISION_PRESETS[0].config.model_name
+            : data.model_name,
           api_key: data.api_key || '',
           dual_model_enabled: data.dual_model_enabled || false,
-          decision_base_url: data.decision_base_url || '',
-          decision_model_name: data.decision_model_name || '',
+          decision_base_url:
+            data.decision_base_url || DECISION_PRESETS[0].config.base_url,
+          decision_model_name:
+            data.decision_model_name || DECISION_PRESETS[0].config.model_name,
           decision_api_key: data.decision_api_key || '',
           agent_type: data.agent_type || 'glm',
           agent_config_params: data.agent_config_params || {},
         });
 
-        if (!data.base_url) {
+        if (useDefault) {
           setShowConfig(true);
         }
       } catch (err) {


### PR DESCRIPTION
## Summary

- 当用户首次使用时，配置对话框默认显示智谱 BigModel API 配置，而不是空白的自定义配置
- 提升用户体验，减少手动选择预设的步骤
- 决策模型也同步使用智谱预设作为默认值

## Changes

- 修改 `tempConfig` 初始值，使用 `VISION_PRESETS[0]`（智谱 API）的配置
- 修改 `loadConfiguration` 逻辑，当后端返回空配置时使用智谱预设填充表单
- 后端保持不变（`base_url` 默认为空字符串）

Closes #105

## Test plan

- [ ] 清除本地配置文件 (`~/.config/autoglm/config.json`)，启动应用
- [ ] 验证配置对话框默认显示智谱 API 配置
- [ ] 验证保存配置后正常工作