### PR TITLE
fix: resolve hdiutil resource busy error on macOS build

### DIFF
--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -49,8 +49,10 @@ mac:
 dmg:
   # 禁用 writeUpdateInfo 避免额外的磁盘操作
   writeUpdateInfo: false
-  # 使用简单的 DMG 格式，减少 hdiutil 操作
-  format: ULFO
+  # 使用默认的 UDZO 格式，兼容性更好，避免 hdiutil resource busy 错误
+  # format: ULFO
+  sign: false
+
 
 linux:
   target:


### PR DESCRIPTION
Reverts DMG format to UDZO and disables signing to fix 'resource busy' errors on macOS x64 runners.