### PR TITLE
refactor(ci): simplify docker-e2e workflow by removing duplicate logic

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -43,48 +43,6 @@ jobs:
         run: |
           uv sync --dev --frozen
 
-      - name: Start Mock Device Agent
-        run: |
-          uv run uvicorn tests.integration.device_agent.mock_agent_server:app \
-            --host 127.0.0.1 --port 18001 --log-level warning &
-          echo "Waiting for mock agent to start..."
-          sleep 5
-          curl -f http://127.0.0.1:18001/test/state || exit 1
-
-      - name: Build Docker image
-        run: |
-          docker build -t autoglm-gui:e2e-test .
-
-      # TODO: 逻辑和 tests/integration/test_docker_e2e.py  重复了，应该只保留一个
-      - name: Run Docker container with Remote Device
-        env:
-          AUTOGLM_BASE_URL: ${{ secrets.AUTOGLM_BASE_URL }}
-          AUTOGLM_MODEL_NAME: ${{ secrets.AUTOGLM_MODEL_NAME }}
-          AUTOGLM_API_KEY: ${{ secrets.AUTOGLM_API_KEY }}
-        run: |
-          docker run -d \
-            --name autoglm-e2e-test \
-            --add-host=host.docker.internal:host-gateway \
-            -p 8000:8000 \
-            -e REMOTE_DEVICE_BASE_URL=http://host.docker.internal:18001 \
-            -e AUTOGLM_BASE_URL="$AUTOGLM_BASE_URL" \
-            -e AUTOGLM_MODEL_NAME="$AUTOGLM_MODEL_NAME" \
-            -e AUTOGLM_API_KEY="$AUTOGLM_API_KEY" \
-            -e AUTOGLM_CORS_ORIGINS="*" \
-            autoglm-gui:e2e-test
-
-      - name: Wait for container to be ready
-        run: |
-          echo "Waiting for container to start..."
-          for i in {1..30}; do
-            if curl -s http://localhost:8000/api/health > /dev/null 2>&1; then
-              echo "Container is ready!"
-              break
-            fi
-            echo "Attempt $i/30 - waiting..."
-            sleep 2
-          done
-
       - name: Run Docker E2E tests
         env:
           AUTOGLM_BASE_URL: ${{ secrets.AUTOGLM_BASE_URL }}
@@ -92,18 +50,6 @@ jobs:
           AUTOGLM_API_KEY: ${{ secrets.AUTOGLM_API_KEY }}
         run: |
           uv run pytest tests/integration/test_docker_e2e.py -v -s
-
-      - name: Collect container logs on failure
-        if: failure()
-        run: |
-          echo "=== Container Logs ==="
-          docker logs autoglm-e2e-test || true
-
-      - name: Cleanup
-        if: always()
-        run: |
-          docker stop autoglm-e2e-test || true
-          docker rm autoglm-e2e-test || true
 
       - name: Generate test summary
         if: always()


### PR DESCRIPTION
## 概述

简化 `docker-e2e.yml` workflow，删除与 pytest fixture 重复的 Docker 生命周期管理逻辑。

## 背景

之前的 workflow 存在代码重复问题：
- Workflow 中手动管理 Mock Agent 启动、Docker 构建、容器运行、健康检查、清理等步骤
- `test_docker_e2e.py` 中的 pytest fixture 也实现了相同的逻辑
- 文件中甚至有 TODO 注释标记了这个重复：`# TODO: 逻辑和 tests/integration/test_docker_e2e.py 重复了，应该只保留一个`

## 更改内容

### 删除的 Workflow 步骤

```yaml
- Start Mock Device Agent          # ✅ fixture: mock_agent_server
- Build Docker image               # ✅ fixture: docker_container
- Run Docker container             # ✅ fixture: docker_container
- Wait for container to be ready   # ✅ fixture: docker_container (health check)
- Collect container logs           # ⚠️  pytest 自动输出失败信息
- Cleanup                          # ✅ fixture: teardown
```

### 保留的核心逻辑

```yaml
- Install dependencies
- Run pytest tests/integration/test_docker_e2e.py -v -s  # fixture 自动处理所有 Docker 逻辑
- Generate test summary
```

## 收益

### 1. **消除代码重复** ✅
- 删除了 54 行重复代码（46% 减少）
- 单一数据源：pytest fixtures 是 Docker 生命周期管理的唯一实现

### 2. **职责分离** ✅
- **Workflow**: 环境准备
- **Pytest fixtures**: 测试基础设施（Mock Agent + Docker 容器）
- **Test cases**: 业务逻辑验证

### 3. **本地开发体验** ✅
现在本地和 CI 运行完全相同的测试：
```bash
# 本地运行（与 CI 完全一致）
uv run pytest tests/integration/test_docker_e2e.py -v -s
```

### 4. **更好的可维护性** ✅
- 修改 Docker 配置只需要改一处（pytest fixture）
- 不需要同步修改 workflow 和 Python 代码

## 技术细节

pytest fixture 已实现的完整生命周期管理：

```python
@pytest.fixture(scope="module")
def mock_agent_server():
    """启动 Mock Agent + 自动清理"""

@pytest.fixture(scope="module")
def docker_container(mock_agent_server):
    """清理旧容器 → 构建 → 运行 → 健康检查 → yield → 清理"""
    # 跨平台网络配置（Linux host mode vs macOS/Windows host.docker.internal）
    # 健康检查（最多等待 30 秒）
    # 自动清理（stop + rm）
```

## 测试

- ✅ pytest fixture 在失败时自动打印详细错误信息
- ✅ fixture teardown 保证资源清理（即使测试失败）
- ✅ pytest 返回非零退出码，CI 能正确检测失败

## 相关文件

- `.github/workflows/docker-e2e.yml` - 简化 workflow
- `tests/integration/test_docker_e2e.py` - pytest fixtures（未更改）

🤖 Generated with [Claude Code](https://claude.com/claude-code)