### PR TITLE
fix: align acquire/release_device key space with context isolation

### DIFF
--- a/AutoGLM_GUI/api/agents.py
+++ b/AutoGLM_GUI/api/agents.py
@@ -49,7 +49,10 @@ async def chat(request: ChatRequest) -> ChatResponse:
     acquired = False
     try:
         acquired = await asyncio.to_thread(
-            manager.acquire_device, device_id, timeout=None, auto_initialize=True
+            manager.acquire_device,
+            device_id,
+            auto_initialize=True,
+            context="chat",
         )
         # Use chat context with async agent
         agent = await asyncio.to_thread(
@@ -82,7 +85,7 @@ async def chat(request: ChatRequest) -> ChatResponse:
         return ChatResponse(result=str(e), steps=0, success=False)
     finally:
         if acquired:
-            manager.release_device(device_id)
+            manager.release_device(device_id, context="chat")
 
 
 @router.post("/api/chat/stream")
@@ -111,9 +114,10 @@ async def chat_stream(request: ChatRequest):
         acquired = await asyncio.to_thread(
             manager.acquire_device,
             device_id,
+            auto_initialize=True,
             timeout=0,
             raise_on_timeout=True,
-            auto_initialize=True,
+            context="chat",
         )
     except DeviceBusyError:
         logger.warning(f"Device {device_id} is busy, returning 409")
@@ -246,7 +250,7 @@ async def chat_stream(request: ChatRequest):
             if acquired:
                 try:
                     # 同步直接调用，避免 await 被 CancelledError 中断
-                    manager.release_device(device_id)
+                    manager.release_device(device_id, context="chat")
                     logger.info(f"Device lock released for {device_id}")
                 except BaseException as e:
                     logger.error(f"Failed to release device lock for {device_id}: {e}")

--- a/AutoGLM_GUI/api/layered_agent.py
+++ b/AutoGLM_GUI/api/layered_agent.py
@@ -223,7 +223,10 @@ async def chat(device_id: str, message: str) -> str:
 
     try:
         acquired = await asyncio.to_thread(
-            manager.acquire_device, device_id, timeout=None, auto_initialize=True
+            manager.acquire_device,
+            device_id,
+            auto_initialize=True,
+            context="layered",
         )
         agent = await asyncio.to_thread(
             manager.get_agent_with_context,
@@ -297,7 +300,7 @@ async def chat(device_id: str, message: str) -> str:
     finally:
         if acquired:
             try:
-                manager.release_device(device_id)
+                manager.release_device(device_id, context="layered")
             except BaseException as e:
                 logger.error(f"Failed to release device lock for {device_id}: {e}")
 

--- a/AutoGLM_GUI/api/mcp.py
+++ b/AutoGLM_GUI/api/mcp.py
@@ -49,7 +49,10 @@ async def chat(device_id: str, message: str) -> ChatResult:
 
     try:
         acquired = await asyncio.to_thread(
-            manager.acquire_device, device_id, timeout=None, auto_initialize=True
+            manager.acquire_device,
+            device_id,
+            auto_initialize=True,
+            context="mcp",
         )
         agent = await asyncio.to_thread(
             manager.get_agent_with_context,
@@ -104,7 +107,7 @@ async def chat(device_id: str, message: str) -> ChatResult:
     finally:
         if acquired:
             try:
-                manager.release_device(device_id)
+                manager.release_device(device_id, context="mcp")
             except BaseException as e:
                 logger.error(f"Failed to release device lock for {device_id}: {e}")
 

--- a/AutoGLM_GUI/phone_agent_manager.py
+++ b/AutoGLM_GUI/phone_agent_manager.py
@@ -272,8 +272,7 @@ class PhoneAgentManager:
             Agent instance for this device+context combination
         """
         with self._manager_lock:
-            # Use composite key for context isolation (except for default)
-            agent_key = device_id if context == "default" else f"{device_id}:{context}"
+            agent_key = self._make_agent_key(device_id, context)
 
             if agent_key not in self._agents:
                 self._auto_initialize_agent(agent_key, device_id, agent_type=agent_type)
@@ -342,12 +341,17 @@ class PhoneAgentManager:
 
     # ==================== Concurrency Control ====================
 
+    def _make_agent_key(self, device_id: str, context: str = "default") -> str:
+        """Build composite key for device+context isolation."""
+        return device_id if context == "default" else f"{device_id}:{context}"
+
     def acquire_device(
         self,
         device_id: str,
         auto_initialize: bool = False,
         timeout: float | None = None,
         raise_on_timeout: bool = True,
+        context: str = "default",
     ) -> bool:
         """
         Atomically transition device state from IDLE to BUSY.
@@ -365,6 +369,8 @@ class PhoneAgentManager:
                 is non-blocking and completes instantly.
             raise_on_timeout: If True (default), raise DeviceBusyError when
                 device is BUSY. If False, return False instead.
+            context: Context identifier for key isolation (e.g., "mcp", "layered").
+                Defaults to "default" for backward compatibility.
 
         Returns:
             bool: True if state was IDLE and is now BUSY, False if device is
@@ -375,35 +381,37 @@ class PhoneAgentManager:
             AgentNotInitializedError: If agent not initialized AND auto_initialize=False
             AgentInitializationError: If auto_initialize=True and initialization fails
         """
+        agent_key = self._make_agent_key(device_id, context)
+
         # Verify agent exists (with optional auto-initialization)
-        if not self.is_initialized(device_id):
+        if not self.is_initialized(agent_key):
             if auto_initialize:
                 with self._manager_lock:
-                    if not self.is_initialized(device_id):
-                        self._auto_initialize_agent(device_id, device_id)
+                    if not self.is_initialized(agent_key):
+                        self._auto_initialize_agent(agent_key, device_id)
             else:
                 raise AgentNotInitializedError(
-                    f"Agent not initialized for device {device_id}. "
+                    f"Agent not initialized for device {agent_key}. "
                     f"Use auto_initialize=True or call initialize_agent() first."
                 )
 
         # Atomic CAS: IDLE → BUSY
         with self._manager_lock:
-            metadata = self._metadata.get(device_id)
+            metadata = self._metadata.get(agent_key)
             if metadata and metadata.state == AgentState.BUSY:
                 if raise_on_timeout:
                     raise DeviceBusyError(
-                        f"Device {device_id} is busy, could not acquire lock"
+                        f"Device {agent_key} is busy, could not acquire lock"
                     )
                 return False
             if metadata:
                 metadata.state = AgentState.BUSY
                 metadata.last_used = time.time()
 
-        logger.debug(f"Device lock acquired for {device_id}")
+        logger.debug(f"Device lock acquired for {agent_key}")
         return True
 
-    def release_device(self, device_id: str) -> None:
+    def release_device(self, device_id: str, context: str = "default") -> None:
         """
         Atomically transition device state from BUSY to IDLE and clear abort handler.
 
@@ -413,14 +421,16 @@ class PhoneAgentManager:
 
         Args:
             device_id: Device identifier
+            context: Context identifier, must match the one used in acquire_device.
         """
+        agent_key = self._make_agent_key(device_id, context)
         with self._manager_lock:
-            metadata = self._metadata.get(device_id)
+            metadata = self._metadata.get(agent_key)
             if metadata:
                 metadata.state = AgentState.IDLE
                 metadata.abort_handler = None
 
-        logger.debug(f"Device lock released for {device_id}")
+        logger.debug(f"Device lock released for {agent_key}")
 
     @contextmanager
     def use_agent(

--- a/tests/test_agents_chat_config_api.py
+++ b/tests/test_agents_chat_config_api.py
@@ -79,7 +79,7 @@ class FakePhoneAgentManager:
         _ = (device_id, kwargs)
         return self.agent
 
-    def release_device(self, device_id: str) -> None:
+    def release_device(self, device_id: str, **kwargs) -> None:
         self.release_calls.append(device_id)
 
     def register_abort_handler(self, device_id: str, handler: Any) -> None:


### PR DESCRIPTION
## Summary

- `acquire_device` / `release_device` operated on raw `device_id`, while `get_agent_with_context` used composite keys (`device_id:context`). This key space mismatch meant the BUSY state machine didn't protect the actual agent being used, allowing potential concurrent access bypass.
- Added `context` parameter to `acquire_device` / `release_device` (default `"default"` for backward compatibility) and unified key computation via `_make_agent_key()`.
- All callers now pass matching context: `"chat"`, `"mcp"`, `"layered"`, or `"default"`.

## Changed files

| File | Change |
|------|--------|
| `phone_agent_manager.py` | Add `_make_agent_key()`, add `context` param to `acquire_device`/`release_device`, reuse in `get_agent_with_context` |
| `api/layered_agent.py` | Pass `context="layered"` to acquire/release |
| `api/mcp.py` | Pass `context="mcp"` to acquire/release |
| `api/agents.py` | Pass `context="chat"` to acquire/release |
| `tests/test_agents_chat_config_api.py` | Update mock signature |

## Test plan

- [x] All 215 existing tests pass