### PR TITLE
fix: docker frontend 404 error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,11 +45,12 @@ COPY phone_agent ./phone_agent
 COPY mai_agent ./mai_agent
 COPY scrcpy-server-v3.3.3 ./scrcpy-server-v3.3.3
 
-# Install Python dependencies
-RUN pip install --no-cache-dir .
-
-# Copy frontend build output from Stage 1
+# Copy frontend build output from Stage 1 BEFORE pip install
+# This ensures static files are included in the Python package
 COPY --from=frontend /app/frontend/dist ./AutoGLM_GUI/static
+
+# Install Python dependencies (now includes static files)
+RUN pip install --no-cache-dir .
 
 # Create directories for persistent data
 RUN mkdir -p /root/.config/autoglm /app/logs


### PR DESCRIPTION
Fixes #142

Docker containers were returning 404 errors when accessing the frontend page because static files were not included in the Python package.

The issue was that frontend build output was copied AFTER `pip install`, so the static files were never packaged with the application.

This fix reorders the Dockerfile to copy frontend files BEFORE pip install, ensuring they're included in the installed package.

Verified by building and testing the Docker image locally.

Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>