### PR TITLE
Refine async agent flow and non-blocking ADB handlers

### DIFF
--- a/AutoGLM_GUI/adb_plus/__init__.py
+++ b/AutoGLM_GUI/adb_plus/__init__.py
@@ -1,28 +1,42 @@
 """Lightweight ADB helpers with a more robust screenshot implementation."""
 
 from .device import check_device_available
-from .ip import get_wifi_ip
+from .ip import get_wifi_ip, get_wifi_ip_async
 from .keyboard_installer import ADBKeyboardInstaller
 from .mdns import MdnsDevice, discover_mdns_devices
-from .pair import pair_device
+from .pair import pair_device, pair_device_async
 from .qr_pair import qr_pairing_manager
-from .screenshot import Screenshot, capture_screenshot
-from .serial import extract_serial_from_mdns, get_device_serial
-from .touch import touch_down, touch_move, touch_up
+from .screenshot import Screenshot, capture_screenshot, capture_screenshot_async
+from .serial import extract_serial_from_mdns, get_device_serial, get_device_serial_async
+from .touch import (
+    touch_down,
+    touch_down_async,
+    touch_move,
+    touch_move_async,
+    touch_up,
+    touch_up_async,
+)
 from .version import get_adb_version, supports_mdns_services
 
 __all__ = [
     "ADBKeyboardInstaller",
     "Screenshot",
     "capture_screenshot",
+    "capture_screenshot_async",
     "touch_down",
+    "touch_down_async",
     "touch_move",
+    "touch_move_async",
     "touch_up",
+    "touch_up_async",
     "get_wifi_ip",
+    "get_wifi_ip_async",
     "get_device_serial",
+    "get_device_serial_async",
     "extract_serial_from_mdns",
     "check_device_available",
     "pair_device",
+    "pair_device_async",
     "discover_mdns_devices",
     "MdnsDevice",
     "qr_pairing_manager",

--- a/AutoGLM_GUI/adb_plus/ip.py
+++ b/AutoGLM_GUI/adb_plus/ip.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 
 from AutoGLM_GUI.logger import logger
+from AutoGLM_GUI.platform_utils import run_cmd_silently
 
 __all__ = ["get_wifi_ip"]
 
@@ -28,6 +29,13 @@ def _extract_ip(text: str) -> str | None:
     if ip == "0.0.0.0":
         return None
     return ip
+
+
+def _build_shell_cmd(adb_path: str, device_id: str | None, cmd: list[str]) -> list[str]:
+    base_cmd = [adb_path]
+    if device_id:
+        base_cmd.extend(["-s", device_id])
+    return base_cmd + ["shell", *cmd]
 
 
 def get_wifi_ip(adb_path: str = "adb", device_id: str | None = None) -> str | None:
@@ -75,3 +83,51 @@ def get_wifi_ip(adb_path: str = "adb", device_id: str | None = None) -> str | No
         logger.debug(f"Failed to get IP from wlan0: {e}")
 
     return None
+
+
+async def get_wifi_ip_async(
+    adb_path: str = "adb", device_id: str | None = None
+) -> str | None:
+    """Async variant of ``get_wifi_ip`` for non-blocking request flows."""
+    try:
+        route_result = await run_cmd_silently(
+            _build_shell_cmd(
+                adb_path, device_id, ["ip", "-4", "route", "get", "8.8.8.8"]
+            ),
+            timeout=5,
+        )
+        for line in (route_result.stdout or route_result.stderr).splitlines():
+            if "src" not in line:
+                continue
+            parts = line.split()
+            iface = None
+            ip = None
+            if "dev" in parts:
+                try:
+                    iface = parts[parts.index("dev") + 1]
+                except (IndexError, ValueError) as exc:
+                    logger.debug("Failed to extract async route iface: %s", exc)
+            if "src" in parts:
+                try:
+                    ip = parts[parts.index("src") + 1]
+                except (IndexError, ValueError) as exc:
+                    logger.debug("Failed to extract async route ip: %s", exc)
+            if not ip or ip == "0.0.0.0":
+                continue
+            if iface and (iface.startswith("ccmni") or iface.startswith("rmnet")):
+                continue
+            return ip
+    except Exception as exc:
+        logger.debug("Failed to get async IP from route: %s", exc)
+
+    try:
+        addr_result = await run_cmd_silently(
+            _build_shell_cmd(
+                adb_path, device_id, ["ip", "-4", "addr", "show", "wlan0"]
+            ),
+            timeout=5,
+        )
+        return _extract_ip((addr_result.stdout or "") + (addr_result.stderr or ""))
+    except Exception as exc:
+        logger.debug("Failed to get async IP from wlan0: %s", exc)
+        return None

--- a/AutoGLM_GUI/adb_plus/mdns.py
+++ b/AutoGLM_GUI/adb_plus/mdns.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
+from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.platform_utils import run_cmd_silently_sync
 
 __all__ = ["MdnsDevice", "discover_mdns_devices"]
@@ -187,6 +188,7 @@ def discover_mdns_devices(adb_path: str = "adb") -> list[MdnsDevice]:
 
         return devices
 
-    except Exception:
+    except Exception as exc:
+        logger.debug("Failed to discover mDNS devices: %s", exc)
         # Return empty list on any error (timeout, command not found, etc.)
         return []

--- a/AutoGLM_GUI/adb_plus/pair.py
+++ b/AutoGLM_GUI/adb_plus/pair.py
@@ -1,6 +1,6 @@
 """ADB wireless pairing support for Android 11+."""
 
-from AutoGLM_GUI.platform_utils import run_cmd_silently_sync
+from AutoGLM_GUI.platform_utils import run_cmd_silently, run_cmd_silently_sync
 
 
 def pair_device(
@@ -58,3 +58,38 @@ def pair_device(
 
     except Exception as e:
         return False, f"Pairing error: {e}"
+
+
+async def pair_device_async(
+    ip: str,
+    port: int,
+    pairing_code: str,
+    adb_path: str = "adb",
+) -> tuple[bool, str]:
+    """Async variant of ``pair_device`` for request flows."""
+    if not pairing_code.isdigit() or len(pairing_code) != 6:
+        return False, "Pairing code must be 6 digits"
+
+    address = f"{ip}:{port}"
+
+    try:
+        result = await run_cmd_silently(
+            [adb_path, "pair", address, pairing_code],
+            timeout=30,
+        )
+        output = result.stdout + result.stderr
+
+        if "Successfully paired" in output or "success" in output.lower():
+            return True, f"Successfully paired to {address}"
+        if "failed" in output.lower():
+            if "pairing code" in output.lower():
+                return False, "Invalid pairing code"
+            if "refused" in output.lower():
+                return (
+                    False,
+                    "Connection refused - check if wireless debugging is enabled",
+                )
+            return False, f"Pairing failed: {output.strip()}"
+        return False, output.strip() or "Unknown pairing error"
+    except Exception as exc:
+        return False, f"Pairing error: {exc}"

--- a/AutoGLM_GUI/adb_plus/screenshot.py
+++ b/AutoGLM_GUI/adb_plus/screenshot.py
@@ -6,6 +6,7 @@ Features:
 - Validates PNG signature/size and retries before falling back.
 """
 
+import asyncio
 import base64
 import subprocess
 from dataclasses import dataclass
@@ -14,6 +15,8 @@ from io import BytesIO
 from PIL import Image
 
 from AutoGLM_GUI.exceptions import DeviceNotAvailableError
+from AutoGLM_GUI.logger import logger
+from AutoGLM_GUI.platform_utils import is_windows
 from AutoGLM_GUI.trace import trace_span
 
 
@@ -77,7 +80,10 @@ def capture_screenshot(
                     }
                 )
                 return Screenshot(base64_data=base64_data, width=width, height=height)
-            except Exception:
+            except Exception as exc:
+                logger.debug(
+                    "Failed to decode screenshot PNG for %s: %s", device_id, exc
+                )
                 continue
 
         span.set_attributes({"success": False, "fallback": True})
@@ -120,7 +126,114 @@ def _try_capture(device_id: str | None, adb_path: str, timeout: int) -> bytes | 
         return result.stdout
     except DeviceNotAvailableError:
         raise  # Re-raise to caller
-    except Exception:
+    except Exception as exc:
+        logger.debug("Screenshot capture failed for %s: %s", device_id, exc)
+        return None
+
+
+async def capture_screenshot_async(
+    device_id: str | None = None,
+    adb_path: str = "adb",
+    timeout: int = 10,
+    retries: int = 1,
+) -> Screenshot:
+    """Async screenshot capture for FastAPI handlers."""
+    with trace_span(
+        "adb.capture_screenshot_async",
+        attrs={"device_id": device_id, "timeout": timeout, "retries": retries},
+    ) as span:
+        attempts = max(1, retries + 1)
+        for attempt in range(attempts):
+            data = await _try_capture_async(
+                device_id=device_id,
+                adb_path=adb_path,
+                timeout=timeout,
+            )
+            if not data or not _is_valid_png(data):
+                continue
+
+            try:
+                image = await asyncio.to_thread(Image.open, BytesIO(data))
+                width, height = image.size
+                base64_data = base64.b64encode(data).decode("utf-8")
+                span.set_attributes(
+                    {
+                        "success": True,
+                        "attempt": attempt + 1,
+                        "width": width,
+                        "height": height,
+                    }
+                )
+                return Screenshot(base64_data=base64_data, width=width, height=height)
+            except Exception as exc:
+                logger.debug(
+                    "Failed to decode async screenshot PNG for %s: %s",
+                    device_id,
+                    exc,
+                )
+                continue
+
+        span.set_attributes({"success": False, "fallback": True})
+        return _fallback_screenshot()
+
+
+async def _try_capture_async(
+    device_id: str | None, adb_path: str, timeout: int
+) -> bytes | None:
+    """Async exec-out screencap helper."""
+    cmd: list[str] = [adb_path]
+    if device_id:
+        cmd.extend(["-s", device_id])
+    cmd.extend(["exec-out", "screencap", "-p"])
+
+    try:
+        with trace_span(
+            "adb.exec_out_screencap_async",
+            attrs={"device_id": device_id, "timeout": timeout},
+        ):
+            if is_windows():
+                result = await asyncio.to_thread(
+                    subprocess.run,
+                    cmd,
+                    capture_output=True,
+                    timeout=timeout,
+                )
+            else:
+                process = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                try:
+                    stdout, stderr = await asyncio.wait_for(
+                        process.communicate(),
+                        timeout=timeout,
+                    )
+                except asyncio.TimeoutError:
+                    process.kill()
+                    await process.communicate()
+                    raise subprocess.TimeoutExpired(cmd, timeout)
+                result = subprocess.CompletedProcess(
+                    cmd,
+                    process.returncode if process.returncode is not None else -1,
+                    stdout,
+                    stderr,
+                )
+        if result.returncode != 0:
+            stderr = (
+                result.stderr.decode("utf-8", errors="ignore") if result.stderr else ""
+            )
+            stderr_lower = stderr.lower()
+            if "device not found" in stderr_lower or "offline" in stderr_lower:
+                raise DeviceNotAvailableError(
+                    f"Device {device_id} not found or offline"
+                )
+            return None
+        return result.stdout
+    except DeviceNotAvailableError:
+        raise
+    except Exception as exc:
+        logger.debug("Async screenshot capture failed for %s: %s", device_id, exc)
         return None
 
 

--- a/AutoGLM_GUI/adb_plus/serial.py
+++ b/AutoGLM_GUI/adb_plus/serial.py
@@ -2,7 +2,7 @@
 
 import re
 
-from AutoGLM_GUI.platform_utils import run_cmd_silently_sync
+from AutoGLM_GUI.platform_utils import run_cmd_silently, run_cmd_silently_sync
 
 
 def extract_serial_from_mdns(device_id: str) -> str | None:
@@ -104,6 +104,36 @@ def get_device_serial(device_id: str, adb_path: str = "adb") -> str:
     # Fallback: Use device_id itself as serial
     # This handles emulators (MuMu, Nox, etc.) and restricted devices
     # that don't expose serial number via getprop
+    logger.warning(
+        f"Could not get hardware serial for {device_id}, "
+        f"using device_id as serial (emulator/restricted device)"
+    )
+    return device_id
+
+
+async def get_device_serial_async(device_id: str, adb_path: str = "adb") -> str:
+    """Async variant of ``get_device_serial`` for request flows."""
+    from AutoGLM_GUI.logger import logger
+
+    mdns_serial = extract_serial_from_mdns(device_id)
+    if mdns_serial:
+        logger.debug(f"Extracted serial from mDNS name: {device_id} → {mdns_serial}")
+        return mdns_serial
+
+    for prop in _SERIAL_PROPS:
+        try:
+            result = await run_cmd_silently(
+                [adb_path, "-s", device_id, "shell", "getprop", prop],
+                timeout=5,
+            )
+            if result.returncode == 0:
+                serial = result.stdout.strip()
+                if serial and not serial.startswith("error:") and serial != "unknown":
+                    logger.debug(f"Got serial via {prop}: {device_id} → {serial}")
+                    return serial
+        except Exception as exc:
+            logger.debug(f"Failed to get serial via {prop} for {device_id}: {exc}")
+
     logger.warning(
         f"Could not get hardware serial for {device_id}, "
         f"using device_id as serial (emulator/restricted device)"

--- a/AutoGLM_GUI/adb_plus/touch.py
+++ b/AutoGLM_GUI/adb_plus/touch.py
@@ -1,9 +1,10 @@
 """Touch control utilities using ADB motion events for real-time dragging."""
 
+import asyncio
 import subprocess
 import time
 
-from AutoGLM_GUI.platform_utils import build_adb_command
+from AutoGLM_GUI.platform_utils import build_adb_command, run_cmd_silently
 
 
 def touch_down(
@@ -85,3 +86,54 @@ def touch_up(
     )
     if delay > 0:
         time.sleep(delay)
+
+
+async def touch_down_async(
+    x: int,
+    y: int,
+    device_id: str | None = None,
+    delay: float = 0.0,
+    adb_path: str = "adb",
+) -> None:
+    """Async variant of ``touch_down`` for request handlers."""
+    adb_prefix = build_adb_command(device_id, adb_path)
+    await run_cmd_silently(
+        adb_prefix + ["shell", "input", "motionevent", "DOWN", str(x), str(y)],
+        timeout=5,
+    )
+    if delay > 0:
+        await asyncio.sleep(delay)
+
+
+async def touch_move_async(
+    x: int,
+    y: int,
+    device_id: str | None = None,
+    delay: float = 0.0,
+    adb_path: str = "adb",
+) -> None:
+    """Async variant of ``touch_move`` for request handlers."""
+    adb_prefix = build_adb_command(device_id, adb_path)
+    await run_cmd_silently(
+        adb_prefix + ["shell", "input", "motionevent", "MOVE", str(x), str(y)],
+        timeout=5,
+    )
+    if delay > 0:
+        await asyncio.sleep(delay)
+
+
+async def touch_up_async(
+    x: int,
+    y: int,
+    device_id: str | None = None,
+    delay: float = 0.0,
+    adb_path: str = "adb",
+) -> None:
+    """Async variant of ``touch_up`` for request handlers."""
+    adb_prefix = build_adb_command(device_id, adb_path)
+    await run_cmd_silently(
+        adb_prefix + ["shell", "input", "motionevent", "UP", str(x), str(y)],
+        timeout=5,
+    )
+    if delay > 0:
+        await asyncio.sleep(delay)

--- a/AutoGLM_GUI/agents/__init__.py
+++ b/AutoGLM_GUI/agents/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 from collections.abc import Callable
 
-from .protocols import AsyncAgent, BaseAgent, is_async_agent
+from .protocols import AsyncAgent
 
 
 def register_agent(agent_type: str, creator: Callable[..., Any]) -> None:
@@ -20,7 +20,7 @@ def create_agent(
     device: Any,
     takeover_callback: Callable[..., Any] | None = None,
     confirmation_callback: Callable[..., Any] | None = None,
-) -> AsyncAgent | BaseAgent:
+) -> AsyncAgent:
     from .factory import create_agent as _create_agent
 
     return _create_agent(
@@ -48,10 +48,8 @@ def is_agent_type_registered(agent_type: str) -> bool:
 
 __all__ = [
     "AsyncAgent",
-    "BaseAgent",
     "create_agent",
     "is_agent_type_registered",
-    "is_async_agent",
     "list_agent_types",
     "register_agent",
 ]

--- a/AutoGLM_GUI/agents/factory.py
+++ b/AutoGLM_GUI/agents/factory.py
@@ -14,16 +14,16 @@ from AutoGLM_GUI.device_protocol import DeviceProtocol
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.types import AgentSpecificConfig
 
-from .protocols import AsyncAgent, BaseAgent
+from .protocols import AsyncAgent
 
 
 # Agent registry: agent_type -> (creator_function, config_schema)
-AGENT_REGISTRY: dict[str, Callable[..., AsyncAgent | BaseAgent]] = {}
+AGENT_REGISTRY: dict[str, Callable[..., AsyncAgent]] = {}
 
 
 def register_agent(
     agent_type: str,
-    creator: Callable[..., AsyncAgent | BaseAgent],
+    creator: Callable[..., AsyncAgent],
 ) -> None:
     """
     Register a new agent type.
@@ -31,7 +31,7 @@ def register_agent(
     Args:
         agent_type: Unique identifier for the agent type (e.g., "glm-async", "mai")
         creator: Function that creates the agent instance.
-                  Signature: (model_config, agent_config, agent_specific_config, callbacks) -> BaseAgent
+                  Signature: (model_config, agent_config, agent_specific_config, callbacks) -> AsyncAgent
 
     Example:
         >>> def create_mai_agent(model_config, agent_config, mai_config, callbacks):
@@ -54,7 +54,7 @@ def create_agent(
     device: DeviceProtocol,
     takeover_callback: Callable[..., Any] | None = None,
     confirmation_callback: Callable[..., Any] | None = None,
-) -> AsyncAgent | BaseAgent:
+) -> AsyncAgent:
     """
     Create an agent instance using the factory pattern.
 
@@ -68,8 +68,7 @@ def create_agent(
         confirmation_callback: Confirmation callback
 
     Returns:
-        Agent instance implementing AsyncAgent or BaseAgent interface.
-        Use runtime type detection (e.g., inspect.iscoroutinefunction) to determine which.
+        Agent instance implementing AsyncAgent.
 
     Raises:
         ValueError: If agent_type is not registered

--- a/AutoGLM_GUI/agents/protocols.py
+++ b/AutoGLM_GUI/agents/protocols.py
@@ -1,48 +1,9 @@
 from __future__ import annotations
 
-import inspect
 from typing import Any, Protocol
 from collections.abc import AsyncIterator
 
 from AutoGLM_GUI.config import AgentConfig, ModelConfig, StepResult
-
-
-def is_async_agent(agent: AsyncAgent | BaseAgent) -> bool:
-    """Check if an agent implements the AsyncAgent interface.
-
-    Uses runtime inspection to detect async capabilities since static
-    type narrowing is not possible with Protocol union types.
-
-    Args:
-        agent: Agent instance to check
-
-    Returns:
-        True if agent has async stream() method, False otherwise
-    """
-    stream_method = getattr(agent, "stream", None)
-    return stream_method is not None and inspect.isasyncgenfunction(stream_method)
-
-
-class BaseAgent(Protocol):
-    model_config: ModelConfig
-    agent_config: AgentConfig
-
-    def run(self, task: str) -> str: ...
-
-    def step(self, task: str | None = None) -> StepResult: ...
-
-    def reset(self) -> None: ...
-
-    def abort(self) -> None: ...
-
-    @property
-    def step_count(self) -> int: ...
-
-    @property
-    def context(self) -> list[dict[str, Any]]: ...
-
-    @property
-    def is_running(self) -> bool: ...
 
 
 class AsyncAgent(Protocol):
@@ -115,6 +76,10 @@ class AsyncAgent(Protocol):
 
     def reset(self) -> None:
         """重置状态（同步方法，只清理内存）。"""
+        ...
+
+    def step(self, task: str | None = None) -> StepResult:
+        """执行单步任务。"""
         ...
 
     @property

--- a/AutoGLM_GUI/api/control.py
+++ b/AutoGLM_GUI/api/control.py
@@ -1,5 +1,7 @@
 """Device control routes (tap/swipe/touch)."""
 
+import asyncio
+
 from fastapi import APIRouter
 
 from AutoGLM_GUI.devices.adb_device import ADBDevice
@@ -20,14 +22,15 @@ router = APIRouter()
 
 
 @router.post("/api/control/tap", response_model=TapResponse)
-def control_tap(request: TapRequest) -> TapResponse:
+async def control_tap(request: TapRequest) -> TapResponse:
     """Execute tap at specified device coordinates."""
     try:
         if not request.device_id:
             return TapResponse(success=False, error="device_id is required")
 
         device = ADBDevice(request.device_id)
-        device.tap(
+        await asyncio.to_thread(
+            device.tap,
             x=request.x,
             y=request.y,
             delay=request.delay,
@@ -39,14 +42,15 @@ def control_tap(request: TapRequest) -> TapResponse:
 
 
 @router.post("/api/control/swipe", response_model=SwipeResponse)
-def control_swipe(request: SwipeRequest) -> SwipeResponse:
+async def control_swipe(request: SwipeRequest) -> SwipeResponse:
     """Execute swipe from start to end coordinates."""
     try:
         if not request.device_id:
             return SwipeResponse(success=False, error="device_id is required")
 
         device = ADBDevice(request.device_id)
-        device.swipe(
+        await asyncio.to_thread(
+            device.swipe,
             start_x=request.start_x,
             start_y=request.start_y,
             end_x=request.end_x,
@@ -61,12 +65,12 @@ def control_swipe(request: SwipeRequest) -> SwipeResponse:
 
 
 @router.post("/api/control/touch/down", response_model=TouchDownResponse)
-def control_touch_down(request: TouchDownRequest) -> TouchDownResponse:
+async def control_touch_down(request: TouchDownRequest) -> TouchDownResponse:
     """Send touch DOWN event at specified device coordinates."""
     try:
-        from AutoGLM_GUI.adb_plus import touch_down
+        from AutoGLM_GUI.adb_plus import touch_down_async
 
-        touch_down(
+        await touch_down_async(
             x=request.x,
             y=request.y,
             device_id=request.device_id,
@@ -79,12 +83,12 @@ def control_touch_down(request: TouchDownRequest) -> TouchDownResponse:
 
 
 @router.post("/api/control/touch/move", response_model=TouchMoveResponse)
-def control_touch_move(request: TouchMoveRequest) -> TouchMoveResponse:
+async def control_touch_move(request: TouchMoveRequest) -> TouchMoveResponse:
     """Send touch MOVE event at specified device coordinates."""
     try:
-        from AutoGLM_GUI.adb_plus import touch_move
+        from AutoGLM_GUI.adb_plus import touch_move_async
 
-        touch_move(
+        await touch_move_async(
             x=request.x,
             y=request.y,
             device_id=request.device_id,
@@ -97,12 +101,12 @@ def control_touch_move(request: TouchMoveRequest) -> TouchMoveResponse:
 
 
 @router.post("/api/control/touch/up", response_model=TouchUpResponse)
-def control_touch_up(request: TouchUpRequest) -> TouchUpResponse:
+async def control_touch_up(request: TouchUpRequest) -> TouchUpResponse:
     """Send touch UP event at specified device coordinates."""
     try:
-        from AutoGLM_GUI.adb_plus import touch_up
+        from AutoGLM_GUI.adb_plus import touch_up_async
 
-        touch_up(
+        await touch_up_async(
             x=request.x,
             y=request.y,
             device_id=request.device_id,

--- a/AutoGLM_GUI/api/devices.py
+++ b/AutoGLM_GUI/api/devices.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter
 
@@ -58,7 +58,7 @@ def _build_device_response_with_agent(
     """
     from AutoGLM_GUI.device_group_manager import device_group_manager
 
-    response = device.to_dict()
+    response: dict[str, Any] = dict(device.to_dict())
 
     # 添加分组信息
     response["group_id"] = device_group_manager.get_device_group(device.serial)

--- a/AutoGLM_GUI/api/layered_agent.py
+++ b/AutoGLM_GUI/api/layered_agent.py
@@ -211,7 +211,6 @@ async def chat(device_id: str, message: str) -> str:
         - steps: 执行的步数
         - success: 是否成功
     """
-    from AutoGLM_GUI.agents.protocols import is_async_agent
     from AutoGLM_GUI.exceptions import DeviceBusyError
     from AutoGLM_GUI.phone_agent_manager import PhoneAgentManager
     from AutoGLM_GUI.prompts import MCP_SYSTEM_PROMPT_ZH
@@ -272,13 +271,10 @@ async def chat(device_id: str, message: str) -> str:
                     attrs={
                         "device_id": device_id,
                         "agent_type": agent.__class__.__name__,
-                        "is_async_agent": is_async_agent(agent),
+                        "is_async_agent": True,
                     },
                 ):
-                    if is_async_agent(agent):
-                        result = await agent.run(message)  # type: ignore[misc]
-                    else:
-                        result = await asyncio.to_thread(agent.run, message)  # type: ignore[misc]
+                    result = await agent.run(message)
                 steps = agent.step_count
 
                 if steps >= MCP_MAX_STEPS and result == "Max steps reached":

--- a/AutoGLM_GUI/api/mcp.py
+++ b/AutoGLM_GUI/api/mcp.py
@@ -38,7 +38,6 @@ async def chat(device_id: str, message: str) -> ChatResult:
         device_id: Device identifier (e.g., "192.168.1.100:5555" or serial)
         message: Natural language task (e.g., "打开微信", "发送消息")
     """
-    from AutoGLM_GUI.agents.protocols import is_async_agent
     from AutoGLM_GUI.exceptions import DeviceBusyError
     from AutoGLM_GUI.phone_agent_manager import PhoneAgentManager
 
@@ -71,13 +70,7 @@ async def chat(device_id: str, message: str) -> ChatResult:
             # Reset agent before each chat to ensure clean state
             agent.reset()
 
-            if is_async_agent(agent):
-                result = cast(str, await agent.run(message))  # type: ignore[misc]
-            else:
-                result = cast(
-                    str,
-                    await asyncio.to_thread(agent.run, message),  # type: ignore[misc]
-                )
+            result = cast(str, await agent.run(message))
             steps = agent.step_count
 
             # Check if MCP step limit was reached

--- a/AutoGLM_GUI/api/media.py
+++ b/AutoGLM_GUI/api/media.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from fastapi import APIRouter
 
-from AutoGLM_GUI.adb_plus import capture_screenshot
+from AutoGLM_GUI.adb_plus import capture_screenshot_async
 from AutoGLM_GUI.exceptions import DeviceNotAvailableError
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.schemas import ScreenshotRequest, ScreenshotResponse
@@ -30,7 +31,7 @@ async def reset_video_stream(device_id: str | None = None) -> dict[str, Any]:
 
 
 @router.post("/api/screenshot", response_model=ScreenshotResponse)
-def take_screenshot(request: ScreenshotRequest) -> ScreenshotResponse:
+async def take_screenshot(request: ScreenshotRequest) -> ScreenshotResponse:
     """获取设备截图。此操作无副作用，不影响 PhoneAgent 运行。"""
     from AutoGLM_GUI.device_manager import DeviceManager
 
@@ -75,7 +76,10 @@ def take_screenshot(request: ScreenshotRequest) -> ScreenshotResponse:
                         error=f"Remote device {serial} not found",
                     )
 
-                screenshot = remote_device.get_screenshot(timeout=10)  # type: ignore
+                screenshot = await asyncio.to_thread(
+                    remote_device.get_screenshot,
+                    timeout=10,
+                )
                 return ScreenshotResponse(
                     success=True,
                     image=screenshot.base64_data,
@@ -84,7 +88,7 @@ def take_screenshot(request: ScreenshotRequest) -> ScreenshotResponse:
                     is_sensitive=screenshot.is_sensitive,
                 )
 
-        screenshot = capture_screenshot(device_id=device_id)
+        screenshot = await capture_screenshot_async(device_id=device_id)
         return ScreenshotResponse(
             success=True,
             image=screenshot.base64_data,

--- a/AutoGLM_GUI/config_manager.py
+++ b/AutoGLM_GUI/config_manager.py
@@ -18,9 +18,10 @@ import os
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Self, cast
 
 from pydantic import BaseModel, field_validator
+from typing_extensions import TypedDict
 
 from AutoGLM_GUI.logger import logger
 
@@ -49,6 +50,19 @@ class ThinkingMode(StrEnum):
 
     FAST = "fast"  # 快速响应模式 - 减少思考时间
     DEEP = "deep"  # 深度思考模式 - 完整思考过程
+
+
+class ConfigFileData(TypedDict, total=False):
+    base_url: str
+    model_name: str
+    api_key: str
+    agent_type: str
+    agent_config_params: dict[str, Any]
+    default_max_steps: int
+    layered_max_turns: int
+    decision_base_url: str
+    decision_model_name: str
+    decision_api_key: str
 
 
 class ConfigModel(BaseModel):
@@ -161,28 +175,31 @@ class ConfigLayer:
         value = getattr(self, key, None)
         return value is not None
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> ConfigFileData:
         """转换为字典，排除 None 值.
 
         Returns:
             dict[str, Any]: 配置字典
         """
-        return {
-            k: v
-            for k, v in {
-                "base_url": self.base_url,
-                "model_name": self.model_name,
-                "api_key": self.api_key,
-                "agent_type": self.agent_type,
-                "agent_config_params": self.agent_config_params,
-                "default_max_steps": self.default_max_steps,
-                "layered_max_turns": self.layered_max_turns,
-                "decision_base_url": self.decision_base_url,
-                "decision_model_name": self.decision_model_name,
-                "decision_api_key": self.decision_api_key,
-            }.items()
-            if v is not None
-        }
+        return cast(
+            ConfigFileData,
+            {
+                k: v
+                for k, v in {
+                    "base_url": self.base_url,
+                    "model_name": self.model_name,
+                    "api_key": self.api_key,
+                    "agent_type": self.agent_type,
+                    "agent_config_params": self.agent_config_params,
+                    "default_max_steps": self.default_max_steps,
+                    "layered_max_turns": self.layered_max_turns,
+                    "decision_base_url": self.decision_base_url,
+                    "decision_model_name": self.decision_model_name,
+                    "decision_api_key": self.decision_api_key,
+                }.items()
+                if v is not None
+            },
+        )
 
 
 # ==================== 配置冲突数据类 ====================
@@ -250,7 +267,7 @@ class UnifiedConfigManager:
         )
 
         # 文件缓存（带修改时间戳）
-        self._file_cache: dict[str, Any] | None = None
+        self._file_cache: ConfigFileData | None = None
         self._file_mtime: float | None = None
 
         # 有效配置缓存
@@ -452,7 +469,7 @@ class UnifiedConfigManager:
             self._config_path.parent.mkdir(parents=True, exist_ok=True)
 
             # 准备新配置
-            new_config: dict[str, str | bool | int | dict[str, Any] | None] = {
+            new_config: ConfigFileData = {
                 "base_url": base_url,
                 "model_name": model_name,
             }
@@ -569,7 +586,7 @@ class UnifiedConfigManager:
             return self._effective_config
 
         # 按优先级合并配置
-        merged = {}
+        merged: ConfigFileData = {}
 
         # 所有配置字段
         config_keys = [
@@ -733,7 +750,7 @@ class UnifiedConfigManager:
         """
         return self._config_path
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> ConfigFileData:
         """
         将有效配置转换为字典.
 
@@ -741,18 +758,21 @@ class UnifiedConfigManager:
             dict[str, Any]: 配置字典
         """
         config = self.get_effective_config()
-        return {
-            "base_url": config.base_url,
-            "model_name": config.model_name,
-            "api_key": config.api_key,
-            "agent_type": config.agent_type,
-            "agent_config_params": config.agent_config_params,
-            "default_max_steps": config.default_max_steps,
-            "decision_base_url": config.decision_base_url,
-            "decision_model_name": config.decision_model_name,
-            "decision_api_key": config.decision_api_key,
-            "layered_max_turns": config.layered_max_turns,
-        }
+        return cast(
+            ConfigFileData,
+            {
+                "base_url": config.base_url,
+                "model_name": config.model_name,
+                "api_key": config.api_key,
+                "agent_type": config.agent_type,
+                "agent_config_params": config.agent_config_params,
+                "default_max_steps": config.default_max_steps,
+                "decision_base_url": config.decision_base_url,
+                "decision_model_name": config.decision_model_name,
+                "decision_api_key": config.decision_api_key,
+                "layered_max_turns": config.layered_max_turns,
+            },
+        )
 
 
 # ==================== 全局单例 ====================

--- a/AutoGLM_GUI/device_manager.py
+++ b/AutoGLM_GUI/device_manager.py
@@ -8,7 +8,9 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
+
+from typing_extensions import TypedDict
 
 from AutoGLM_GUI.adb import ADBConnection, ConnectionType, DeviceInfo
 from AutoGLM_GUI.logger import logger
@@ -25,6 +27,29 @@ if TYPE_CHECKING:
 DeviceSerial: TypeAlias = str
 ConnectionDeviceID: TypeAlias = str
 PrimaryDeviceID: TypeAlias = str
+
+
+class ManagedDevicePayload(TypedDict):
+    id: str
+    serial: str
+    model: str
+    display_name: str | None
+    status: str
+    connection_type: str
+    state: str
+    is_available_only: bool
+
+
+class RemoteDeviceConfig(TypedDict):
+    base_url: str
+    device_id: str
+
+
+class RemoteDiscoveryDevice(TypedDict):
+    device_id: str
+    model: str
+    platform: str
+    status: str
 
 
 def map_adb_connection_type_to_device_connection_type(
@@ -153,7 +178,7 @@ class ManagedDevice:
 
         self.primary_connection_idx = sorted_conns[0][0]
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> ManagedDevicePayload:
         """转换为纯设备信息字典（不包含 Agent 状态）。
 
         Returns:
@@ -266,7 +291,7 @@ class DeviceManager:
         self._enable_mdns_discovery: bool = True  # Feature toggle
 
         self._remote_devices: dict[str, DeviceProtocol] = {}
-        self._remote_device_configs: dict[str, dict[str, Any]] = {}
+        self._remote_device_configs: dict[str, RemoteDeviceConfig] = {}
 
         # ADB Keyboard setup state (process-local, best-effort)
         self._adb_keyboard_attempted_serials: set[DeviceSerial] = set()
@@ -840,7 +865,7 @@ class DeviceManager:
 
     def discover_remote_devices(
         self, base_url: str, timeout: int = 5
-    ) -> tuple[bool, str, list[dict[str, Any]]]:
+    ) -> tuple[bool, str, list[RemoteDiscoveryDevice]]:
         """Discover devices from a remote Device Agent Server.
 
         Args:
@@ -860,7 +885,7 @@ class DeviceManager:
             remote_manager = RemoteDeviceManager(base_url, timeout=float(timeout))
             devices = remote_manager.list_devices()
 
-            devices_list = [
+            devices_list: list[RemoteDiscoveryDevice] = [
                 {
                     "device_id": d.device_id,
                     "model": d.model or "Unknown",

--- a/AutoGLM_GUI/phone_agent_manager.py
+++ b/AutoGLM_GUI/phone_agent_manager.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
-from AutoGLM_GUI.agents.protocols import AsyncAgent, BaseAgent
+from AutoGLM_GUI.agents.protocols import AsyncAgent
 from AutoGLM_GUI.config import AgentConfig, ModelConfig
 from AutoGLM_GUI.exceptions import (
     AgentInitializationError,
@@ -91,8 +91,7 @@ class PhoneAgentManager:
         self._metadata: dict[str, AgentMetadata] = {}
 
         # Agent storage (transition from global state to instance state)
-        # Agents can be either AsyncAgent or BaseAgent depending on agent_type
-        self._agents: dict[str, AsyncAgent | BaseAgent] = {}
+        self._agents: dict[str, AsyncAgent] = {}
         self._agent_configs: dict[str, tuple[ModelConfig, AgentConfig]] = {}
 
     @classmethod
@@ -117,7 +116,7 @@ class PhoneAgentManager:
         takeover_callback: Callable[..., Any] | None = None,
         confirmation_callback: Callable[..., Any] | None = None,
         force: bool = False,
-    ) -> AsyncAgent | BaseAgent:
+    ) -> AsyncAgent:
         from AutoGLM_GUI.agents import create_agent
 
         with trace_span(
@@ -277,7 +276,7 @@ class PhoneAgentManager:
         )
         logger.info(f"Agent auto-initialized for key {agent_key}")
 
-    def get_agent(self, device_id: str) -> AsyncAgent | BaseAgent:
+    def get_agent(self, device_id: str) -> AsyncAgent:
         """Get agent using default context (backward compatible)."""
         return self.get_agent_with_context(device_id, context="default")
 
@@ -286,7 +285,7 @@ class PhoneAgentManager:
         device_id: str,
         context: str = "default",
         agent_type: str | None = None,
-    ) -> AsyncAgent | BaseAgent:
+    ) -> AsyncAgent:
         """Get or create agent for specific context.
 
         Args:
@@ -305,7 +304,7 @@ class PhoneAgentManager:
 
             return self._agents[agent_key]
 
-    def get_agent_safe(self, device_id: str) -> AsyncAgent | BaseAgent | None:
+    def get_agent_safe(self, device_id: str) -> AsyncAgent | None:
         with self._manager_lock:
             return self._agents.get(device_id)
 
@@ -522,7 +521,7 @@ class PhoneAgentManager:
             auto_initialize: Auto-initialize if not already initialized (default: True)
 
         Yields:
-            BaseAgent: Agent instance
+            AsyncAgent: Agent instance
 
         Raises:
             DeviceBusyError: If device is busy

--- a/AutoGLM_GUI/platform_utils.py
+++ b/AutoGLM_GUI/platform_utils.py
@@ -31,19 +31,35 @@ def run_cmd_silently_sync(
     )
 
 
-async def run_cmd_silently(cmd: Sequence[str]) -> subprocess.CompletedProcess[str]:
+async def run_cmd_silently(
+    cmd: Sequence[str], timeout: float | None = None
+) -> subprocess.CompletedProcess[str]:
     """Run a command, suppressing output but preserving it in the result; safe for async contexts on all platforms."""
     if is_windows():
         # Avoid blocking the event loop with a blocking subprocess call on Windows.
         return await asyncio.to_thread(
-            subprocess.run, cmd, capture_output=True, text=True, check=False
+            subprocess.run,
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
         )
 
     # Use PIPE on macOS/Linux to capture output
     process = await asyncio.create_subprocess_exec(
         *cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
-    stdout, stderr = await process.communicate()
+    try:
+        communicate = process.communicate()
+        if timeout is None:
+            stdout, stderr = await communicate
+        else:
+            stdout, stderr = await asyncio.wait_for(communicate, timeout=timeout)
+    except asyncio.TimeoutError:
+        process.kill()
+        await process.communicate()
+        raise subprocess.TimeoutExpired(cmd, timeout or 0.0)
     # Decode bytes to string for API consistency across platforms
     stdout_str = stdout.decode("utf-8") if stdout else ""
     stderr_str = stderr.decode("utf-8") if stderr else ""

--- a/AutoGLM_GUI/scheduler_manager.py
+++ b/AutoGLM_GUI/scheduler_manager.py
@@ -238,57 +238,30 @@ class SchedulerManager:
         task_success = False
 
         try:
-            from AutoGLM_GUI.agents.protocols import is_async_agent
-
             agent: Any = manager.get_agent(device.primary_device_id)
             agent.reset()
 
-            if is_async_agent(agent):
-                async for event in agent.stream(workflow["text"]):
-                    step_data: dict[str, Any] = event.get("data", {})
-                    if event["type"] == "step":
-                        messages.append(
-                            MessageRecord(
-                                role="assistant",
-                                content="",
-                                timestamp=datetime.now(),
-                                thinking=step_data.get("thinking", ""),
-                                action=step_data.get("action", {}),
-                                step=step_data.get("step", 0),
-                            )
-                        )
-                    elif event["type"] == "done":
-                        result_message = step_data.get("message", "Task completed")
-                        task_success = step_data.get("success", False)
-                        break
-                    elif event["type"] == "error":
-                        result_message = step_data.get("message", "Task failed")
-                        task_success = False
-                        break
-            else:
-                is_first = True
-                while agent.step_count < agent.agent_config.max_steps:
-                    step_result = await asyncio.to_thread(
-                        agent.step, workflow["text"] if is_first else None
-                    )
-                    is_first = False
+            async for event in agent.stream(workflow["text"]):
+                step_data: dict[str, Any] = event.get("data", {})
+                if event["type"] == "step":
                     messages.append(
                         MessageRecord(
                             role="assistant",
                             content="",
                             timestamp=datetime.now(),
-                            thinking=step_result.thinking,
-                            action=step_result.action,
-                            step=agent.step_count,
+                            thinking=step_data.get("thinking", ""),
+                            action=step_data.get("action", {}),
+                            step=step_data.get("step", 0),
                         )
                     )
-                    if step_result.finished:
-                        result_message = step_result.message or "Task completed"
-                        task_success = step_result.success
-                        break
-                else:
-                    result_message = "Max steps reached"
+                elif event["type"] == "done":
+                    result_message = step_data.get("message", "Task completed")
+                    task_success = step_data.get("success", False)
+                    break
+                elif event["type"] == "error":
+                    result_message = step_data.get("message", "Task failed")
                     task_success = False
+                    break
 
             steps = agent.step_count
             end_time = datetime.now()

--- a/AutoGLM_GUI/scrcpy_stream.py
+++ b/AutoGLM_GUI/scrcpy_stream.py
@@ -550,8 +550,8 @@ class ScrcpyStreamer:
         if self.tcp_socket:
             try:
                 self.tcp_socket.close()
-            except Exception:
-                pass
+            except OSError as exc:
+                logger.debug("Failed to close scrcpy socket: %s", exc)
             self.tcp_socket = None
 
         if self.scrcpy_process:
@@ -559,11 +559,12 @@ class ScrcpyStreamer:
                 self.scrcpy_process.terminate()
                 if isinstance(self.scrcpy_process, subprocess.Popen):
                     self.scrcpy_process.wait(timeout=2)
-            except Exception:
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                logger.debug("Graceful scrcpy shutdown failed: %s", exc)
                 try:
                     self.scrcpy_process.kill()
-                except Exception:
-                    pass
+                except OSError as kill_exc:
+                    logger.debug("Failed to kill scrcpy process: %s", kill_exc)
             self.scrcpy_process = None
 
         if self.forward_cleanup_needed:
@@ -578,8 +579,12 @@ class ScrcpyStreamer:
                     stderr=subprocess.DEVNULL,
                     timeout=2,
                 )
-            except Exception:
-                pass
+            except (OSError, subprocess.SubprocessError) as exc:
+                logger.debug(
+                    "Failed to remove adb forward for port %s: %s",
+                    self.port,
+                    exc,
+                )
             self.forward_cleanup_needed = False
 
     def __del__(self):

--- a/AutoGLM_GUI/socketio_server.py
+++ b/AutoGLM_GUI/socketio_server.py
@@ -114,8 +114,10 @@ async def _stream_packets(sid: str, streamer: ScrcpyStreamer) -> None:
         logger.exception("Video streaming failed: %s", exc)
         try:
             await sio.emit("error", {"message": str(exc)}, to=sid)
-        except Exception:
-            pass
+        except Exception as emit_exc:
+            logger.debug(
+                "Failed to emit Socket.IO stream error to %s: %s", sid, emit_exc
+            )
     finally:
         await _stop_stream_for_sid(sid)
 

--- a/AutoGLM_GUI/task_manager.py
+++ b/AutoGLM_GUI/task_manager.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Awaitable, Callable
-from typing import Any, cast
+from typing import Any
 
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.task_store import (
@@ -258,7 +258,6 @@ class TaskManager:
             self._workers.pop(device_id, None)
 
     async def _execute_classic_chat(self, task: TaskRecord) -> None:
-        from AutoGLM_GUI.agents.protocols import is_async_agent
         from AutoGLM_GUI.exceptions import AgentInitializationError, DeviceBusyError
         from AutoGLM_GUI.phone_agent_manager import PhoneAgentManager
         from AutoGLM_GUI.trace import (
@@ -294,12 +293,7 @@ class TaskManager:
                 )
 
                 async def cancel_handler() -> None:
-                    if is_async_agent(agent):
-                        await agent.cancel()  # type: ignore[union-attr]
-                    else:
-                        abort = getattr(agent, "abort", None)
-                        if callable(abort):
-                            await asyncio.to_thread(abort)
+                    await agent.cancel()
 
                 self._abort_handlers[task_id] = cancel_handler
                 self._register_abort_handler(
@@ -310,52 +304,43 @@ class TaskManager:
                 )
                 abort_registered = True
 
-                if is_async_agent(agent):
-                    async for event in agent.stream(task["input_text"]):  # type: ignore[union-attr]
-                        event_type = event["type"]
-                        event_data = dict(event.get("data", {}))
+                async for event in agent.stream(task["input_text"]):
+                    event_type = event["type"]
+                    event_data = dict(event.get("data", {}))
 
-                        if event_type == "step":
-                            step_count = max(step_count, int(event_data.get("step", 0)))
-                            timings = get_step_timing_summary(
-                                step_count,
-                                trace_id=trace_id,
-                            )
-                            if timings is not None:
-                                event_data = {**event_data, "timings": timings}
-
-                        await asyncio.to_thread(
-                            self.store.append_event,
-                            task_id=task_id,
-                            event_type=event_type,
-                            payload=event_data,
-                            role="assistant",
+                    if event_type == "step":
+                        step_count = max(step_count, int(event_data.get("step", 0)))
+                        timings = get_step_timing_summary(
+                            step_count,
+                            trace_id=trace_id,
                         )
+                        if timings is not None:
+                            event_data = {**event_data, "timings": timings}
 
-                        if event_type == "done":
-                            final_message = str(event_data.get("message", ""))
-                            final_status = (
-                                TaskStatus.SUCCEEDED.value
-                                if event_data.get("success", False)
-                                else TaskStatus.FAILED.value
-                            )
-                            step_count = int(event_data.get("steps", step_count))
-                        elif event_type == "error":
-                            final_message = str(
-                                event_data.get("message", "Task failed")
-                            )
-                            final_status = TaskStatus.FAILED.value
-                        elif event_type == "cancelled":
-                            final_message = str(
-                                event_data.get("message", "Task cancelled by user")
-                            )
-                            final_status = TaskStatus.CANCELLED.value
-                else:
-                    sync_agent = cast(Any, agent)
-                    result = await asyncio.to_thread(sync_agent.run, task["input_text"])
-                    step_count = int(sync_agent.step_count)
-                    final_message = str(result)
-                    final_status = TaskStatus.SUCCEEDED.value
+                    await asyncio.to_thread(
+                        self.store.append_event,
+                        task_id=task_id,
+                        event_type=event_type,
+                        payload=event_data,
+                        role="assistant",
+                    )
+
+                    if event_type == "done":
+                        final_message = str(event_data.get("message", ""))
+                        final_status = (
+                            TaskStatus.SUCCEEDED.value
+                            if event_data.get("success", False)
+                            else TaskStatus.FAILED.value
+                        )
+                        step_count = int(event_data.get("steps", step_count))
+                    elif event_type == "error":
+                        final_message = str(event_data.get("message", "Task failed"))
+                        final_status = TaskStatus.FAILED.value
+                    elif event_type == "cancelled":
+                        final_message = str(
+                            event_data.get("message", "Task cancelled by user")
+                        )
+                        final_status = TaskStatus.CANCELLED.value
 
             if not final_message:
                 final_message = "Task finished without a final response"
@@ -431,7 +416,6 @@ class TaskManager:
         )
 
     async def _execute_scheduled_workflow(self, task: TaskRecord) -> None:
-        from AutoGLM_GUI.agents.protocols import is_async_agent
         from AutoGLM_GUI.exceptions import AgentInitializationError, DeviceBusyError
         from AutoGLM_GUI.phone_agent_manager import PhoneAgentManager
 
@@ -459,8 +443,7 @@ class TaskManager:
             )
 
             async def cancel_handler() -> None:
-                if is_async_agent(agent):
-                    await agent.cancel()  # type: ignore[union-attr]
+                await agent.cancel()
 
             self._abort_handlers[task_id] = cancel_handler
             self._register_abort_handler(
@@ -472,79 +455,44 @@ class TaskManager:
             abort_registered = True
             agent.reset()
 
-            if is_async_agent(agent):
-                async for event in agent.stream(task["input_text"]):  # type: ignore[union-attr]
-                    event_type = event["type"]
-                    event_data = dict(event.get("data", {}))
-                    if event_type == "thinking":
-                        await asyncio.to_thread(
-                            self.store.append_event,
-                            task_id=task_id,
-                            event_type="thinking",
-                            payload=event_data,
-                            role="assistant",
-                        )
-                    elif event_type == "step":
-                        step_count = max(step_count, int(event_data.get("step", 0)))
-                        await asyncio.to_thread(
-                            self.store.append_event,
-                            task_id=task_id,
-                            event_type="step",
-                            payload=event_data,
-                            role="assistant",
-                        )
-                    elif event_type == "done":
-                        final_message = str(event_data.get("message", "Task completed"))
-                        final_status = (
-                            TaskStatus.SUCCEEDED.value
-                            if event_data.get("success", False)
-                            else TaskStatus.FAILED.value
-                        )
-                        step_count = int(event_data.get("steps", step_count))
-                    elif event_type == "error":
-                        final_message = str(event_data.get("message", "Task failed"))
-                        final_status = TaskStatus.FAILED.value
-                        await asyncio.to_thread(
-                            self.store.append_event,
-                            task_id=task_id,
-                            event_type="error",
-                            payload={"message": final_message},
-                            role="assistant",
-                        )
-            else:
-                sync_agent = cast(Any, agent)
-                is_first = True
-                while sync_agent.step_count < sync_agent.agent_config.max_steps:
-                    step_result = await asyncio.to_thread(
-                        sync_agent.step,
-                        task["input_text"] if is_first else None,
+            async for event in agent.stream(task["input_text"]):
+                event_type = event["type"]
+                event_data = dict(event.get("data", {}))
+                if event_type == "thinking":
+                    await asyncio.to_thread(
+                        self.store.append_event,
+                        task_id=task_id,
+                        event_type="thinking",
+                        payload=event_data,
+                        role="assistant",
                     )
-                    is_first = False
-                    step_count = int(sync_agent.step_count)
+                elif event_type == "step":
+                    step_count = max(step_count, int(event_data.get("step", 0)))
                     await asyncio.to_thread(
                         self.store.append_event,
                         task_id=task_id,
                         event_type="step",
-                        payload={
-                            "step": step_count,
-                            "thinking": step_result.thinking,
-                            "action": step_result.action,
-                            "success": step_result.success,
-                            "finished": step_result.finished,
-                        },
+                        payload=event_data,
                         role="assistant",
                     )
-                    if step_result.finished:
-                        final_message = step_result.message or "Task completed"
-                        final_status = (
-                            TaskStatus.SUCCEEDED.value
-                            if step_result.success
-                            else TaskStatus.FAILED.value
-                        )
-                        break
-                else:
-                    final_message = "Max steps reached"
+                elif event_type == "done":
+                    final_message = str(event_data.get("message", "Task completed"))
+                    final_status = (
+                        TaskStatus.SUCCEEDED.value
+                        if event_data.get("success", False)
+                        else TaskStatus.FAILED.value
+                    )
+                    step_count = int(event_data.get("steps", step_count))
+                elif event_type == "error":
+                    final_message = str(event_data.get("message", "Task failed"))
                     final_status = TaskStatus.FAILED.value
+                    await asyncio.to_thread(
+                        self.store.append_event,
+                        task_id=task_id,
+                        event_type="error",
+                        payload={"message": final_message},
+                        role="assistant",
+                    )
 
             if not final_message:
                 final_message = "Task finished without a final response"

--- a/AutoGLM_GUI/workflow_manager.py
+++ b/AutoGLM_GUI/workflow_manager.py
@@ -13,9 +13,21 @@ from __future__ import annotations
 import json
 import uuid as uuid_lib
 from pathlib import Path
-from typing import Any, Self
+from typing import Self
+
+from typing_extensions import TypedDict
 
 from AutoGLM_GUI.logger import logger
+
+
+class WorkflowRecord(TypedDict):
+    uuid: str
+    name: str
+    text: str
+
+
+class WorkflowFile(TypedDict):
+    workflows: list[WorkflowRecord]
 
 
 class WorkflowManager:
@@ -35,10 +47,10 @@ class WorkflowManager:
             return
         self._initialized = True
         self._workflows_path = Path.home() / ".config" / "autoglm" / "workflows.json"
-        self._file_cache: list[dict[str, Any]] | None = None
+        self._file_cache: list[WorkflowRecord] | None = None
         self._file_mtime: float | None = None
 
-    def list_workflows(self) -> list[dict[str, Any]]:
+    def list_workflows(self) -> list[WorkflowRecord]:
         """获取所有 workflows.
 
         Returns:
@@ -46,7 +58,7 @@ class WorkflowManager:
         """
         return self._load_workflows()
 
-    def get_workflow(self, uuid: str) -> dict[str, Any] | None:
+    def get_workflow(self, uuid: str) -> WorkflowRecord | None:
         """根据 UUID 获取单个 workflow.
 
         Args:
@@ -58,7 +70,7 @@ class WorkflowManager:
         workflows = self._load_workflows()
         return next((wf for wf in workflows if wf["uuid"] == uuid), None)
 
-    def create_workflow(self, name: str, text: str) -> dict[str, Any]:
+    def create_workflow(self, name: str, text: str) -> WorkflowRecord:
         """创建新 workflow.
 
         Args:
@@ -69,7 +81,7 @@ class WorkflowManager:
             dict: 新创建的 workflow
         """
         workflows = self._load_workflows()
-        new_workflow = {
+        new_workflow: WorkflowRecord = {
             "uuid": str(uuid_lib.uuid4()),
             "name": name,
             "text": text,
@@ -79,7 +91,7 @@ class WorkflowManager:
         logger.info(f"Created workflow: {name} (uuid={new_workflow['uuid']})")
         return new_workflow
 
-    def update_workflow(self, uuid: str, name: str, text: str) -> dict[str, Any] | None:
+    def update_workflow(self, uuid: str, name: str, text: str) -> WorkflowRecord | None:
         """更新 workflow.
 
         Args:
@@ -120,7 +132,7 @@ class WorkflowManager:
         logger.warning(f"Workflow not found for deletion: uuid={uuid}")
         return False
 
-    def _load_workflows(self) -> list[dict[str, Any]]:
+    def _load_workflows(self) -> list[WorkflowRecord]:
         """从文件加载（带 mtime 缓存）.
 
         Returns:
@@ -147,7 +159,7 @@ class WorkflowManager:
             logger.warning(f"Failed to load workflows: {e}")
             return []
 
-    def _save_workflows(self, workflows: list[dict[str, Any]]) -> bool:
+    def _save_workflows(self, workflows: list[WorkflowRecord]) -> bool:
         """原子写入文件.
 
         Args:
@@ -158,7 +170,7 @@ class WorkflowManager:
         """
         self._workflows_path.parent.mkdir(parents=True, exist_ok=True)
 
-        data = {"workflows": workflows}
+        data: WorkflowFile = {"workflows": workflows}
 
         # 原子写入：临时文件 + rename
         temp_path = self._workflows_path.with_suffix(".tmp")

--- a/tests/test_agents_chat_config_api.py
+++ b/tests/test_agents_chat_config_api.py
@@ -48,22 +48,6 @@ class FakeAsyncAgent:
         self.cancelled = True
 
 
-class FakeSyncAgent:
-    def __init__(self) -> None:
-        self.step_count = 1
-        self.run_result = "sync ok"
-        self.run_error: Exception | None = None
-
-    def run(self, message: str) -> str:
-        _ = message
-        if self.run_error is not None:
-            raise self.run_error
-        return self.run_result
-
-    def abort(self) -> None:
-        return None
-
-
 class FakePhoneAgentManager:
     def __init__(self) -> None:
         self.acquire_mode = "ok"
@@ -261,19 +245,6 @@ def test_chat_unexpected_error_returns_success_false(env: dict[str, Any]) -> Non
     assert env["phone_manager"].release_calls == ["device-2"]
 
 
-def test_chat_supports_sync_agent(env: dict[str, Any]) -> None:
-    env["phone_manager"].agent = FakeSyncAgent()
-
-    response = env["client"].post(
-        "/api/chat",
-        json={"device_id": "device-sync", "message": "open settings"},
-    )
-
-    assert response.status_code == 200
-    assert response.json() == {"result": "sync ok", "steps": 1, "success": True}
-    assert env["phone_manager"].release_calls == ["device-sync"]
-
-
 def test_chat_stream_emits_error_event_when_device_busy(env: dict[str, Any]) -> None:
     env["phone_manager"].acquire_mode = "busy"
 
@@ -389,22 +360,6 @@ def test_chat_stream_persists_step_timings_from_trace_context(
     assert isinstance(timings, dict)
     assert timings["step"] == 1
     assert timings["llm_duration_ms"] >= 0
-
-
-def test_chat_stream_supports_sync_agent(env: dict[str, Any]) -> None:
-    env["phone_manager"].agent = FakeSyncAgent()
-
-    response = env["client"].post(
-        "/api/chat/stream",
-        json={"device_id": "device-sync", "message": "open settings"},
-    )
-
-    assert response.status_code == 200
-    assert response.headers["content-type"].startswith("text/event-stream")
-
-    body = response.text
-    assert "event: done" in body
-    assert '"message": "sync ok"' in body
 
 
 def test_get_config_masks_empty_api_key_and_maps_conflicts(

--- a/tests/test_control_api.py
+++ b/tests/test_control_api.py
@@ -65,7 +65,7 @@ def control_env(monkeypatch: pytest.MonkeyPatch) -> dict:
                 }
             )
 
-    def fake_touch_down(
+    async def fake_touch_down(
         x: int, y: int, device_id: str | None = None, delay: float = 0.0
     ) -> None:
         if should_fail["down"]:
@@ -74,7 +74,7 @@ def control_env(monkeypatch: pytest.MonkeyPatch) -> dict:
             {"x": x, "y": y, "device_id": device_id, "delay": delay}
         )
 
-    def fake_touch_move(
+    async def fake_touch_move(
         x: int, y: int, device_id: str | None = None, delay: float = 0.0
     ) -> None:
         if should_fail["move"]:
@@ -83,7 +83,7 @@ def control_env(monkeypatch: pytest.MonkeyPatch) -> dict:
             {"x": x, "y": y, "device_id": device_id, "delay": delay}
         )
 
-    def fake_touch_up(
+    async def fake_touch_up(
         x: int, y: int, device_id: str | None = None, delay: float = 0.0
     ) -> None:
         if should_fail["up"]:
@@ -93,9 +93,9 @@ def control_env(monkeypatch: pytest.MonkeyPatch) -> dict:
         )
 
     monkeypatch.setattr(control_api, "ADBDevice", FakeADBDevice)
-    monkeypatch.setattr(adb_plus, "touch_down", fake_touch_down)
-    monkeypatch.setattr(adb_plus, "touch_move", fake_touch_move)
-    monkeypatch.setattr(adb_plus, "touch_up", fake_touch_up)
+    monkeypatch.setattr(adb_plus, "touch_down_async", fake_touch_down)
+    monkeypatch.setattr(adb_plus, "touch_move_async", fake_touch_move)
+    monkeypatch.setattr(adb_plus, "touch_up_async", fake_touch_up)
 
     app = FastAPI()
     app.include_router(control_api.router)

--- a/tests/test_media_api.py
+++ b/tests/test_media_api.py
@@ -86,7 +86,7 @@ def media_env(monkeypatch: pytest.MonkeyPatch) -> dict:
     def fake_stop_streamers(device_id: str | None = None) -> None:
         reset_calls.append(device_id)
 
-    def fake_capture_screenshot(device_id: str | None = None) -> FakeScreenshot:
+    async def fake_capture_screenshot(device_id: str | None = None) -> FakeScreenshot:
         captured_requests.append(device_id)
         return FakeScreenshot(
             base64_data="LOCAL_IMG",
@@ -97,7 +97,7 @@ def media_env(monkeypatch: pytest.MonkeyPatch) -> dict:
 
     monkeypatch.setattr(device_manager_module, "DeviceManager", FakeDeviceManagerClass)
     monkeypatch.setattr(media_api, "stop_streamers", fake_stop_streamers)
-    monkeypatch.setattr(media_api, "capture_screenshot", fake_capture_screenshot)
+    monkeypatch.setattr(media_api, "capture_screenshot_async", fake_capture_screenshot)
 
     app = FastAPI()
     app.include_router(media_api.router)
@@ -206,10 +206,10 @@ def test_screenshot_handles_device_not_available_error(
     media_env: dict,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def raise_unavailable(device_id: str | None = None) -> FakeScreenshot:
+    async def raise_unavailable(device_id: str | None = None) -> FakeScreenshot:
         raise DeviceNotAvailableError("device temporarily offline")
 
-    monkeypatch.setattr(media_api, "capture_screenshot", raise_unavailable)
+    monkeypatch.setattr(media_api, "capture_screenshot_async", raise_unavailable)
 
     response = media_env["client"].post(
         "/api/screenshot",


### PR DESCRIPTION
## Summary
- remove the remaining BaseAgent/runtime async detection branch and standardize agent flows on AsyncAgent
- move screenshot/touch request handlers onto non-blocking async ADB helpers and add async adb_plus helpers for screenshot, touch, IP, serial, and pairing flows
- tighten a few high-value error handling sites and replace broad dict[str, Any] return types in workflow/config/device management with focused TypedDicts

## Validation
- uv run pytest tests/test_control_api.py tests/test_media_api.py tests/test_workflows_api.py tests/test_devices_api.py tests/test_agents_chat_config_api.py tests/test_task_manager.py tests/test_scheduler_manager.py tests/test_phone_agent_manager.py -q
- uv run pytest -q
- uv run python -m compileall AutoGLM_GUI
- uv run python scripts/lint.py --backend --check-only
