### PR TITLE
ci: avoid remote-script uv bootstrap in Electron release builds

### DIFF
--- a/.github/actions/setup-electron-build/action.yml
+++ b/.github/actions/setup-electron-build/action.yml
@@ -28,21 +28,12 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    # uv installation - Unix
-    - name: Install uv (Unix)
-      if: runner.os != 'Windows'
-      shell: bash
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-    # uv installation - Windows
-    - name: Install uv (Windows)
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        irm https://astral.sh/uv/install.ps1 | iex
-        echo "$env:USERPROFILE\.cargo\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    # uv installation (pinned GitHub Action, avoids piping remote scripts)
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
 
     # pnpm setup
     - name: Setup pnpm


### PR DESCRIPTION
### Motivation
- Remediate a CI supply‑chain risk where Electron release jobs executed untrusted remote installers via `curl | sh` and `irm | iex`, which could allow arbitrary code execution and tamper with release artifacts.

### Description
- Replace the ad‑hoc shell/PowerShell installer steps with the pinned action `astral-sh/setup-uv@v4` in `.github/actions/setup-electron-build/action.yml` and preserve uv caching via `enable-cache` and `cache-dependency-glob: "uv.lock"`.
- Remove the direct usages of `curl -LsSf https://astral.sh/uv/install.sh | sh` and `irm https://astral.sh/uv/install.ps1 | iex` from the composite action.

### Testing
- Verified no remaining occurrences with `rg -n "astral\.sh/uv/install|curl -LsSf https://astral\.sh/uv/install\.sh \| sh|irm https://astral\.sh/uv/install\.ps1 \| iex" .github/actions .github/workflows` which returned no matches.
- Ran `uv run python scripts/lint.py --backend --check-only`, which passed Ruff but reported pre‑existing Pyright missing‑import errors unrelated to this workflow change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b101924528833283c917fe98dff5d3)