### PR TITLE
refactor(types): add Workflow TypedDict to workflow_manager

### DIFF
--- a/AutoGLM_GUI/workflow_manager.py
+++ b/AutoGLM_GUI/workflow_manager.py
@@ -13,7 +13,16 @@ from __future__ import annotations
 import json
 import uuid as uuid_lib
 from pathlib import Path
-from typing import Any, Self
+from typing import Self, TypedDict
+
+
+class Workflow(TypedDict):
+    """Workflow 数据结构."""
+
+    uuid: str
+    name: str
+    text: str
+
 
 from AutoGLM_GUI.logger import logger
 
@@ -35,10 +44,10 @@ class WorkflowManager:
             return
         self._initialized = True
         self._workflows_path = Path.home() / ".config" / "autoglm" / "workflows.json"
-        self._file_cache: list[dict[str, Any]] | None = None
+        self._file_cache: list[Workflow] | None = None
         self._file_mtime: float | None = None
 
-    def list_workflows(self) -> list[dict[str, Any]]:
+    def list_workflows(self) -> list[Workflow]:
         """获取所有 workflows.
 
         Returns:
@@ -46,7 +55,7 @@ class WorkflowManager:
         """
         return self._load_workflows()
 
-    def get_workflow(self, uuid: str) -> dict[str, Any] | None:
+    def get_workflow(self, uuid: str) -> Workflow | None:
         """根据 UUID 获取单个 workflow.
 
         Args:
@@ -58,7 +67,7 @@ class WorkflowManager:
         workflows = self._load_workflows()
         return next((wf for wf in workflows if wf["uuid"] == uuid), None)
 
-    def create_workflow(self, name: str, text: str) -> dict[str, Any]:
+    def create_workflow(self, name: str, text: str) -> Workflow:
         """创建新 workflow.
 
         Args:
@@ -79,7 +88,7 @@ class WorkflowManager:
         logger.info(f"Created workflow: {name} (uuid={new_workflow['uuid']})")
         return new_workflow
 
-    def update_workflow(self, uuid: str, name: str, text: str) -> dict[str, Any] | None:
+    def update_workflow(self, uuid: str, name: str, text: str) -> Workflow | None:
         """更新 workflow.
 
         Args:
@@ -120,7 +129,7 @@ class WorkflowManager:
         logger.warning(f"Workflow not found for deletion: uuid={uuid}")
         return False
 
-    def _load_workflows(self) -> list[dict[str, Any]]:
+    def _load_workflows(self) -> list[Workflow]:
         """从文件加载（带 mtime 缓存）.
 
         Returns:
@@ -147,7 +156,7 @@ class WorkflowManager:
             logger.warning(f"Failed to load workflows: {e}")
             return []
 
-    def _save_workflows(self, workflows: list[dict[str, Any]]) -> bool:
+    def _save_workflows(self, workflows: list[Workflow]) -> bool:
         """原子写入文件.
 
         Args:


### PR DESCRIPTION
## Summary
- Add `Workflow` TypedDict with `uuid`, `name`, `text` fields
- Replace all `dict[str, Any]` usages in `workflow_manager.py` with `Workflow`
- Improve type safety and IDE support

## Changes
- `WorkflowManager._file_cache`: `list[dict[str, Any]]` → `list[Workflow]`
- `list_workflows()`: `list[dict[str, Any]]` → `list[Workflow]`
- `get_workflow()`: `dict[str, Any] | None` → `Workflow | None`
- `create_workflow()`: `dict[str, Any]` → `Workflow`
- `update_workflow()`: `dict[str, Any] | None` → `Workflow | None`
- `_load_workflows()`: `list[dict[str, Any]]` → `list[Workflow]`
- `_save_workflows()`: `list[dict[str, Any]]` → `list[Workflow]`

## Test plan
- [x] All 225 tests pass
- [x] Workflow API tests pass

Part of optimization plan Task 5 (type annotation optimization).
This is the first step - follow-up PRs will add TypedDict/dataclasses
for config_manager, device_manager, and other modules.