### PR TITLE
feat(frontend): add WebCodecs unavailability warning for video streaming

### DIFF
--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -186,6 +186,17 @@ export const en = {
     increaseWidth: 'Increase width',
     showWidthControls: 'Show width controls',
     hideWidthControls: 'Hide width controls',
+    videoUnavailableWarning: 'Video streaming is unavailable',
+    requireHttpsOrLocalhost:
+      'Video streaming requires HTTPS or localhost. Consider downloading the desktop app for full functionality.',
+    browserNotSupported:
+      'Current browser does not support WebCodecs API. Please use latest Chrome or Edge browser.',
+    decoderInitFailed: 'Video decoder initialization failed',
+    codecNotSupported: 'Device codec not supported',
+    unknownError: 'Unknown error',
+    downloadElectron: 'Download Desktop App',
+    videoStreamWarning:
+      'Video streaming may be unavailable, attempting connection...',
   },
   deviceCard: {
     unknownDevice: 'Unknown Device',

--- a/frontend/src/lib/locales/zh.ts
+++ b/frontend/src/lib/locales/zh.ts
@@ -184,6 +184,16 @@ export const zh = {
     increaseWidth: '增大宽度',
     showWidthControls: '显示宽度控制',
     hideWidthControls: '隐藏宽度控制',
+    videoUnavailableWarning: '视频流不可用',
+    requireHttpsOrLocalhost:
+      '视频流需要 HTTPS 或 localhost 环境。建议下载桌面应用以获得完整功能。',
+    browserNotSupported:
+      '当前浏览器不支持 WebCodecs API。请使用最新版 Chrome 或 Edge 浏览器。',
+    decoderInitFailed: '视频解码器初始化失败',
+    codecNotSupported: '设备编解码器不支持',
+    unknownError: '未知错误',
+    downloadElectron: '下载桌面应用',
+    videoStreamWarning: '视频流可能不可用，正在尝试连接...',
   },
   deviceCard: {
     unknownDevice: '未知设备',

--- a/frontend/src/lib/webcodecs-utils.ts
+++ b/frontend/src/lib/webcodecs-utils.ts
@@ -1,0 +1,44 @@
+/**
+ * WebCodecs API availability detection utilities
+ */
+
+/**
+ * Detect the specific reason why WebCodecs API is unavailable
+ * @returns The unavailability reason, or null if WebCodecs is available
+ */
+export function detectWebCodecsUnavailabilityReason(): string | null {
+  // Check if running in browser environment
+  if (typeof window === 'undefined') {
+    return 'browser_unsupported';
+  }
+
+  // Check if VideoDecoder is available
+  if (!window.VideoDecoder) {
+    return 'browser_unsupported';
+  }
+
+  // Check if running in secure context (HTTPS or localhost)
+  if (!window.isSecureContext) {
+    return 'insecure_context';
+  }
+
+  return null;
+}
+
+// SessionStorage key for tracking dismissed warnings
+const WEBCODECS_WARNING_KEY = 'webcodecs_warning_dismissed';
+
+/**
+ * Check if the WebCodecs warning should be shown to the user
+ * @returns true if the warning should be shown, false if it was dismissed
+ */
+export function shouldShowWebCodecsWarning(): boolean {
+  return !sessionStorage.getItem(WEBCODECS_WARNING_KEY);
+}
+
+/**
+ * Mark the WebCodecs warning as dismissed for the current session
+ */
+export function dismissWebCodecsWarning(): void {
+  sessionStorage.setItem(WEBCODECS_WARNING_KEY, 'true');
+}


### PR DESCRIPTION
为 AutoGLM-GUI 前端添加 WebCodecs API 不可用时的用户提示功能，帮助用户理解为什么视频流不可用，并提供解决方案。

主要变更：
- 新增 WebCodecs 检测工具 (webcodecs-utils.ts)
- 增强 ScrcpyPlayer 组件传递失败原因
- 在 DeviceMonitor 添加警告横幅
- 添加中英文国际化支持

核心功能：
- 智能显示逻辑（仅在用户主动选择视频模式时显示）
- 会话级持久化（sessionStorage）
- 明确的操作指引（下载桌面应用等）
- 响应式设计（支持浅色/深色主题）
- 完整国际化支持