### PR TITLE
fix: avoid premature device unlock in reset path

### DIFF
--- a/AutoGLM_GUI/phone_agent_manager.py
+++ b/AutoGLM_GUI/phone_agent_manager.py
@@ -365,10 +365,6 @@ class PhoneAgentManager:
 
             logger.info(f"Agent reset for device {device_id}")
 
-        # 强制释放设备锁（防御性措施）
-        # 防止 streaming 清理未执行时锁永久卡死
-        self.release_device(device_id)
-
     def destroy_agent(self, device_id: str) -> None:
         """
         Destroy agent and clean up resources.


### PR DESCRIPTION
## Summary
- remove forced release_device call from reset_agent
- keep lock cleanup in stream generator finally path

## Why
- forcing unlock during reset can break mutual exclusion when a streaming task is still unwinding
- this keeps lock lifecycle aligned with request/stream cleanup

## Validation
- uv run python scripts/lint.py --backend --check-only