### PR TITLE
fix(agents): correct message passing in multi-turn conversations

### DIFF
--- a/AutoGLM_GUI/agents/glm/agent.py
+++ b/AutoGLM_GUI/agents/glm/agent.py
@@ -193,7 +193,12 @@ class GLMAgent:
             )
         else:
             screen_info = MessageBuilder.build_screen_info(current_app)
-            text_content = f"** Screen Info **\n\n{screen_info}"
+            # 如果有新的用户消息（多轮对话场景），把它加入消息中
+            if user_prompt:
+                text_content = f"{user_prompt}\n\n** Screen Info **\n\n{screen_info}"
+            else:
+                # 继续执行当前任务，只需要屏幕信息
+                text_content = f"** Screen Info **\n\n{screen_info}"
 
             self._context.append(
                 MessageBuilder.create_user_message(

--- a/AutoGLM_GUI/agents/mai/agent.py
+++ b/AutoGLM_GUI/agents/mai/agent.py
@@ -96,6 +96,9 @@ class InternalMAIAgent:
 
         if is_first:
             self.traj_memory.task_goal = task or ""
+        elif task:
+            # 多轮对话：有新的用户消息，更新 task_goal
+            self.traj_memory.task_goal = task
 
         return self._execute_step(task, is_first)
 

--- a/AutoGLM_GUI/agents/stream_runner.py
+++ b/AutoGLM_GUI/agents/stream_runner.py
@@ -99,9 +99,14 @@ class AgentStepStreamer:
 
                 try:
                     # 执行 step 循环
+                    # 使用会话级别的标记，而不是 agent.step_count
+                    # 这样每次新对话开始时，第一步都会传递 task
+                    is_first_in_session = True
                     while not self._stop_event.is_set():
-                        is_first = self._agent.step_count == 0
-                        result = self._agent.step(self._task if is_first else None)
+                        result = self._agent.step(
+                            self._task if is_first_in_session else None
+                        )
+                        is_first_in_session = False
 
                         # 发射 step 事件
                         self._event_queue.put(


### PR DESCRIPTION
## Summary

- 修复多轮对话时 AI 无法收到用户新消息的问题
- `stream_runner.py` 使用会话级别变量判断是否第一步
- `glm/agent.py` 在非首轮对话时也正确添加用户消息到 context
- `mai/agent.py` 在收到新消息时更新 task_goal

## Problem

在第二轮对话时，AI 看不到用户的新消息：

1. `stream_runner.py:103-104` 用 `agent.step_count == 0` 判断是否第一步，第二轮对话时 step_count 不为 0，所以 task 被传为 None
2. `glm/agent.py:194-202` 在 `is_first=False` 时完全忽略 user_prompt
3. `mai/agent.py:97-100` 多轮对话时 task_goal 不会更新

## Solution

- 在 `stream_runner` 中使用会话级别的 `is_first_in_session` 变量
- 在 GLM agent 的 `_execute_step` 中，当有 user_prompt 时添加到消息
- 在 MAI agent 的 `step` 方法中，当有新 task 时更新 task_goal

## Test plan

- [ ] 第一轮对话：发送消息，AI 正常处理
- [ ] 第一轮后续步骤：AI 继续执行任务
- [ ] 第二轮对话：发送新消息，AI 能看到历史 + 新消息并正确响应
- [ ] 第二轮后续步骤：AI 继续执行新任务