### PR TITLE
chore: add backend ast-grep lint checks

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -52,6 +52,9 @@ jobs:
           echo "🎨 Checking backend Python format..."
           uv run ruff format --check --diff
 
+          echo "🌳 Checking backend structural rules..."
+          uv run ast-grep scan --config sgconfig.yml --report-style medium --color never .
+
       - name: Run frontend lint and format check
         if: always()
         run: |
@@ -110,7 +113,7 @@ jobs:
             ## 🚀 Lint & Format Check Results: ${status}
 
             ### What was checked:
-            - 🐍 **Backend**: Ruff linting + formatting
+            - 🐍 **Backend**: Ruff linting + formatting + ast-grep structural rules
             - 📱 **Frontend**: ESLint + Prettier + TypeScript types
             - 🔧 **Unified**: Custom lint script validation
 
@@ -121,6 +124,7 @@ jobs:
             ### Checks performed:
             - Backend Ruff lint ✅
             - Backend Ruff format ✅
+            - Backend ast-grep ✅
             - Frontend ESLint ✅
             - Frontend Prettier format ✅
             - Frontend TypeScript types ✅
@@ -148,6 +152,7 @@ jobs:
             \`\`\`bash
             uv run ruff check --fix
             uv run ruff format
+            uv run ast-grep scan --config sgconfig.yml --report-style medium --color never .
             \`\`\`
 
             **Frontend:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ allow-direct-references = true
 
 [dependency-groups]
 dev = [
+    "ast-grep-cli>=0.41.1",
     "pyinstaller>=6.17.0",
     "pyright>=1.1.407",
     "pytest>=9.0.2",

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -248,6 +248,78 @@ class AutoGLMLinter:
 
         return result
 
+    def lint_backend_ast_grep(self) -> LintResult:
+        """运行 ast-grep 结构化检查"""
+        if not (self.root_dir / "sgconfig.yml").exists():
+            return LintResult(
+                name="ast-grep 结构检查 (后端)",
+                success=True,
+                output="跳过: ast-grep 配置不存在",
+            )
+
+        cmd = [
+            "uv",
+            "run",
+            "ast-grep",
+            "scan",
+            "--config",
+            "sgconfig.yml",
+            "--report-style",
+            "medium",
+            "--color",
+            "never",
+            ".",
+        ]
+
+        print(f"🌳 运行: {' '.join(cmd)} (后端)")
+        result = self.run_command(cmd, self.backend_dir)
+
+        if result.success:
+            print("✅ ast-grep 结构检查通过")
+            if result.output.strip():
+                print(result.output[:2000])
+        else:
+            print("❌ ast-grep 结构检查失败")
+            if result.output:
+                print(f"发现的问题:\n{result.output[:2000]}")
+            if result.error:
+                print(f"错误: {result.error[:1000]}")
+
+        return result
+
+    def lint_backend_ast_grep_tests(self) -> LintResult:
+        """运行 ast-grep 规则测试"""
+        if not (self.root_dir / "sgconfig.yml").exists():
+            return LintResult(
+                name="ast-grep 规则测试 (后端)",
+                success=True,
+                output="跳过: ast-grep 配置不存在",
+            )
+
+        cmd = [
+            "uv",
+            "run",
+            "ast-grep",
+            "test",
+            "--config",
+            "sgconfig.yml",
+            "--skip-snapshot-tests",
+        ]
+
+        print(f"🧪 运行: {' '.join(cmd)} (后端)")
+        result = self.run_command(cmd, self.backend_dir)
+
+        if result.success:
+            print("✅ ast-grep 规则测试通过")
+        else:
+            print("❌ ast-grep 规则测试失败")
+            if result.output:
+                print(f"发现的问题:\n{result.output[:2000]}")
+            if result.error:
+                print(f"错误: {result.error[:1000]}")
+
+        return result
+
     def lint_frontend(
         self, fix: bool = False, check_only: bool = False
     ) -> list[LintResult]:
@@ -291,6 +363,12 @@ class AutoGLMLinter:
 
         # Pyright 类型检查 (Python 3.11 兼容性)
         results.append(self.lint_backend_types())
+
+        # ast-grep 结构化检查
+        results.append(self.lint_backend_ast_grep())
+
+        # ast-grep 规则测试
+        results.append(self.lint_backend_ast_grep_tests())
 
         return results
 

--- a/sg/rules/python/no-api-print.yml
+++ b/sg/rules/python/no-api-print.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-api-print
+message: API handlers should not write directly to stdout; use structured logging or HTTP responses instead.
+severity: error
+language: Python
+files:
+  - AutoGLM_GUI/api/**/*.py
+rule:
+  pattern: print($$$ARGS)
+note: Keep API request handling free of direct console output.

--- a/sg/rules/python/no-api-subprocess.yml
+++ b/sg/rules/python/no-api-subprocess.yml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-api-subprocess
+message: API handlers should not spawn subprocesses directly; delegate shell work to lower-level services.
+severity: error
+language: Python
+files:
+  - AutoGLM_GUI/api/**/*.py
+rule:
+  any:
+    - pattern: subprocess.run($$$ARGS)
+    - pattern: subprocess.Popen($$$ARGS)
+    - pattern: subprocess.check_output($$$ARGS)
+    - pattern: subprocess.check_call($$$ARGS)
+note: Keep the API layer focused on request orchestration instead of process management.

--- a/sg/rules/python/no-http-exception-detail-str-error.yml
+++ b/sg/rules/python/no-http-exception-detail-str-error.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-http-exception-detail-str-error
+message: Avoid returning raw exception strings in HTTP 500 responses; map to a stable message and log the original error.
+severity: warning
+language: Python
+files:
+  - AutoGLM_GUI/api/**/*.py
+rule:
+  pattern: raise HTTPException(status_code=500, detail=str($ERR))
+note: Raw exception text can leak implementation details to clients.

--- a/sg/rules/python/review-api-base-exception.yml
+++ b/sg/rules/python/review-api-base-exception.yml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: review-api-base-exception
+message: Review BaseException usage in API handlers; it should be reserved for cancellation or cleanup paths with a clear justification.
+severity: warning
+language: Python
+files:
+  - AutoGLM_GUI/api/**/*.py
+rule:
+  any:
+    - pattern: |
+        try:
+            $$$TRY
+        except BaseException:
+            $$$EXCEPT
+    - pattern: |
+        try:
+            $$$TRY
+        except BaseException as $ERR:
+            $$$EXCEPT
+note: Catching BaseException is broader than Exception and can hide cancellation and shutdown signals.

--- a/sg/tests/python/no-api-print-test.yml
+++ b/sg/tests/python/no-api-print-test.yml
@@ -1,0 +1,14 @@
+id: no-api-print
+valid:
+  - |
+    from loguru import logger
+
+    def handler() -> None:
+        logger.info("request started")
+  - |
+    def handler() -> None:
+        return None
+invalid:
+  - |
+    def handler() -> None:
+        print("debug")

--- a/sg/tests/python/no-api-subprocess-test.yml
+++ b/sg/tests/python/no-api-subprocess-test.yml
@@ -1,0 +1,21 @@
+id: no-api-subprocess
+valid:
+  - |
+    def handler() -> None:
+        return None
+  - |
+    from AutoGLM_GUI.platform_utils import run_subprocess
+
+    def handler() -> None:
+        run_subprocess(["adb", "devices"])
+invalid:
+  - |
+    import subprocess
+
+    def handler() -> None:
+        subprocess.run(["adb", "devices"], check=True)
+  - |
+    import subprocess
+
+    def handler() -> None:
+        subprocess.Popen(["adb", "devices"])

--- a/sg/tests/python/no-http-exception-detail-str-error-test.yml
+++ b/sg/tests/python/no-http-exception-detail-str-error-test.yml
@@ -1,0 +1,18 @@
+id: no-http-exception-detail-str-error
+valid:
+  - |
+    from fastapi import HTTPException
+
+    def handler(exc: Exception) -> None:
+        raise HTTPException(status_code=500, detail="Failed to save config")
+  - |
+    from fastapi import HTTPException
+
+    def handler(exc: Exception) -> None:
+        raise HTTPException(status_code=400, detail=str(exc))
+invalid:
+  - |
+    from fastapi import HTTPException
+
+    def handler(exc: Exception) -> None:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/sg/tests/python/review-api-base-exception-test.yml
+++ b/sg/tests/python/review-api-base-exception-test.yml
@@ -1,0 +1,27 @@
+id: review-api-base-exception
+valid:
+  - |
+    def handler() -> None:
+        try:
+            work()
+        except Exception:
+            recover()
+  - |
+    def handler() -> None:
+        try:
+            work()
+        finally:
+            cleanup()
+invalid:
+  - |
+    def handler() -> None:
+        try:
+            work()
+        except BaseException:
+            cleanup()
+  - |
+    def handler() -> None:
+        try:
+            work()
+        except BaseException as exc:
+            cleanup(exc)

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,4 @@
+ruleDirs:
+  - sg/rules
+testConfigs:
+  - testDir: sg/tests

--- a/uv.lock
+++ b/uv.lock
@@ -353,6 +353,21 @@ wheels = [
 ]
 
 [[package]]
+name = "ast-grep-cli"
+version = "0.41.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/31/239033fcb246f85c80adcca69e99bc0e19737d4338c8b5cf397054711420/ast_grep_cli-0.41.1.tar.gz", hash = "sha256:f445ce986d5cc3065cbb7e0f5018b9c39ee9308db85645efd8001142b4957fd1", size = 221381, upload-time = "2026-03-10T14:22:20.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/9f/a32c2976a460b6b053637209ce2764e704f31d1ccd458ac12ac7e6f88e07/ast_grep_cli-0.41.1-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2b1f732c75636b34338afd417fdd0d2ea341bf15fe36ef10fe474340ec0d16de", size = 14485986, upload-time = "2026-03-10T14:16:15.247Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1c/8f025e412d0cffd320a174b85f36a9e0c8af68e16db073a1c4de0d34a236/ast_grep_cli-0.41.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:559732dcde4743c07aa270f0e94aa510ab5d74530797fcea153f222f2574893e", size = 7253198, upload-time = "2026-03-10T14:22:18.655Z" },
+    { url = "https://files.pythonhosted.org/packages/99/d3/06b7443bfee65e51c94d42357d0e4c91bb2748d2aee93626257c1c984e5d/ast_grep_cli-0.41.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:ff06f614953fb205d9f399f20ccc25acde6b56a0f94bf996eb28d139515e8aae", size = 7105758, upload-time = "2026-03-10T14:16:11.12Z" },
+    { url = "https://files.pythonhosted.org/packages/28/fb/e6cf4f609c1c42779094ce33b695c804931156b5fd889d8659cbb2e5ca73/ast_grep_cli-0.41.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:6bd802ea0263d1b55181925bbecbcbca78241804e37a25b05438695a62cbe42a", size = 7385569, upload-time = "2026-03-10T14:16:13.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/76/2a95b832c491d2b9f4df0826995e4e2c8fe7500b12777b3d4f861d7b1529/ast_grep_cli-0.41.1-py3-none-win32.whl", hash = "sha256:085950ba760d1140b369997e7e983c6f674ae1319484fb197b0260b9288543e3", size = 6952936, upload-time = "2026-03-10T14:16:17.439Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f6/276bead5b562308b9ca2ba4ed8b3e48ecdf42ab0fd3b13ee0fa0ed3aca55/ast_grep_cli-0.41.1-py3-none-win_amd64.whl", hash = "sha256:f2747eaeec0239e7d32f65c8b3a7d2357bd0312968de5e22c980707088dc27b6", size = 7415279, upload-time = "2026-03-10T14:22:17.121Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/4e/5af386b58d8ef3d23ed462a9c5ebb748f543414cfc68196cae876ade9fc5/ast_grep_cli-0.41.1-py3-none-win_arm64.whl", hash = "sha256:13447ac9cd5b0d3c31e5e9908e590c0bfec020e99177b0cee9b0f5ea3f6eb9c5", size = 7106431, upload-time = "2026-03-10T14:16:08.815Z" },
+]
+
+[[package]]
 name = "async-adbutils"
 version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -426,6 +441,7 @@ droidrun = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "ast-grep-cli" },
     { name = "pyinstaller" },
     { name = "pyright" },
     { name = "pytest" },
@@ -455,6 +471,7 @@ provides-extras = ["droidrun"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "ast-grep-cli", specifier = ">=0.41.1" },
     { name = "pyinstaller", specifier = ">=6.17.0" },
     { name = "pyright", specifier = ">=1.1.407" },
     { name = "pytest", specifier = ">=9.0.2" },


### PR DESCRIPTION
## Summary
- add ast-grep to dev dependencies and create repository config for structural Python rules
- add initial backend API rules plus ast-grep rule tests
- integrate ast-grep scan into the unified lint script and PR lint workflow

## Verification
- uv run python scripts/lint.py --backend --check-only
- uv run --with ast-grep-cli ast-grep test --config sgconfig.yml --skip-snapshot-tests
- uv run --with ast-grep-cli ast-grep scan --config sgconfig.yml --report-style medium --color never .