### PR TITLE
feat: add MCP screenshot tool

### DIFF
--- a/AutoGLM_GUI/api/mcp.py
+++ b/AutoGLM_GUI/api/mcp.py
@@ -7,9 +7,11 @@ from typing_extensions import TypedDict
 
 from fastmcp import FastMCP
 
+from AutoGLM_GUI.adb_plus import capture_screenshot_async
+from AutoGLM_GUI.exceptions import DeviceNotAvailableError
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.prompts import MCP_SYSTEM_PROMPT_ZH
-from AutoGLM_GUI.schemas import DeviceResponse
+from AutoGLM_GUI.schemas import DeviceResponse, ScreenshotResponse
 
 
 class ChatResult(TypedDict):
@@ -141,6 +143,97 @@ def list_devices() -> list[DeviceResponse]:
     ]
 
     return devices_with_agents
+
+
+@mcp.tool()
+async def screenshot(device_id: str) -> ScreenshotResponse:
+    """
+    Capture a screenshot from the specified device.
+
+    This is a read-only operation and does not affect Phone Agent execution.
+
+    Args:
+        device_id: Device identifier returned by list_devices()
+    """
+    from AutoGLM_GUI.device_manager import DeviceManager
+
+    logger.info(f"[MCP] screenshot tool called: device_id={device_id}")
+
+    try:
+        if not device_id:
+            return ScreenshotResponse(
+                success=False,
+                image="",
+                width=0,
+                height=0,
+                is_sensitive=False,
+                error="device_id is required",
+            )
+
+        device_manager = DeviceManager.get_instance()
+        serial = device_manager.get_serial_by_device_id(device_id)
+
+        if not serial:
+            return ScreenshotResponse(
+                success=False,
+                image="",
+                width=0,
+                height=0,
+                is_sensitive=False,
+                error=f"Device {device_id} not found",
+            )
+
+        managed = device_manager.get_device_by_serial(serial)
+        if managed and managed.connection_type.value == "remote":
+            remote_device = device_manager.get_remote_device_instance(serial)
+
+            if not remote_device:
+                return ScreenshotResponse(
+                    success=False,
+                    image="",
+                    width=0,
+                    height=0,
+                    is_sensitive=False,
+                    error=f"Remote device {serial} not found",
+                )
+
+            shot = await asyncio.to_thread(remote_device.get_screenshot, timeout=10)
+            return ScreenshotResponse(
+                success=True,
+                image=shot.base64_data,
+                width=shot.width,
+                height=shot.height,
+                is_sensitive=shot.is_sensitive,
+            )
+
+        shot = await capture_screenshot_async(device_id=device_id)
+        return ScreenshotResponse(
+            success=True,
+            image=shot.base64_data,
+            width=shot.width,
+            height=shot.height,
+            is_sensitive=shot.is_sensitive,
+        )
+    except DeviceNotAvailableError as e:
+        logger.warning("[MCP] screenshot failed - device not available: %s", e)
+        return ScreenshotResponse(
+            success=False,
+            image="",
+            width=0,
+            height=0,
+            is_sensitive=False,
+            error=str(e),
+        )
+    except Exception as e:
+        logger.exception("[MCP] screenshot tool error for device %s", device_id)
+        return ScreenshotResponse(
+            success=False,
+            image="",
+            width=0,
+            height=0,
+            is_sensitive=False,
+            error=str(e),
+        )
 
 
 def get_mcp_asgi_app() -> Any:

--- a/tests/test_mcp_api.py
+++ b/tests/test_mcp_api.py
@@ -1,0 +1,176 @@
+"""Contract tests for MCP tool implementations."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import pytest
+
+import AutoGLM_GUI.api.mcp as mcp_api
+import AutoGLM_GUI.device_manager as device_manager_module
+from AutoGLM_GUI.exceptions import DeviceNotAvailableError
+
+pytestmark = [pytest.mark.contract, pytest.mark.release_gate]
+
+
+@dataclass
+class FakeConnectionType:
+    value: str
+
+
+@dataclass
+class FakeManagedDevice:
+    connection_type: FakeConnectionType
+
+
+@dataclass
+class FakeScreenshot:
+    base64_data: str
+    width: int
+    height: int
+    is_sensitive: bool
+
+
+class FakeRemoteDevice:
+    def __init__(self, screenshot: FakeScreenshot) -> None:
+        self._screenshot = screenshot
+
+    def get_screenshot(self, timeout: int = 10) -> FakeScreenshot:
+        return self._screenshot
+
+
+class FakeDeviceManager:
+    def __init__(self) -> None:
+        self.device_id_to_serial = {
+            "local-device": "serial-local",
+            "remote-device": "serial-remote",
+        }
+        self.serial_to_device = {
+            "serial-local": FakeManagedDevice(FakeConnectionType("usb")),
+            "serial-remote": FakeManagedDevice(FakeConnectionType("remote")),
+        }
+        self.remote_instances = {
+            "serial-remote": FakeRemoteDevice(
+                FakeScreenshot(
+                    base64_data="REMOTE_IMG",
+                    width=800,
+                    height=1600,
+                    is_sensitive=True,
+                )
+            )
+        }
+
+    def get_serial_by_device_id(self, device_id: str) -> str | None:
+        return self.device_id_to_serial.get(device_id)
+
+    def get_device_by_serial(self, serial: str) -> FakeManagedDevice | None:
+        return self.serial_to_device.get(serial)
+
+    def get_remote_device_instance(self, serial: str) -> FakeRemoteDevice | None:
+        return self.remote_instances.get(serial)
+
+
+@pytest.fixture
+def mcp_env(monkeypatch: pytest.MonkeyPatch) -> dict:
+    fake_manager = FakeDeviceManager()
+    captured_requests: list[str | None] = []
+
+    class FakeDeviceManagerClass:
+        @staticmethod
+        def get_instance() -> FakeDeviceManager:
+            return fake_manager
+
+    async def fake_capture_screenshot(device_id: str | None = None) -> FakeScreenshot:
+        captured_requests.append(device_id)
+        return FakeScreenshot(
+            base64_data="LOCAL_IMG",
+            width=1080,
+            height=1920,
+            is_sensitive=False,
+        )
+
+    monkeypatch.setattr(device_manager_module, "DeviceManager", FakeDeviceManagerClass)
+    monkeypatch.setattr(mcp_api, "capture_screenshot_async", fake_capture_screenshot)
+
+    return {
+        "manager": fake_manager,
+        "captured_requests": captured_requests,
+    }
+
+
+def test_mcp_screenshot_requires_device_id(mcp_env: dict) -> None:
+    result = asyncio.run(mcp_api.screenshot.fn(""))
+
+    assert result.model_dump() == {
+        "success": False,
+        "image": "",
+        "width": 0,
+        "height": 0,
+        "is_sensitive": False,
+        "error": "device_id is required",
+    }
+
+
+def test_mcp_screenshot_device_not_found(mcp_env: dict) -> None:
+    result = asyncio.run(mcp_api.screenshot.fn("unknown-device"))
+
+    assert result.success is False
+    assert result.error == "Device unknown-device not found"
+
+
+def test_mcp_screenshot_local_device_success(mcp_env: dict) -> None:
+    result = asyncio.run(mcp_api.screenshot.fn("local-device"))
+
+    assert result.model_dump() == {
+        "success": True,
+        "image": "LOCAL_IMG",
+        "width": 1080,
+        "height": 1920,
+        "is_sensitive": False,
+        "error": None,
+    }
+    assert mcp_env["captured_requests"] == ["local-device"]
+
+
+def test_mcp_screenshot_remote_device_success(mcp_env: dict) -> None:
+    result = asyncio.run(mcp_api.screenshot.fn("remote-device"))
+
+    assert result.model_dump() == {
+        "success": True,
+        "image": "REMOTE_IMG",
+        "width": 800,
+        "height": 1600,
+        "is_sensitive": True,
+        "error": None,
+    }
+
+
+def test_mcp_screenshot_remote_device_missing_instance(mcp_env: dict) -> None:
+    mcp_env["manager"].remote_instances.pop("serial-remote", None)
+
+    result = asyncio.run(mcp_api.screenshot.fn("remote-device"))
+
+    assert result.success is False
+    assert result.error == "Remote device serial-remote not found"
+
+
+def test_mcp_screenshot_handles_device_not_available_error(
+    mcp_env: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def raise_unavailable(device_id: str | None = None) -> FakeScreenshot:
+        raise DeviceNotAvailableError("device temporarily offline")
+
+    monkeypatch.setattr(mcp_api, "capture_screenshot_async", raise_unavailable)
+
+    result = asyncio.run(mcp_api.screenshot.fn("local-device"))
+
+    assert result.model_dump() == {
+        "success": False,
+        "image": "",
+        "width": 0,
+        "height": 0,
+        "is_sensitive": False,
+        "error": "device temporarily offline",
+    }


### PR DESCRIPTION
## Summary
- add a new MCP `screenshot(device_id)` tool in `AutoGLM_GUI/api/mcp.py`
- reuse existing screenshot logic for both local ADB and remote devices
- add MCP contract tests covering success and failure paths

## Verification
- `uv run pytest tests/test_mcp_api.py -v`
- `uv run python scripts/lint.py --backend --check-only`