### PR TITLE
fix(api): prevent path traversal in SPA catch-all static serving

### DIFF
--- a/AutoGLM_GUI/api/__init__.py
+++ b/AutoGLM_GUI/api/__init__.py
@@ -213,7 +213,13 @@ def create_app() -> FastAPI:
 
         # Define SPA serving function
         async def serve_spa(full_path: str) -> FileResponse:
-            file_path = static_dir / full_path
+            static_root = static_dir.resolve()
+            file_path = (static_dir / full_path).resolve()
+            try:
+                file_path.relative_to(static_root)
+            except ValueError:
+                file_path = static_dir / "index.html"
+
             if file_path.is_file():
                 return FileResponse(
                     file_path,

--- a/tests/test_static_assets_mime.py
+++ b/tests/test_static_assets_mime.py
@@ -89,3 +89,27 @@ def test_spa_favicon_mime_type_when_guess_type_fails(
 
     assert response.status_code == 200
     assert "image/x-icon" in response.headers["content-type"]
+
+
+def test_spa_path_traversal_does_not_escape_static_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    static_dir = tmp_path / "static"
+    static_dir.mkdir(parents=True)
+
+    (static_dir / "index.html").write_text(
+        "<!doctype html><html><body>index</body></html>", encoding="utf-8"
+    )
+    secret_file = tmp_path / "secret.txt"
+    secret_file.write_text("top-secret", encoding="utf-8")
+
+    monkeypatch.setattr(api_module, "_get_static_dir", lambda: static_dir)
+
+    app = api_module.create_app()
+    client = TestClient(app)
+
+    response = client.get("/../secret.txt")
+
+    assert response.status_code == 200
+    assert "index" in response.text
+    assert "top-secret" not in response.text


### PR DESCRIPTION
### Motivation
- The SPA catch-all handler built a `Path` from an attacker-controlled URL segment and served it directly, allowing `../` path traversal to read files outside the intended static root.
- This became reachable after static mounts were ordered ahead of the MCP mount, exposing a high-severity information disclosure vector.

### Description
- Normalize and constrain requested SPA paths by resolving the static root and the requested `file_path`, then enforcing `file_path.relative_to(static_root)` to detect escapes and fallback to `index.html` when an escape is attempted.
- Keep existing behavior of serving real static assets with deterministic MIME types and returning `index.html` for SPA routes not matching a file.
- Add a regression test `test_spa_path_traversal_does_not_escape_static_root` in `tests/test_static_assets_mime.py` that ensures `GET /../secret.txt` returns the SPA `index.html` content and does not leak the secret file.

### Testing
- Ran `uv run pytest -q tests/test_static_assets_mime.py` and the suite passed (`4 passed`).
- Ran `uv run python scripts/lint.py --backend --check-only` which reported a pre-existing `pyright` missing-imports failure unrelated to this patch while other checks (`ruff`) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0fbf6cae08332956d13980ad3535d)