### PR TITLE
fix(api): prioritize MCP routes over SPA catch-all

### DIFF
--- a/AutoGLM_GUI/api/__init__.py
+++ b/AutoGLM_GUI/api/__init__.py
@@ -233,14 +233,41 @@ def create_app() -> FastAPI:
                 },
             )
 
-        # Add catch-all route for SPA (handles all non-API routes)
-        app.add_api_route(
-            "/{full_path:path}", serve_spa, methods=["GET"], include_in_schema=False
-        )
+        # Mount SPA handler at root with lower priority than MCP
+        # Use a custom ASGI app that only handles non-MCP requests
+        from typing import Any
 
-    # Mount MCP server at root (mcp_app already has /mcp path prefix)
-    # This must be AFTER static files to avoid intercepting them
-    app.mount("/", mcp_app)
+        from starlette.types import Receive, Scope, Send
+
+        class SPAApp:
+            """ASGI app that serves SPA, delegates to MCP for /mcp paths."""
+
+            def __init__(self, spa_dir: Path, mcp_app: Any):
+                self.spa_dir = spa_dir
+                self.mcp_app = mcp_app
+
+            async def __call__(self, scope: Scope, receive: Receive, send: Send):
+                # Only handle HTTP requests, pass everything else to MCP
+                if scope["type"] != "http":
+                    await self.mcp_app(scope, receive, send)
+                    return
+
+                path = scope["path"]
+                # Delegate /mcp and /mcp/* to MCP app
+                # MCP app's http_app(path="/mcp") expects the full path including /mcp prefix
+                if path == "/mcp" or path.startswith("/mcp/"):
+                    await self.mcp_app(scope, receive, send)
+                    return
+
+                # Handle SPA requests
+                full_path = path.lstrip("/")
+                response = await serve_spa(full_path)
+                await response(scope, receive, send)
+
+        app.mount("/", SPAApp(static_dir, mcp_app))
+    else:
+        # No static files, just mount MCP
+        app.mount("/", mcp_app)
 
     return app
 


### PR DESCRIPTION
## Summary
- 修复了 `/mcp` 端点被 SPA catch-all 路由拦截的问题
- 创建自定义 ASGI 应用 `SPAApp` 来正确处理路由优先级
- 确保 MCP 请求（`/mcp/*`）优先被 MCP 应用处理，其他路径才由 SPA 处理

## Problem
访问 `http://127.0.0.1:38000/mcp` 时返回的是前端 HTML 而不是 MCP API 响应。原因是 FastAPI 的 `add_api_route` 优先级高于 `app.mount()`，导致 SPA 的 catch-all 路由 `/{full_path:path}` 先匹配到了 `/mcp` 路径。

## Solution
用一个自定义的 ASGI 应用 `SPAApp` 替代 catch-all 路由：
- 检查请求路径是否以 `/mcp` 开头
- 如果是，直接委托给 MCP 应用处理
- 否则，由 SPA 处理

## Test plan
- [x] 启动服务后访问 `/mcp` 返回 MCP 响应（需要正确的 Accept 头）
- [x] 访问 `/` 和其他前端路由正常显示 SPA 页面