### PR TITLE
Fix issue #299 device status for contextual agent sessions

### DIFF
--- a/AutoGLM_GUI/api/devices.py
+++ b/AutoGLM_GUI/api/devices.py
@@ -67,7 +67,7 @@ def _build_device_response_with_agent(
     # 使用 device.connections 公开属性（ManagedDevice 提供）
     for conn in device.connections:
         # 只调用 PhoneAgentManager 的公开方法
-        metadata = agent_manager.get_metadata(conn.device_id)
+        metadata = agent_manager.get_metadata_for_device(conn.device_id)
         if metadata:
             # 找到了已初始化的 Agent
             response["agent"] = {

--- a/AutoGLM_GUI/phone_agent_manager.py
+++ b/AutoGLM_GUI/phone_agent_manager.py
@@ -591,6 +591,40 @@ class PhoneAgentManager:
         with self._manager_lock:
             return self._metadata.get(device_id)
 
+    def get_metadata_for_device(self, device_id: str) -> AgentMetadata | None:
+        """Get the most relevant metadata for a device across all contexts.
+
+        Device-level UI cares whether a device has any initialized agent, even when
+        the runtime agent is stored under a contextual key such as
+        ``device_id:chat:<session_id>``.
+        """
+        state_priority = {
+            AgentState.BUSY: 4,
+            AgentState.INITIALIZING: 3,
+            AgentState.ERROR: 2,
+            AgentState.IDLE: 1,
+        }
+        key_prefix = f"{device_id}:"
+
+        with self._manager_lock:
+            candidates = [
+                metadata
+                for key, metadata in self._metadata.items()
+                if key == device_id or key.startswith(key_prefix)
+            ]
+
+        if not candidates:
+            return None
+
+        return max(
+            candidates,
+            key=lambda metadata: (
+                state_priority.get(metadata.state, 0),
+                metadata.last_used,
+                metadata.created_at,
+            ),
+        )
+
     def register_abort_handler(
         self,
         device_id: str,

--- a/tests/test_devices_api.py
+++ b/tests/test_devices_api.py
@@ -73,6 +73,17 @@ class FakePhoneAgentManager:
     def get_metadata(self, device_id: str) -> FakeMetadata | None:
         return self.metadata_by_device_id.get(device_id)
 
+    def get_metadata_for_device(self, device_id: str) -> FakeMetadata | None:
+        exact = self.metadata_by_device_id.get(device_id)
+        if exact:
+            return exact
+
+        prefix = f"{device_id}:"
+        for key, metadata in self.metadata_by_device_id.items():
+            if key.startswith(prefix):
+                return metadata
+        return None
+
 
 class FakeDeviceManager:
     def __init__(self) -> None:
@@ -195,6 +206,19 @@ def test_list_devices_refreshes_when_polling_inactive(devices_env: dict) -> None
     assert device["group_id"] == "qa"
     assert device["agent"]["state"] == "idle"
     assert device["agent"]["model_name"] == "autoglm-phone-9b"
+
+
+def test_list_devices_surfaces_contextual_agent_metadata(devices_env: dict) -> None:
+    devices_env["agent_manager"].metadata_by_device_id["dev-1:chat:session-42"] = (
+        FakeMetadata(model_name="mock-context-model")
+    )
+
+    response = devices_env["client"].get("/api/devices")
+
+    assert response.status_code == 200
+    device = response.json()["devices"][0]
+    assert device["agent"]["state"] == "idle"
+    assert device["agent"]["model_name"] == "mock-context-model"
 
 
 def test_connect_wifi_requires_device_id(devices_env: dict) -> None:


### PR DESCRIPTION
## Summary
- aggregate device agent metadata across contextual session keys such as `device_id:chat:<session_id>`
- use the aggregated metadata in `/api/devices` so the frontend no longer shows connected devices as uninitialized after chat auto-init
- add a regression test covering contextual agent metadata lookup

## Root cause
Classic chat tasks initialize agents under contextual keys, but the device list API only looked up the bare `device_id`. After auto-initialization, the agent existed, but `/api/devices` still returned `agent: null`, so the frontend stayed gray/"未初始化".

## Verification
- `uv run pytest tests/test_devices_api.py -v`
- `uv run python scripts/lint.py --backend --check-only`
- restarted backend and verified end-to-end with the repo's mock device + mock LLM flow:
  - `/api/screenshot` returned `success: true` with a 1200x2670 image
  - `/api/chat` returned `success: true`
  - `/api/devices` changed from `agent: null` to `agent.state: idle` for the same device after chat

Closes #299
