### PR TITLE
Rename Gemini Agent preset to General Vision Agent

### DIFF
--- a/frontend/src/routes/chat.tsx
+++ b/frontend/src/routes/chat.tsx
@@ -98,7 +98,7 @@ const AGENT_PRESETS = [
   },
   {
     name: 'gemini',
-    displayName: 'Gemini Agent',
+    displayName: 'General Vision Agent',
     description: '通用视觉模型，支持 Gemini/GPT-4o 等，使用 Function Calling',
     icon: Sparkles,
     defaultConfig: {},


### PR DESCRIPTION
## Summary
- rename the frontend preset display name from `Gemini Agent` to `General Vision Agent`
- keep internal `gemini` keys and implementation names unchanged
- preserve scope to user-visible naming only

## Validation
- pnpm run type-check
- pnpm run build