### PR TITLE
feat(ci): add Python version matrix testing for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- 为集成测试添加Python版本矩阵策略，测试Python 3.10到3.14的所有版本
- 确保项目在所有支持的Python版本上都能正常工作
- 帮助及早发现版本特定的兼容性问题

## Changes
- 修改 `.github/workflows/integration-tests.yml`
- 将 `python-version` 从单一版本 `['3.11']` 扩展为矩阵 `['3.10', '3.11', '3.12', '3.13', '3.14']`

## Test plan
- [x] 修改workflow配置文件
- [ ] 等待CI运行完成，验证所有Python版本的测试都能通过
- [ ] 检查是否有版本特定的兼容性问题