### PR TITLE
fix(docker): remove hardcoded env vars that override config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,9 +56,6 @@ RUN pip install --no-cache-dir .
 RUN mkdir -p /root/.config/autoglm /app/logs
 
 # Environment variables (can be overridden at runtime)
-ENV AUTOGLM_BASE_URL=""
-ENV AUTOGLM_MODEL_NAME="autoglm-phone"
-ENV AUTOGLM_API_KEY=""
 ENV AUTOGLM_CORS_ORIGINS="*"
 
 # Expose the default port


### PR DESCRIPTION
## 问题描述

修复 #158 - Docker 版本中 ModelScope 模型配置不生效的问题

## 问题根源

Dockerfile 中硬编码了环境变量 `ENV AUTOGLM_MODEL_NAME="autoglm-phone"`，由于配置优先级为 **CLI > ENV > FILE > DEFAULT**，环境变量的优先级高于配置文件，导致用户通过 Web UI 保存的配置被忽略。

### 问题流程

1. 用户在 Docker 容器中通过 Web UI 保存配置：`model_name: "ZhipuAI/AutoGLM-Phone-9B"` ✓
2. 配置成功保存到 `/root/.config/autoglm/config.json` ✓
3. Agent 初始化时加载配置：
   - ENV 层读取到 `AUTOGLM_MODEL_NAME="autoglm-phone"` 
   - 配置优先级判断：ENV > FILE
   - 最终使用环境变量的值 `"autoglm-phone"` ✗
4. 用户期望的 ModelScope 模型未被使用 ✗

## 解决方案

### 修改内容

删除 Dockerfile 中不必要的环境变量声明：

```diff
- ENV AUTOGLM_BASE_URL=""
- ENV AUTOGLM_MODEL_NAME="autoglm-phone"
- ENV AUTOGLM_API_KEY=""
  ENV AUTOGLM_CORS_ORIGINS="*"
```

### 环境变量分析

| 环境变量 | 删除原因 | 影响 |
|---------|---------|------|
| `AUTOGLM_BASE_URL=""` | 空字符串会被 `load_env_config()` 转为 `None`，不影响配置 | 无影响 |
| `AUTOGLM_MODEL_NAME="autoglm-phone"` | **非空值会覆盖配置文件，导致 bug** | ✅ 修复后配置文件可正常工作 |
| `AUTOGLM_API_KEY=""` | 空字符串会被转为 `None`，不影响配置 | 无影响 |
| `AUTOGLM_CORS_ORIGINS="*"` | **保留**，CORS 中间件需要此配置 | 保持不变 |

### 配置方式

修复后，用户可以通过以下方式配置（按优先级排序）：

1. **配置文件**（推荐）：通过 Web UI 配置并保存到 `~/.config/autoglm/config.json`
2. **环境变量**：在 docker-compose.yml 中设置（如需覆盖配置文件）
3. **CLI 参数**：启动时通过 `--base-url`, `--model` 等参数指定

## 测试验证

### 复现步骤（修复前）

1. 启动 Docker 容器：`docker-compose up -d`
2. 访问 Web UI，配置 ModelScope 模型：`ZhipuAI/AutoGLM-Phone-9B`
3. 保存配置
4. 初始化 Agent 并执行任务
5. **观察到实际使用的是 `autoglm-phone` 而非配置的模型** ✗

### 验证步骤（修复后）

1. 重新构建镜像：`docker build -t autoglm-gui:fix .`
2. 启动容器
3. 配置 ModelScope 模型并保存
4. 初始化 Agent 并执行任务
5. **确认使用的是配置文件中的 `ZhipuAI/AutoGLM-Phone-9B`** ✓

## 相关代码

- `AutoGLM_GUI/config_manager.py:269-300` - `load_env_config()` 方法
- `AutoGLM_GUI/config_manager.py:502-571` - `get_effective_config()` 配置合并逻辑
- `AutoGLM_GUI/phone_agent_manager.py:193-245` - `_auto_initialize_agent()` 使用配置初始化

## 兼容性说明

此修改不会影响现有用户：

- ✅ 通过 docker-compose.yml 设置环境变量的用户：继续生效（ENV 层优先级仍高于 FILE）
- ✅ 通过 CLI 参数启动的用户：继续生效（CLI 层优先级最高）
- ✅ 使用配置文件的用户：**现在可以正常工作**
- ✅ 未配置任何参数的用户：使用默认值（`model_name: "autoglm-phone-9b"`）

## Checklist

- [x] 修复了 #158 描述的 bug
- [x] 不影响现有配置方式的用户
- [x] 配置文件可以正常覆盖默认值
- [x] CORS 配置保持不变
- [x] 符合配置优先级设计：CLI > ENV > FILE > DEFAULT