### PR TITLE
🧹 [Code Health] Enable stricter pyright type checking

### DIFF
--- a/AutoGLM_GUI/__init__.py
+++ b/AutoGLM_GUI/__init__.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 from functools import wraps
 from importlib import metadata
+from typing import Any
 
 from AutoGLM_GUI.config import AgentConfig, ModelConfig, StepResult
 from AutoGLM_GUI.logger import logger
@@ -28,7 +29,7 @@ _original_popen = subprocess.Popen
 
 
 @wraps(_original_run)
-def _patched_run(*args, **kwargs) -> subprocess.CompletedProcess:
+def _patched_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
     """Patched subprocess.run that defaults to UTF-8 encoding on Windows."""
     if sys.platform == "win32":
         # Add encoding='utf-8' if text=True is set but encoding is not specified
@@ -41,7 +42,7 @@ def _patched_run(*args, **kwargs) -> subprocess.CompletedProcess:
 class _PatchedPopen(_original_popen):
     """Patched subprocess.Popen that defaults to UTF-8 encoding on Windows."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         if sys.platform == "win32":
             # Add encoding='utf-8' if text=True is set but encoding is not specified
             if kwargs.get("text") or kwargs.get("universal_newlines"):

--- a/AutoGLM_GUI/actions/handler.py
+++ b/AutoGLM_GUI/actions/handler.py
@@ -61,7 +61,9 @@ class ActionHandler:
                 success=False, should_finish=False, message=f"Action failed: {e}"
             )
 
-    def _get_handler(self, action_name: str) -> Callable | None:
+    def _get_handler(
+        self, action_name: str
+    ) -> Callable[[dict[str, Any], int, int], ActionResult] | None:
         handlers = {
             "Launch": self._handle_launch,
             "Tap": self._handle_tap,
@@ -87,7 +89,9 @@ class ActionHandler:
         y = int(clamped_y / 1000 * screen_height)
         return x, y
 
-    def _handle_launch(self, action: dict, width: int, height: int) -> ActionResult:
+    def _handle_launch(
+        self, action: dict[str, Any], width: int, height: int
+    ) -> ActionResult:
         app_name = action.get("app")
         if not app_name:
             return ActionResult(False, False, "No app name specified")
@@ -97,7 +101,9 @@ class ActionHandler:
             return ActionResult(True, False)
         return ActionResult(False, False, f"App not found: {app_name}")
 
-    def _handle_tap(self, action: dict, width: int, height: int) -> ActionResult:
+    def _handle_tap(
+        self, action: dict[str, Any], width: int, height: int
+    ) -> ActionResult:
         element = action.get("element")
         if not element:
             return ActionResult(False, False, "No element coordinates")
@@ -117,7 +123,9 @@ class ActionHandler:
 
     _ADB_IME = "com.android.adbkeyboard/.AdbIME"
 
-    def _handle_type(self, action: dict, width: int, height: int) -> ActionResult:
+    def _handle_type(
+        self, action: dict[str, Any], width: int, height: int
+    ) -> ActionResult:
         text = action.get("text", "")
 
         original_ime = self.device.detect_and_set_adb_keyboard()
@@ -139,7 +147,9 @@ class ActionHandler:
 
         return ActionResult(True, False)
 
-    def _handle_swipe(self, action: dict, width: int, height: int) -> ActionResult:
+    def _handle_swipe(
+        self, action: dict[str, Any], width: int, height: int
+    ) -> ActionResult:
         start = action.get("start")
         end = action.get("end")
 
@@ -152,15 +162,21 @@ class ActionHandler:
         self.device.swipe(start_x, start_y, end_x, end_y)
         return ActionResult(True, False)
 
-    def _handle_back(self, action: dict, width: int, height: int) -> ActionResult:
+    def _handle_back(
+        self, action: dict[str, Any], width: int, height: int
+    ) -> ActionResult:
         self.device.back()
         return ActionResult(True, False)
 
-    def _handle_home(self, action: dict, width: int, height: int) -> ActionResult:
+    def _handle_home(
+        self, action: dict[str, Any], width: int, height: int
+    ) -> ActionResult:
         self.device.home()
         return ActionResult(True, False)
 
-    def _handle_double_tap(self, action: dict, width: int, height: int) -> ActionResult:
+    def _handle_double_tap(
+        self, action: dict[str, Any], width: int, height: int
+    ) -> ActionResult:
         element = action.get("element")
         if not element:
             return ActionResult(False, False, "No element coordinates")
@@ -169,7 +185,9 @@ class ActionHandler:
         self.device.double_tap(x, y)
         return ActionResult(True, False)
 
-    def _handle_long_press(self, action: dict, width: int, height: int) -> ActionResult:
+    def _handle_long_press(
+        self, action: dict[str, Any], width: int, height: int
+    ) -> ActionResult:
         element = action.get("element")
         if not element:
             return ActionResult(False, False, "No element coordinates")
@@ -180,7 +198,9 @@ class ActionHandler:
 
     MAX_WAIT_SECONDS = 30
 
-    def _handle_wait(self, action: dict, width: int, height: int) -> ActionResult:
+    def _handle_wait(
+        self, action: dict[str, Any], width: int, height: int
+    ) -> ActionResult:
         duration_str = action.get("duration", "1 seconds")
         try:
             duration = float(duration_str.replace("seconds", "").strip())
@@ -191,12 +211,16 @@ class ActionHandler:
         time.sleep(duration)
         return ActionResult(True, False)
 
-    def _handle_takeover(self, action: dict, width: int, height: int) -> ActionResult:
+    def _handle_takeover(
+        self, action: dict[str, Any], width: int, height: int
+    ) -> ActionResult:
         message = action.get("message", "User intervention required")
         self.takeover_callback(message)
         return ActionResult(True, False)
 
-    def _handle_note(self, action: dict, width: int, height: int) -> ActionResult:
+    def _handle_note(
+        self, action: dict[str, Any], width: int, height: int
+    ) -> ActionResult:
         return ActionResult(True, False)
 
     @staticmethod

--- a/AutoGLM_GUI/adb_plus/keyboard_installer.py
+++ b/AutoGLM_GUI/adb_plus/keyboard_installer.py
@@ -7,6 +7,7 @@ without requiring users to manually download and install APK.
 import asyncio
 import urllib.request
 from pathlib import Path
+from typing import Any
 
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.platform_utils import run_cmd_silently
@@ -315,7 +316,7 @@ class ADBKeyboardInstaller:
         logger.error(error_msg)
         return False, error_msg
 
-    def get_status(self) -> dict:
+    def get_status(self) -> dict[str, Any]:
         """
         Get detailed status of ADB Keyboard.
 

--- a/AutoGLM_GUI/adb_plus/mdns.py
+++ b/AutoGLM_GUI/adb_plus/mdns.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from typing import Any
 
 from AutoGLM_GUI.platform_utils import run_cmd_silently_sync
 
@@ -119,7 +120,7 @@ def discover_mdns_devices(adb_path: str = "adb") -> list[MdnsDevice]:
             return []
 
         # Parse devices by name (consolidate multiple service types)
-        devices_dict: dict[str, dict] = {}
+        devices_dict: dict[str, dict[str, Any]] = {}
 
         for line in output.splitlines():
             # Skip header line

--- a/AutoGLM_GUI/adb_plus/qr_pair.py
+++ b/AutoGLM_GUI/adb_plus/qr_pair.py
@@ -14,7 +14,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 
-from zeroconf import ServiceBrowser, ServiceListener, Zeroconf
+from zeroconf import ServiceBrowser, ServiceInfo, ServiceListener, Zeroconf
 
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.platform_utils import run_cmd_silently_sync
@@ -49,7 +49,7 @@ class PairingSession:
     thread: threading.Thread | None = None  # Listener thread
 
 
-def _pick_host_from_info(info) -> str | None:
+def _pick_host_from_info(info: ServiceInfo) -> str | None:
     """Extract preferred host from service info (IPv4 preferred)."""
     try:
         # Prefer IPv4 addresses

--- a/AutoGLM_GUI/adb_plus/screenshot.py
+++ b/AutoGLM_GUI/adb_plus/screenshot.py
@@ -105,7 +105,7 @@ def _try_capture(device_id: str | None, adb_path: str, timeout: int) -> bytes | 
                 )
             return None
         # stdout should hold the PNG data
-        return result.stdout if isinstance(result.stdout, (bytes, bytearray)) else None
+        return result.stdout
     except DeviceNotAvailableError:
         raise  # Re-raise to caller
     except Exception:

--- a/AutoGLM_GUI/agents/__init__.py
+++ b/AutoGLM_GUI/agents/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from typing import Any
 from collections.abc import Callable
 
 from .protocols import AsyncAgent, BaseAgent, is_async_agent
 
 
-def register_agent(agent_type: str, creator: Callable) -> None:
+def register_agent(agent_type: str, creator: Callable[..., Any]) -> None:
     from .factory import register_agent as _register_agent
 
     _register_agent(agent_type=agent_type, creator=creator)
@@ -13,13 +14,13 @@ def register_agent(agent_type: str, creator: Callable) -> None:
 
 def create_agent(
     agent_type: str,
-    model_config,
-    agent_config,
-    agent_specific_config,
-    device,
-    takeover_callback: Callable | None = None,
-    confirmation_callback: Callable | None = None,
-):
+    model_config: Any,
+    agent_config: Any,
+    agent_specific_config: Any,
+    device: Any,
+    takeover_callback: Callable[..., Any] | None = None,
+    confirmation_callback: Callable[..., Any] | None = None,
+) -> AsyncAgent | BaseAgent:
     from .factory import create_agent as _create_agent
 
     return _create_agent(

--- a/AutoGLM_GUI/agents/factory.py
+++ b/AutoGLM_GUI/agents/factory.py
@@ -6,9 +6,11 @@ making it easy to add new agent types without modifying existing code.
 
 from __future__ import annotations
 
+from typing import Any
 from collections.abc import Callable
 
 from AutoGLM_GUI.config import AgentConfig, ModelConfig
+from AutoGLM_GUI.device_protocol import DeviceProtocol
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.types import AgentSpecificConfig
 
@@ -16,12 +18,12 @@ from .protocols import AsyncAgent, BaseAgent
 
 
 # Agent registry: agent_type -> (creator_function, config_schema)
-AGENT_REGISTRY: dict[str, Callable] = {}
+AGENT_REGISTRY: dict[str, Callable[..., AsyncAgent | BaseAgent]] = {}
 
 
 def register_agent(
     agent_type: str,
-    creator: Callable,
+    creator: Callable[..., AsyncAgent | BaseAgent],
 ) -> None:
     """
     Register a new agent type.
@@ -49,9 +51,9 @@ def create_agent(
     model_config: ModelConfig,
     agent_config: AgentConfig,
     agent_specific_config: AgentSpecificConfig,
-    device,
-    takeover_callback: Callable | None = None,
-    confirmation_callback: Callable | None = None,
+    device: DeviceProtocol,
+    takeover_callback: Callable[..., Any] | None = None,
+    confirmation_callback: Callable[..., Any] | None = None,
 ) -> AsyncAgent | BaseAgent:
     """
     Create an agent instance using the factory pattern.
@@ -113,9 +115,9 @@ def _create_async_glm_agent(
     model_config: ModelConfig,
     agent_config: AgentConfig,
     agent_specific_config: AgentSpecificConfig,  # noqa: ARG001
-    device,
-    takeover_callback: Callable | None = None,
-    confirmation_callback: Callable | None = None,
+    device: DeviceProtocol,
+    takeover_callback: Callable[..., Any] | None = None,
+    confirmation_callback: Callable[..., Any] | None = None,
 ) -> AsyncAgent:
     """Create AsyncGLMAgent instance.
 
@@ -142,9 +144,9 @@ def _create_async_mai_agent(
     model_config: ModelConfig,
     agent_config: AgentConfig,
     agent_specific_config: AgentSpecificConfig,
-    device,
-    takeover_callback: Callable | None = None,
-    confirmation_callback: Callable | None = None,
+    device: DeviceProtocol,
+    takeover_callback: Callable[..., Any] | None = None,
+    confirmation_callback: Callable[..., Any] | None = None,
 ) -> AsyncAgent:
     from .mai.async_agent import AsyncMAIAgent
 
@@ -164,9 +166,9 @@ def _create_async_gemini_agent(
     model_config: ModelConfig,
     agent_config: AgentConfig,
     agent_specific_config: AgentSpecificConfig,  # noqa: ARG001
-    device,
-    takeover_callback: Callable | None = None,
-    confirmation_callback: Callable | None = None,
+    device: DeviceProtocol,
+    takeover_callback: Callable[..., Any] | None = None,
+    confirmation_callback: Callable[..., Any] | None = None,
 ) -> AsyncAgent:
     """Create AsyncGeminiAgent instance.
 
@@ -195,9 +197,9 @@ def _create_droidrun_agent(
     model_config: ModelConfig,
     agent_config: AgentConfig,
     agent_specific_config: AgentSpecificConfig,  # noqa: ARG001
-    device,
-    takeover_callback: Callable | None = None,
-    confirmation_callback: Callable | None = None,
+    device: DeviceProtocol,
+    takeover_callback: Callable[..., Any] | None = None,
+    confirmation_callback: Callable[..., Any] | None = None,
 ) -> AsyncAgent:
     """Create DroidRunAgent instance.
 
@@ -223,9 +225,9 @@ def _create_midscene_agent(
     model_config: ModelConfig,
     agent_config: AgentConfig,
     agent_specific_config: AgentSpecificConfig,
-    device,
-    takeover_callback: Callable | None = None,
-    confirmation_callback: Callable | None = None,
+    device: DeviceProtocol,
+    takeover_callback: Callable[..., Any] | None = None,
+    confirmation_callback: Callable[..., Any] | None = None,
 ) -> AsyncAgent:
     """Create AsyncMidsceneAgent instance.
 

--- a/AutoGLM_GUI/agents/gemini/async_agent.py
+++ b/AutoGLM_GUI/agents/gemini/async_agent.py
@@ -163,7 +163,7 @@ class AsyncGeminiAgent(AsyncAgentBase):
             },
         }
 
-    async def _call_llm_with_tools(self) -> tuple[str, str, dict]:
+    async def _call_llm_with_tools(self) -> tuple[str, str, dict[str, Any]]:
         """调用 LLM，返回 (thinking, tool_name, tool_args)。"""
         if self._cancel_event.is_set():
             raise asyncio.CancelledError()

--- a/AutoGLM_GUI/agents/glm/parser.py
+++ b/AutoGLM_GUI/agents/glm/parser.py
@@ -100,7 +100,7 @@ class GLMParser:
 
     def _parse_value(
         self, value_str: str
-    ) -> str | int | float | bool | list | dict | None:
+    ) -> str | int | float | bool | list[Any] | dict[str, Any] | None:
         value_str = value_str.strip()
 
         if not value_str:

--- a/AutoGLM_GUI/api/agents.py
+++ b/AutoGLM_GUI/api/agents.py
@@ -3,6 +3,8 @@
 import asyncio
 import json
 
+from typing import Any
+
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import ValidationError
@@ -22,7 +24,7 @@ from AutoGLM_GUI.version import APP_VERSION
 router = APIRouter()
 
 
-SSEPayload = dict[str, str | int | bool | None | dict]
+SSEPayload = dict[str, str | int | bool | None | dict[str, Any]]
 
 
 def _create_sse_event(
@@ -315,7 +317,7 @@ def get_status(device_id: str | None = None) -> StatusResponse:
 
 
 @router.post("/api/reset")
-def reset_agent(request: ResetRequest) -> dict:
+def reset_agent(request: ResetRequest) -> dict[str, Any]:
     """重置 Agent 状态（多设备支持）。"""
     from AutoGLM_GUI.exceptions import AgentNotInitializedError
     from AutoGLM_GUI.phone_agent_manager import PhoneAgentManager
@@ -335,7 +337,7 @@ def reset_agent(request: ResetRequest) -> dict:
 
 
 @router.post("/api/chat/abort")
-async def abort_chat(request: AbortRequest) -> dict:
+async def abort_chat(request: AbortRequest) -> dict[str, Any]:
     """中断正在进行的对话流 (支持 AsyncAgent)。"""
     from AutoGLM_GUI.phone_agent_manager import PhoneAgentManager
 
@@ -393,7 +395,7 @@ def get_config_endpoint() -> ConfigResponse:
 
 
 @router.post("/api/config")
-def save_config_endpoint(request: ConfigSaveRequest) -> dict:
+def save_config_endpoint(request: ConfigSaveRequest) -> dict[str, Any]:
     """保存配置到文件.
 
     配置保存后需重启应用以立即生效。
@@ -462,7 +464,7 @@ def save_config_endpoint(request: ConfigSaveRequest) -> dict:
 
 
 @router.delete("/api/config")
-def delete_config_endpoint() -> dict:
+def delete_config_endpoint() -> dict[str, Any]:
     """删除配置文件."""
     from AutoGLM_GUI.config_manager import config_manager
 

--- a/AutoGLM_GUI/api/health.py
+++ b/AutoGLM_GUI/api/health.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import APIRouter
 
 from AutoGLM_GUI.version import APP_VERSION
@@ -6,7 +8,7 @@ router = APIRouter(prefix="/api", tags=["health"])
 
 
 @router.get("/health")
-async def health_check() -> dict:
+async def health_check() -> dict[str, Any]:
     return {
         "status": "healthy",
         "version": APP_VERSION,

--- a/AutoGLM_GUI/api/history.py
+++ b/AutoGLM_GUI/api/history.py
@@ -1,5 +1,7 @@
 """History API routes."""
 
+from typing import Any
+
 from fastapi import APIRouter, HTTPException
 
 from AutoGLM_GUI.history_manager import history_manager
@@ -91,7 +93,7 @@ def get_history_record(serialno: str, record_id: str) -> HistoryRecordResponse:
 
 
 @router.delete("/api/history/{serialno}/{record_id}")
-def delete_history_record(serialno: str, record_id: str) -> dict:
+def delete_history_record(serialno: str, record_id: str) -> dict[str, Any]:
     success = history_manager.delete_record(serialno, record_id)
     if not success:
         raise HTTPException(status_code=404, detail="Record not found")
@@ -99,6 +101,6 @@ def delete_history_record(serialno: str, record_id: str) -> dict:
 
 
 @router.delete("/api/history/{serialno}")
-def clear_history(serialno: str) -> dict:
+def clear_history(serialno: str) -> dict[str, Any]:
     history_manager.clear_device_history(serialno)
     return {"success": True, "message": f"History cleared for {serialno}"}

--- a/AutoGLM_GUI/api/layered_agent.py
+++ b/AutoGLM_GUI/api/layered_agent.py
@@ -552,7 +552,7 @@ async def layered_agent_chat(request: LayeredAgentRequest) -> StreamingResponse:
                                                 tool_args = {"raw": str(call.arguments)}
 
                             logger.info(
-                                f"[LayeredAgent] Tool call: {tool_name}, args keys: {list(tool_args.keys()) if isinstance(tool_args, dict) else 'not dict'}"
+                                f"[LayeredAgent] Tool call: {tool_name}, args keys: {list(tool_args.keys())}"
                             )
 
                             current_tool_call = {

--- a/AutoGLM_GUI/api/media.py
+++ b/AutoGLM_GUI/api/media.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi import APIRouter
 
 from AutoGLM_GUI.adb_plus import capture_screenshot
@@ -14,7 +16,7 @@ router = APIRouter()
 
 
 @router.post("/api/video/reset")
-async def reset_video_stream(device_id: str | None = None) -> dict:
+async def reset_video_stream(device_id: str | None = None) -> dict[str, Any]:
     """Reset active scrcpy streams (Socket.IO)."""
     stop_streamers(device_id=device_id)
     if device_id:

--- a/AutoGLM_GUI/api/scheduled_tasks.py
+++ b/AutoGLM_GUI/api/scheduled_tasks.py
@@ -1,7 +1,10 @@
 """Scheduled tasks API routes."""
 
+from typing import Any
+
 from fastapi import APIRouter, HTTPException
 
+from AutoGLM_GUI.models.scheduled_task import ScheduledTask
 from AutoGLM_GUI.scheduler_manager import scheduler_manager
 from AutoGLM_GUI.schemas import (
     ScheduledTaskCreate,
@@ -13,7 +16,7 @@ from AutoGLM_GUI.schemas import (
 router = APIRouter()
 
 
-def _task_to_response(task) -> ScheduledTaskResponse:
+def _task_to_response(task: ScheduledTask) -> ScheduledTaskResponse:
     next_run = scheduler_manager.get_next_run_time(task.id)
     return ScheduledTaskResponse(
         id=task.id,
@@ -80,7 +83,7 @@ def update_scheduled_task(
 
 
 @router.delete("/api/scheduled-tasks/{task_id}")
-def delete_scheduled_task(task_id: str) -> dict:
+def delete_scheduled_task(task_id: str) -> dict[str, Any]:
     success = scheduler_manager.delete_task(task_id)
     if not success:
         raise HTTPException(status_code=404, detail="Task not found")
@@ -88,7 +91,7 @@ def delete_scheduled_task(task_id: str) -> dict:
 
 
 @router.post("/api/scheduled-tasks/{task_id}/enable")
-def enable_scheduled_task(task_id: str) -> dict:
+def enable_scheduled_task(task_id: str) -> dict[str, Any]:
     success = scheduler_manager.set_enabled(task_id, True)
     if not success:
         raise HTTPException(status_code=404, detail="Task not found")
@@ -96,7 +99,7 @@ def enable_scheduled_task(task_id: str) -> dict:
 
 
 @router.post("/api/scheduled-tasks/{task_id}/disable")
-def disable_scheduled_task(task_id: str) -> dict:
+def disable_scheduled_task(task_id: str) -> dict[str, Any]:
     success = scheduler_manager.set_enabled(task_id, False)
     if not success:
         raise HTTPException(status_code=404, detail="Task not found")

--- a/AutoGLM_GUI/api/workflows.py
+++ b/AutoGLM_GUI/api/workflows.py
@@ -1,5 +1,7 @@
 """Workflow API 路由."""
 
+from typing import Any
+
 from fastapi import APIRouter, HTTPException
 
 from AutoGLM_GUI.schemas import (
@@ -61,7 +63,7 @@ def update_workflow(workflow_uuid: str, request: WorkflowUpdate) -> WorkflowResp
 
 
 @router.delete("/api/workflows/{workflow_uuid}")
-def delete_workflow(workflow_uuid: str) -> dict:
+def delete_workflow(workflow_uuid: str) -> dict[str, Any]:
     """删除 workflow."""
     from AutoGLM_GUI.workflow_manager import workflow_manager
 

--- a/AutoGLM_GUI/config_manager.py
+++ b/AutoGLM_GUI/config_manager.py
@@ -18,7 +18,7 @@ import os
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import Self
+from typing import Any, Self
 
 from pydantic import BaseModel, field_validator
 
@@ -60,7 +60,7 @@ class ConfigModel(BaseModel):
 
     # Agent 类型配置
     agent_type: str = "glm-async"  # Agent type (e.g., "glm-async", "mai")
-    agent_config_params: dict | None = None  # Agent-specific configuration
+    agent_config_params: dict[str, Any] | None = None  # Agent-specific configuration
 
     # Agent 执行配置
     default_max_steps: int = 100  # 单次任务最大执行步数
@@ -138,7 +138,7 @@ class ConfigLayer:
     api_key: str | None = None
     # Agent 类型配置
     agent_type: str | None = None
-    agent_config_params: dict | None = None
+    agent_config_params: dict[str, Any] | None = None
     # Agent 执行配置
     default_max_steps: int | None = None
     layered_max_turns: int | None = None
@@ -161,11 +161,11 @@ class ConfigLayer:
         value = getattr(self, key, None)
         return value is not None
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """转换为字典，排除 None 值.
 
         Returns:
-            dict: 配置字典
+            dict[str, Any]: 配置字典
         """
         return {
             k: v
@@ -250,7 +250,7 @@ class UnifiedConfigManager:
         )
 
         # 文件缓存（带修改时间戳）
-        self._file_cache: dict | None = None
+        self._file_cache: dict[str, Any] | None = None
         self._file_mtime: float | None = None
 
         # 有效配置缓存
@@ -420,7 +420,7 @@ class UnifiedConfigManager:
         model_name: str,
         api_key: str | None = None,
         agent_type: str | None = None,
-        agent_config_params: dict | None = None,
+        agent_config_params: dict[str, Any] | None = None,
         default_max_steps: int | None = None,
         layered_max_turns: int | None = None,
         decision_base_url: str | None = None,
@@ -452,7 +452,7 @@ class UnifiedConfigManager:
             self._config_path.parent.mkdir(parents=True, exist_ok=True)
 
             # 准备新配置
-            new_config: dict[str, str | bool | int | dict | None] = {
+            new_config: dict[str, str | bool | int | dict[str, Any] | None] = {
                 "base_url": base_url,
                 "model_name": model_name,
             }
@@ -733,12 +733,12 @@ class UnifiedConfigManager:
         """
         return self._config_path
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """
         将有效配置转换为字典.
 
         Returns:
-            dict: 配置字典
+            dict[str, Any]: 配置字典
         """
         config = self.get_effective_config()
         return {

--- a/AutoGLM_GUI/device_manager.py
+++ b/AutoGLM_GUI/device_manager.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from AutoGLM_GUI.adb import ADBConnection, ConnectionType, DeviceInfo
 from AutoGLM_GUI.logger import logger
@@ -153,11 +153,11 @@ class ManagedDevice:
 
         self.primary_connection_idx = sorted_conns[0][0]
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """转换为纯设备信息字典（不包含 Agent 状态）。
 
         Returns:
-            dict: 设备基础信息，匹配 DeviceResponse schema（无 agent 字段）
+            dict[str, Any]: 设备基础信息，匹配 DeviceResponse schema（无 agent 字段）
         """
         return {
             "id": self.primary_device_id,
@@ -266,7 +266,7 @@ class DeviceManager:
         self._enable_mdns_discovery: bool = True  # Feature toggle
 
         self._remote_devices: dict[str, DeviceProtocol] = {}
-        self._remote_device_configs: dict[str, dict] = {}
+        self._remote_device_configs: dict[str, dict[str, Any]] = {}
 
         # ADB Keyboard setup state (process-local, best-effort)
         self._adb_keyboard_attempted_serials: set[DeviceSerial] = set()
@@ -840,7 +840,7 @@ class DeviceManager:
 
     def discover_remote_devices(
         self, base_url: str, timeout: int = 5
-    ) -> tuple[bool, str, list[dict]]:
+    ) -> tuple[bool, str, list[dict[str, Any]]]:
         """Discover devices from a remote Device Agent Server.
 
         Args:

--- a/AutoGLM_GUI/device_metadata_manager.py
+++ b/AutoGLM_GUI/device_metadata_manager.py
@@ -7,6 +7,7 @@ import threading
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from AutoGLM_GUI.logger import logger
 
@@ -21,7 +22,7 @@ class DeviceMetadata:
     display_name: str | None = None
     last_updated: datetime = field(default_factory=datetime.now)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to serializable dict."""
         return {
             "serial": self.serial,
@@ -30,7 +31,7 @@ class DeviceMetadata:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> DeviceMetadata:
+    def from_dict(cls, data: dict[str, Any]) -> DeviceMetadata:
         """Create instance from dict."""
         last_updated_str = data.get("last_updated")
         last_updated = (

--- a/AutoGLM_GUI/devices/remote_device.py
+++ b/AutoGLM_GUI/devices/remote_device.py
@@ -4,6 +4,9 @@ This module provides a RemoteDevice that connects to a Device Agent
 via HTTP, allowing remote control of devices.
 """
 
+from types import TracebackType
+from typing import Any, Self
+
 import httpx
 
 from AutoGLM_GUI.device_protocol import (
@@ -36,14 +39,16 @@ class RemoteDevice(DeviceProtocol):
     def device_id(self) -> str:
         return self._device_id
 
-    def _post(self, endpoint: str, json: dict | None = None) -> dict:
+    def _post(
+        self, endpoint: str, json: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """POST request helper."""
         url = f"{self._base_url}/device/{self._device_id}{endpoint}"
         resp = self._client.post(url, json=json or {})
         resp.raise_for_status()
         return resp.json()
 
-    def _get(self, endpoint: str) -> dict:
+    def _get(self, endpoint: str) -> dict[str, Any]:
         """GET request helper."""
         url = f"{self._base_url}/device/{self._device_id}{endpoint}"
         resp = self._client.get(url)
@@ -124,10 +129,15 @@ class RemoteDevice(DeviceProtocol):
         """Close the HTTP client."""
         self._client.close()
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         self.close()
 
 

--- a/AutoGLM_GUI/i18n.py
+++ b/AutoGLM_GUI/i18n.py
@@ -51,7 +51,7 @@ MESSAGES_EN = {
 }
 
 
-def get_messages(lang: str = "cn") -> dict:
+def get_messages(lang: str = "cn") -> dict[str, str]:
     """
     Get UI messages dictionary by language.
 

--- a/AutoGLM_GUI/models/device_group.py
+++ b/AutoGLM_GUI/models/device_group.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Any
 from uuid import uuid4
 
 # Default group ID - this group cannot be deleted
@@ -25,7 +26,7 @@ class DeviceGroup:
     created_at: datetime = field(default_factory=datetime.now)
     updated_at: datetime = field(default_factory=datetime.now)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """转换为可序列化的字典."""
         return {
             "id": self.id,
@@ -36,7 +37,7 @@ class DeviceGroup:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> DeviceGroup:
+    def from_dict(cls, data: dict[str, Any]) -> DeviceGroup:
         """从字典创建实例."""
         return cls(
             id=data.get("id", str(uuid4())),

--- a/AutoGLM_GUI/models/history.py
+++ b/AutoGLM_GUI/models/history.py
@@ -21,7 +21,7 @@ class MessageRecord:
     action: dict[str, Any] | None = None
     step: int | None = None
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """转换为可序列化的字典."""
         return {
             "role": self.role,
@@ -33,7 +33,7 @@ class MessageRecord:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> MessageRecord:
+    def from_dict(cls, data: dict[str, Any]) -> MessageRecord:
         """从字典创建实例."""
         return cls(
             role=data.get("role", "user"),
@@ -74,7 +74,7 @@ class ConversationRecord:
     # 完整对话消息列表
     messages: list[MessageRecord] = field(default_factory=list)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """转换为可序列化的字典."""
         return {
             "id": self.id,
@@ -92,7 +92,7 @@ class ConversationRecord:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> ConversationRecord:
+    def from_dict(cls, data: dict[str, Any]) -> ConversationRecord:
         """从字典创建实例."""
         return cls(
             id=data.get("id", str(uuid4())),
@@ -122,7 +122,7 @@ class DeviceHistory:
     records: list[ConversationRecord] = field(default_factory=list)
     last_updated: datetime = field(default_factory=datetime.now)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """转换为可序列化的字典."""
         return {
             "serialno": self.serialno,
@@ -131,7 +131,7 @@ class DeviceHistory:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> DeviceHistory:
+    def from_dict(cls, data: dict[str, Any]) -> DeviceHistory:
         """从字典创建实例."""
         return cls(
             serialno=data.get("serialno", ""),

--- a/AutoGLM_GUI/models/scheduled_task.py
+++ b/AutoGLM_GUI/models/scheduled_task.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Any
 from uuid import uuid4
 
 
@@ -59,7 +60,7 @@ class ScheduledTask:
     last_run_total_count: int | None = None
     last_run_message: str | None = None
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """转换为可序列化的字典."""
         return {
             "id": self.id,
@@ -82,7 +83,7 @@ class ScheduledTask:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> ScheduledTask:
+    def from_dict(cls, data: dict[str, Any]) -> ScheduledTask:
         """从字典创建实例，向后兼容旧数据格式."""
         # 处理设备序列号：支持旧格式的单字符串和新格式的列表
         device_serialnos = _normalize_device_serialnos(data.get("device_serialnos", []))

--- a/AutoGLM_GUI/phone_agent_manager.py
+++ b/AutoGLM_GUI/phone_agent_manager.py
@@ -9,6 +9,7 @@ from collections.abc import Awaitable, Callable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import Any
 
 from AutoGLM_GUI.agents.protocols import AsyncAgent, BaseAgent
 from AutoGLM_GUI.config import AgentConfig, ModelConfig
@@ -112,8 +113,8 @@ class PhoneAgentManager:
         model_config: ModelConfig,
         agent_config: AgentConfig,
         agent_specific_config: AgentSpecificConfig,
-        takeover_callback: Callable | None = None,
-        confirmation_callback: Callable | None = None,
+        takeover_callback: Callable[..., Any] | None = None,
+        confirmation_callback: Callable[..., Any] | None = None,
         force: bool = False,
     ) -> AsyncAgent | BaseAgent:
         from AutoGLM_GUI.agents import create_agent

--- a/AutoGLM_GUI/platform_utils.py
+++ b/AutoGLM_GUI/platform_utils.py
@@ -14,7 +14,7 @@ def is_windows() -> bool:
 
 def run_cmd_silently_sync(
     cmd: Sequence[str], timeout: float | None = None
-) -> subprocess.CompletedProcess:
+) -> subprocess.CompletedProcess[str]:
     """Run a command synchronously, suppressing output but preserving it in the result.
 
     This is the synchronous version that works on all platforms.
@@ -31,7 +31,7 @@ def run_cmd_silently_sync(
     )
 
 
-async def run_cmd_silently(cmd: Sequence[str]) -> subprocess.CompletedProcess:
+async def run_cmd_silently(cmd: Sequence[str]) -> subprocess.CompletedProcess[str]:
     """Run a command, suppressing output but preserving it in the result; safe for async contexts on all platforms."""
     if is_windows():
         # Avoid blocking the event loop with a blocking subprocess call on Windows.

--- a/AutoGLM_GUI/scheduler_manager.py
+++ b/AutoGLM_GUI/scheduler_manager.py
@@ -83,7 +83,7 @@ class SchedulerManager:
         logger.info(f"Created scheduled task: {name} (id={task.id})")
         return task
 
-    def update_task(self, task_id: str, **kwargs) -> ScheduledTask | None:
+    def update_task(self, task_id: str, **kwargs: Any) -> ScheduledTask | None:
         task = self._tasks.get(task_id)
         if not task:
             return None

--- a/AutoGLM_GUI/schemas.py
+++ b/AutoGLM_GUI/schemas.py
@@ -1,6 +1,7 @@
 """Shared Pydantic models for the AutoGLM-GUI API."""
 
 import re
+from typing import Any
 
 from pydantic import BaseModel, field_validator
 
@@ -270,7 +271,7 @@ class ConfigResponse(BaseModel):
 
     # Agent 类型配置
     agent_type: str = "glm-async"  # Agent type (e.g., "glm-async", "mai")
-    agent_config_params: dict | None = None  # Agent-specific configuration
+    agent_config_params: dict[str, Any] | None = None  # Agent-specific configuration
 
     # Agent 执行配置
     default_max_steps: int = 100  # 单次任务最大执行步数
@@ -283,7 +284,7 @@ class ConfigResponse(BaseModel):
     decision_model_name: str | None = None
     decision_api_key: str | None = None
 
-    conflicts: list[dict] | None = None  # 配置冲突信息（可选）
+    conflicts: list[dict[str, Any]] | None = None  # 配置冲突信息（可选）
 
 
 class ConfigSaveRequest(BaseModel):
@@ -295,7 +296,9 @@ class ConfigSaveRequest(BaseModel):
 
     # Agent 类型配置
     agent_type: str = "glm-async"  # Agent type to use (e.g., "glm-async", "mai")
-    agent_config_params: dict | None = None  # Agent-specific configuration parameters
+    agent_config_params: dict[str, Any] | None = (
+        None  # Agent-specific configuration parameters
+    )
 
     # Agent 执行配置
     default_max_steps: int | None = None  # 单次任务最大执行步数
@@ -703,7 +706,7 @@ class MessageRecordResponse(BaseModel):
     content: str
     timestamp: str
     thinking: str | None = None
-    action: dict | None = None
+    action: dict[str, Any] | None = None
     step: int | None = None
 
 
@@ -780,7 +783,7 @@ class ScheduledTaskCreate(BaseModel):
             )
         return v.strip()
 
-    def model_post_init(self, __context) -> None:
+    def model_post_init(self, __context: Any) -> None:
         """验证必须指定 device_serialnos 或 device_group_id 之一."""
         if not self.device_serialnos and not self.device_group_id:
             raise ValueError(

--- a/AutoGLM_GUI/scrcpy_stream.py
+++ b/AutoGLM_GUI/scrcpy_stream.py
@@ -353,7 +353,7 @@ class ScrcpyStreamer:
             # Check if process is still running
             error_msg = None
             proc = self.scrcpy_process
-            if proc is not None:
+            if proc:
                 if is_windows():
                     if proc.poll() is not None:  # type: ignore[union-attr]
                         stdout, stderr = proc.communicate()  # type: ignore[union-attr]

--- a/AutoGLM_GUI/socketio_server.py
+++ b/AutoGLM_GUI/socketio_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from typing import Any
 
 from typing import NotRequired
 from typing_extensions import TypedDict
@@ -30,7 +31,7 @@ sio = socketio.AsyncServer(
 )
 
 _socket_streamers: dict[str, ScrcpyStreamer] = {}
-_stream_tasks: dict[str, asyncio.Task] = {}
+_stream_tasks: dict[str, asyncio.Task[None]] = {}
 _device_locks: dict[
     str, asyncio.Lock
 ] = {}  # Lock per device to prevent concurrent connections
@@ -46,7 +47,7 @@ async def _stop_stream_for_sid(sid: str) -> None:
         streamer.stop()
 
 
-def _classify_error(exc: Exception) -> dict:
+def _classify_error(exc: Exception) -> dict[str, Any]:
     """Classify error and return user-friendly message."""
     error_str = str(exc)
 
@@ -132,7 +133,7 @@ def _packet_to_payload(packet: ScrcpyMediaStreamPacket) -> VideoPacketPayload:
 
 
 @sio.event
-async def connect(sid: str, environ: dict) -> None:
+async def connect(sid: str, environ: dict[str, Any]) -> None:
     logger.info("Socket.IO client connected: %s", sid)
 
 
@@ -143,7 +144,7 @@ async def disconnect(sid: str) -> None:
 
 
 @sio.on("connect-device")  # type: ignore[misc]
-async def connect_device(sid: str, data: dict | None) -> None:
+async def connect_device(sid: str, data: dict[str, Any] | None) -> None:
     payload = data or {}
     device_id = payload.get("device_id") or payload.get("deviceId")
     if not device_id:

--- a/AutoGLM_GUI/workflow_manager.py
+++ b/AutoGLM_GUI/workflow_manager.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import uuid as uuid_lib
 from pathlib import Path
-from typing import Self
+from typing import Any, Self
 
 from AutoGLM_GUI.logger import logger
 
@@ -35,10 +35,10 @@ class WorkflowManager:
             return
         self._initialized = True
         self._workflows_path = Path.home() / ".config" / "autoglm" / "workflows.json"
-        self._file_cache: list[dict] | None = None
+        self._file_cache: list[dict[str, Any]] | None = None
         self._file_mtime: float | None = None
 
-    def list_workflows(self) -> list[dict]:
+    def list_workflows(self) -> list[dict[str, Any]]:
         """获取所有 workflows.
 
         Returns:
@@ -46,7 +46,7 @@ class WorkflowManager:
         """
         return self._load_workflows()
 
-    def get_workflow(self, uuid: str) -> dict | None:
+    def get_workflow(self, uuid: str) -> dict[str, Any] | None:
         """根据 UUID 获取单个 workflow.
 
         Args:
@@ -58,7 +58,7 @@ class WorkflowManager:
         workflows = self._load_workflows()
         return next((wf for wf in workflows if wf["uuid"] == uuid), None)
 
-    def create_workflow(self, name: str, text: str) -> dict:
+    def create_workflow(self, name: str, text: str) -> dict[str, Any]:
         """创建新 workflow.
 
         Args:
@@ -79,7 +79,7 @@ class WorkflowManager:
         logger.info(f"Created workflow: {name} (uuid={new_workflow['uuid']})")
         return new_workflow
 
-    def update_workflow(self, uuid: str, name: str, text: str) -> dict | None:
+    def update_workflow(self, uuid: str, name: str, text: str) -> dict[str, Any] | None:
         """更新 workflow.
 
         Args:
@@ -120,7 +120,7 @@ class WorkflowManager:
         logger.warning(f"Workflow not found for deletion: uuid={uuid}")
         return False
 
-    def _load_workflows(self) -> list[dict]:
+    def _load_workflows(self) -> list[dict[str, Any]]:
         """从文件加载（带 mtime 缓存）.
 
         Returns:
@@ -147,7 +147,7 @@ class WorkflowManager:
             logger.warning(f"Failed to load workflows: {e}")
             return []
 
-    def _save_workflows(self, workflows: list[dict]) -> bool:
+    def _save_workflows(self, workflows: list[dict[str, Any]]) -> bool:
         """原子写入文件.
 
         Args:

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -13,5 +13,9 @@
   ],
   "typeCheckingMode": "standard",
   "reportMissingImports": true,
-  "reportMissingTypeStubs": false
+  "reportMissingTypeStubs": false,
+  "reportMissingTypeArgument": true,
+  "reportMissingParameterType": true,
+  "reportUnnecessaryIsInstance": true,
+  "reportUnnecessaryComparison": true
 }


### PR DESCRIPTION
## Summary

- Enable 4 additional pyright type checking rules for improved type safety
- Fix all 117 type errors introduced by the new rules
- All 217 tests pass

## Changes

### New pyright rules enabled
- `reportMissingTypeArgument` - Requires type arguments for generic classes
- `reportMissingParameterType` - Requires type annotations for parameters
- `reportUnnecessaryIsInstance` - Flags redundant isinstance checks
- `reportUnnecessaryComparison` - Flags unnecessary comparisons

### Types of fixes
1. **Type arguments added** (93 fixes)
   - `dict` → `dict[str, Any]`
   - `list` → `list[Any]`
   - `Callable` → `Callable[..., Any]`
   - `CompletedProcess` → `CompletedProcess[str]`
   - `Task` → `Task[None]`

2. **Parameter type annotations** (21 fixes)
   - Added `Any` type to `*args`, `**kwargs` parameters
   - Added proper types to `__exit__` parameters

3. **Redundant code removal** (3 fixes)
   - Removed unnecessary `isinstance` checks
   - Removed unnecessary `is not None` checks

## Test plan

- [x] Run `uv run pyright` - 0 errors
- [x] Run `uv run pytest` - 217 passed, 1 skipped