### PR TITLE
fix: 增强前端静态资源的 MIME 类型处理

### DIFF
--- a/AutoGLM_GUI/api/__init__.py
+++ b/AutoGLM_GUI/api/__init__.py
@@ -55,6 +55,10 @@ _STATIC_MEDIA_TYPES: dict[str, str] = {
     ".map": "application/json",
     ".wasm": "application/wasm",
     ".svg": "image/svg+xml",
+    ".ico": "image/x-icon",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".webp": "image/webp",
 }
 
 

--- a/tests/test_static_assets_mime.py
+++ b/tests/test_static_assets_mime.py
@@ -1,0 +1,91 @@
+"""Regression tests for frontend static asset MIME handling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import starlette.responses as starlette_responses
+import pytest
+from fastapi.testclient import TestClient
+
+from AutoGLM_GUI import api as api_module
+
+pytestmark = [pytest.mark.contract, pytest.mark.release_gate]
+
+
+def test_assets_js_mime_type_is_javascript_when_guess_type_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    static_dir = tmp_path / "static"
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir(parents=True)
+
+    (static_dir / "index.html").write_text(
+        "<!doctype html><html></html>", encoding="utf-8"
+    )
+    (assets_dir / "index-test.js").write_text("console.log('ok');", encoding="utf-8")
+
+    # Simulate environments where system mime db is missing and FileResponse falls back to text/plain.
+    monkeypatch.setattr(
+        starlette_responses, "guess_type", lambda *_args, **_kwargs: (None, None)
+    )
+    monkeypatch.setattr(api_module, "_get_static_dir", lambda: static_dir)
+
+    app = api_module.create_app()
+    client = TestClient(app)
+
+    response = client.get("/assets/index-test.js")
+
+    assert response.status_code == 200
+    assert "javascript" in response.headers["content-type"]
+
+
+def test_assets_css_mime_type_when_guess_type_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    static_dir = tmp_path / "static"
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir(parents=True)
+
+    (static_dir / "index.html").write_text(
+        "<!doctype html><html></html>", encoding="utf-8"
+    )
+    (assets_dir / "style.css").write_text("body { margin: 0; }", encoding="utf-8")
+
+    monkeypatch.setattr(
+        starlette_responses, "guess_type", lambda *_args, **_kwargs: (None, None)
+    )
+    monkeypatch.setattr(api_module, "_get_static_dir", lambda: static_dir)
+
+    app = api_module.create_app()
+    client = TestClient(app)
+
+    response = client.get("/assets/style.css")
+
+    assert response.status_code == 200
+    assert "text/css" in response.headers["content-type"]
+
+
+def test_spa_favicon_mime_type_when_guess_type_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    static_dir = tmp_path / "static"
+    static_dir.mkdir(parents=True)
+
+    (static_dir / "index.html").write_text(
+        "<!doctype html><html></html>", encoding="utf-8"
+    )
+    (static_dir / "favicon.ico").write_bytes(b"\x00\x00\x01\x00")
+
+    monkeypatch.setattr(
+        starlette_responses, "guess_type", lambda *_args, **_kwargs: (None, None)
+    )
+    monkeypatch.setattr(api_module, "_get_static_dir", lambda: static_dir)
+
+    app = api_module.create_app()
+    client = TestClient(app)
+
+    response = client.get("/favicon.ico")
+
+    assert response.status_code == 200
+    assert "image/x-icon" in response.headers["content-type"]


### PR DESCRIPTION
## 问题背景

在 PyInstaller 打包环境或某些最小化系统中，系统可能缺少完整的 MIME 数据库，导致 `mimetypes.guess_type()` 无法正确识别前端静态资源的 MIME 类型。这会导致 `.js` 文件被错误地返回为 `text/plain`，浏览器拒绝执行。

## 解决方案

1. **显式定义 MIME 类型映射** - 创建 `_STATIC_MEDIA_TYPES` 字典，优先使用预定义的 MIME 类型
2. **自定义 StaticFiles 类** - 继承 `StaticFiles` 并重写 `file_response()` 方法
3. **优雅降级** - 预定义映射未命中时，回退到 `mimetypes.guess_type()`

## 支持的文件类型

| 扩展名 | MIME 类型 |
|--------|-----------|
| `.js` / `.mjs` | `application/javascript` |
| `.css` | `text/css` |
| `.json` / `.map` | `application/json` |
| `.wasm` | `application/wasm` |
| `.svg` | `image/svg+xml` |
| `.ico` | `image/x-icon` |
| `.woff` | `font/woff` |
| `.woff2` | `font/woff2` |
| `.webp` | `image/webp` |

## 测试

新增回归测试，模拟 `mimetypes.guess_type()` 失败的场景：
- `test_assets_js_mime_type_is_javascript_when_guess_type_fails`
- `test_assets_css_mime_type_when_guess_type_fails`
- `test_spa_favicon_mime_type_when_guess_type_fails`