### PR TITLE
fix: macOS 复制粘贴失效（Issue #216）

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -813,6 +813,33 @@ function createMenu() {
         isMac ? { role: 'close' } : { role: 'quit', label: '退出' }
       ]
     },
+    // 编辑菜单（修复 macOS 上 Cmd+C / Cmd+V 等系统快捷键失效）
+    {
+      label: '编辑',
+      submenu: [
+        { role: 'undo', label: '撤销' },
+        { role: 'redo', label: '重做' },
+        { type: 'separator' },
+        { role: 'cut', label: '剪切' },
+        { role: 'copy', label: '复制' },
+        { role: 'paste', label: '粘贴' },
+        ...(isMac
+          ? [
+              { role: 'pasteAndMatchStyle', label: '粘贴并匹配样式' },
+              { role: 'delete', label: '删除' },
+              { role: 'selectAll', label: '全选' },
+              { type: 'separator' },
+              {
+                label: '语音',
+                submenu: [
+                  { role: 'startSpeaking', label: '开始朗读' },
+                  { role: 'stopSpeaking', label: '停止朗读' },
+                ],
+              },
+            ]
+          : [{ role: 'delete', label: '删除' }, { type: 'separator' }, { role: 'selectAll', label: '全选' }]),
+      ],
+    },
     // 视图菜单
     {
       label: '视图',


### PR DESCRIPTION
## 背景
- 修复 [#216](https://github.com/suyiiyii/AutoGLM-GUI/issues/216) 提到的 macOS 下复制/粘贴失效问题。

## 原因
- Electron 自定义菜单覆盖了系统默认菜单，但缺少 编辑(Edit) 菜单及标准编辑 role。
- 在 macOS 下，Cmd+C / Cmd+V / Cmd+X / Cmd+A 等快捷键依赖这些菜单 role 才会正确路由到聚焦输入组件。

## 修改
- 在 `electron/main.js` 的 `createMenu()` 中新增 编辑 菜单。
- 补齐标准编辑项：undo、redo、cut、copy、paste、selectAll（含 macOS 对应项）。

## 验证
- `node --check electron/main.js`

Closes #216
