### PR TITLE
fix: remove undefined kwargs usage in acquire_device

### DIFF
--- a/AutoGLM_GUI/phone_agent_manager.py
+++ b/AutoGLM_GUI/phone_agent_manager.py
@@ -375,8 +375,6 @@ class PhoneAgentManager:
             AgentNotInitializedError: If agent not initialized AND auto_initialize=False
             AgentInitializationError: If auto_initialize=True and initialization fails
         """
-        raise_on_timeout = kwargs.get("raise_on_timeout", True)
-
         # Verify agent exists (with optional auto-initialization)
         if not self.is_initialized(device_id):
             if auto_initialize:


### PR DESCRIPTION
## 问题描述

修复 `PhoneAgentManager.acquire_device` 方法中使用了未定义的 `kwargs` 变量的问题（fixes #257）。

## 问题详情

- 在 `acquire_device` 方法中，第 378 行使用了 `kwargs.get("raise_on_timeout", True)`，但该函数签名并没有定义 `**kwargs` 参数
- 这会导致 `NameError: name 'kwargs' is not defined`
- 在分层模式下调用 `/api/layered-agent/chat` 时，该异常会被捕获并返回 `steps=0`，导致任务无法执行

## 修复方案

直接删除第 378 行的 `raise_on_timeout = kwargs.get(...)` 代码，因为 `raise_on_timeout` 已经是函数的显式参数（第 350 行）。

## 复现验证

修复前：
```
NameError: name 'kwargs' is not defined
→ 返回 {"steps": 0, "success": False}
```

修复后：
```
分层模式正常进入步骤执行，steps 正常递增
```

Closes #257