### PR TITLE
feat(ui): add image preview component with click-to-zoom

### DIFF
--- a/frontend/src/components/DevicePanel.tsx
+++ b/frontend/src/components/DevicePanel.tsx
@@ -944,11 +944,17 @@ export function DevicePanel({
                                               1000) *
                                             100;
                                           const x2 =
-                                            (Math.max(0, Math.min(end[0], 1000)) /
+                                            (Math.max(
+                                              0,
+                                              Math.min(end[0], 1000)
+                                            ) /
                                               1000) *
                                             100;
                                           const y2 =
-                                            (Math.max(0, Math.min(end[1], 1000)) /
+                                            (Math.max(
+                                              0,
+                                              Math.min(end[1], 1000)
+                                            ) /
                                               1000) *
                                             100;
                                           return (

--- a/frontend/src/components/ui/image-preview.tsx
+++ b/frontend/src/components/ui/image-preview.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-refresh/only-export-components */
 import * as React from 'react';
 import { X, ZoomIn } from 'lucide-react';
 import { cn } from '@/lib/utils';


### PR DESCRIPTION
## Summary

- Add `ImagePreview` component using Radix UI Dialog for image preview functionality
- Click on screenshot thumbnail to open full-screen preview
- Support ESC key and click outside to close
- Preserve action overlay (tap/swipe indicators) functionality
- Replace static `<img>` tag in DevicePanel with new component

## Changes

| File | Change |
|------|--------|
| `frontend/src/components/ui/image-preview.tsx` | New component |
| `frontend/src/components/DevicePanel.tsx` | Integrate ImagePreview |

## Test Plan

- [ ] Start frontend dev server
- [ ] Execute a task that produces screenshots
- [ ] Click on screenshot to verify full-screen preview opens
- [ ] Press ESC to close preview
- [ ] Click outside image to close preview
- [ ] Verify action overlays (tap/swipe indicators) still display correctly
- [ ] Check dark mode styling