### PR TITLE
fix: 修复分层代理模式的任务中断机制

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1018,3 +1018,15 @@ export async function resetDualModel(deviceId: string): Promise<{
   const res = await axios.post('/api/dual/reset', { device_id: deviceId });
   return res.data;
 }
+
+// ==================== Layered Agent API ====================
+
+export async function abortLayeredAgentChat(sessionId: string): Promise<{
+  success: boolean;
+  message: string;
+}> {
+  const res = await axios.post('/api/layered-agent/abort', {
+    session_id: sessionId,
+  });
+  return res.data;
+}

--- a/frontend/src/components/ChatKitPanel.tsx
+++ b/frontend/src/components/ChatKitPanel.tsx
@@ -606,6 +606,14 @@ export function ChatKitPanel({
         return prev;
       });
 
+      // Notify backend to abort (don't wait for response)
+      // Use deviceId as session_id (same as in handleSend)
+      import('../api').then(({ abortLayeredAgentChat }) => {
+        abortLayeredAgentChat(deviceId).catch(e =>
+          console.error('Backend abort failed:', e)
+        );
+      });
+
       // Show feedback
       showFeedback(t.chat?.aborted || '任务已中断', 2000, 'success');
     } catch (error) {
@@ -615,7 +623,7 @@ export function ChatKitPanel({
       setLoading(false);
       setAborting(false);
     }
-  }, [t]);
+  }, [t, deviceId]);
 
   const handleReset = React.useCallback(async () => {
     // Abort any ongoing request


### PR DESCRIPTION
## 问题

Closes #99

分层代理模式（Layered Agent）点击中断按钮后，任务在后台仍继续执行，导致：
- 用户以为任务已中断，但实际还在运行
- 再次发起请求时提示设备忙

## 根本原因

| 模式 | Abort 端点 | 状态 |
|------|------------|------|
| 经典模式 | `/api/chat/abort` | ✅ 已实现 |
| 双模型协作 | `/api/dual/chat/abort` | ✅ 已实现 |
| **分层代理** | 无 | ❌ 缺失 |

前端 `ChatKitPanel` 的 `handleAbort` 只断开了浏览器 SSE 连接，没有通知后端停止任务。

## 修复方案

使用 OpenAI agents SDK 原生的 `RunResultStreaming.cancel()` 方法：

### 后端
- 添加 `_active_runs` 字典存储活跃的运行实例
- 添加 `/api/layered-agent/abort` 端点，调用 `result.cancel(mode="immediate")`

### 前端
- `api.ts`: 添加 `abortLayeredAgentChat()` 函数
- `ChatKitPanel.tsx`: 修改 `handleAbort` 调用后端 abort API

## 测试

- [ ] 分层代理模式中断任务后，后台立即停止执行
- [ ] 中断后可以正常发起新的请求