### PR TITLE
Generalize gemini naming to general vision

### DIFF
--- a/AutoGLM_GUI/agents/factory.py
+++ b/AutoGLM_GUI/agents/factory.py
@@ -161,7 +161,7 @@ def _create_async_mai_agent(
     )
 
 
-def _create_async_gemini_agent(
+def _create_async_general_vision_agent(
     model_config: ModelConfig,
     agent_config: AgentConfig,
     agent_specific_config: AgentSpecificConfig,  # noqa: ARG001
@@ -169,14 +169,14 @@ def _create_async_gemini_agent(
     takeover_callback: Callable[..., Any] | None = None,
     confirmation_callback: Callable[..., Any] | None = None,
 ) -> AsyncAgent:
-    """Create AsyncGeminiAgent instance.
+    """Create AsyncGeneralVisionAgent instance.
 
     Uses OpenAI-compatible function calling for general vision models
     (Gemini, GPT-4o, Claude, etc.).
     """
-    from .gemini.async_agent import AsyncGeminiAgent
+    from .general_vision.async_agent import AsyncGeneralVisionAgent
 
-    return AsyncGeminiAgent(  # type: ignore[return-value]
+    return AsyncGeneralVisionAgent(  # type: ignore[return-value]
         model_config=model_config,
         agent_config=agent_config,
         device=device,
@@ -188,8 +188,8 @@ def _create_async_gemini_agent(
 register_agent("glm-async", _create_async_glm_agent)
 register_agent("async-glm", _create_async_glm_agent)  # 别名
 register_agent("mai", _create_async_mai_agent)
-register_agent("gemini", _create_async_gemini_agent)
-register_agent("general-vision", _create_async_gemini_agent)  # 通用别名
+register_agent("gemini", _create_async_general_vision_agent)  # 兼容别名
+register_agent("general-vision", _create_async_general_vision_agent)
 
 
 def _create_droidrun_agent(

--- a/AutoGLM_GUI/agents/gemini/action_mapper.py
+++ b/AutoGLM_GUI/agents/gemini/action_mapper.py
@@ -1,4 +1,4 @@
-"""Tool-call to action mapping for Gemini Agent."""
+"""Tool-call to action mapping for the general vision agent."""
 
 from typing import Any
 

--- a/AutoGLM_GUI/agents/gemini/async_agent.py
+++ b/AutoGLM_GUI/agents/gemini/async_agent.py
@@ -1,4 +1,4 @@
-"""AsyncGeminiAgent - 通用视觉模型 Agent，使用 OpenAI 兼容的 function calling。
+"""General vision agent implementation using OpenAI-compatible function calling.
 
 支持 Gemini、GPT-4o、Claude 等任何支持 vision + tool use 的模型，
 通过 OpenAI 兼容 API 端点接入。
@@ -21,7 +21,7 @@ from .prompts import get_system_prompt
 from .tools import DEVICE_TOOLS
 
 
-class AsyncGeminiAgent(AsyncAgentBase):
+class AsyncGeneralVisionAgent(AsyncAgentBase):
     """通用视觉模型 Agent，使用 function calling 而非自定义格式解析。"""
 
     def _get_default_system_prompt(self, lang: str) -> str:
@@ -250,3 +250,7 @@ class AsyncGeminiAgent(AsyncAgentBase):
 
         logger.warning("Model did not return a tool call, treating as finish")
         return thinking, "finish", {"message": thinking or "No action returned"}
+
+
+# Backward-compatible alias. Keep this until external imports migrate.
+AsyncGeminiAgent = AsyncGeneralVisionAgent

--- a/AutoGLM_GUI/agents/gemini/models.py
+++ b/AutoGLM_GUI/agents/gemini/models.py
@@ -1,4 +1,4 @@
-"""Supported models and benchmark results for Gemini Agent.
+"""Supported models and benchmark results for the general vision agent.
 
 All models tested via OpenAI-compatible API.
 Task: "打开微信" with mock Android home screen screenshot.

--- a/AutoGLM_GUI/agents/gemini/prompts.py
+++ b/AutoGLM_GUI/agents/gemini/prompts.py
@@ -1,4 +1,4 @@
-"""System prompt templates for Gemini Agent.
+"""System prompt templates for the general vision agent.
 
 Date is injected dynamically to avoid stale values in long-running processes.
 """

--- a/AutoGLM_GUI/agents/gemini/tools.py
+++ b/AutoGLM_GUI/agents/gemini/tools.py
@@ -1,4 +1,4 @@
-"""Tool definitions for Gemini Agent function calling.
+"""Tool definitions for the general vision agent.
 
 Maps device operations to OpenAI-compatible tool schemas.
 Coordinates use 0-1000 relative scale (same as GLM agent).

--- a/AutoGLM_GUI/agents/general_vision/__init__.py
+++ b/AutoGLM_GUI/agents/general_vision/__init__.py
@@ -1,7 +1,11 @@
-"""Legacy compatibility exports for the general vision agent implementation."""
+"""General vision agent exports.
 
-from .async_agent import AsyncGeminiAgent, AsyncGeneralVisionAgent
-from .models import (
+This package is the preferred import path for the OpenAI-compatible
+vision + function-calling agent implementation.
+"""
+
+from ..gemini import (
+    AsyncGeneralVisionAgent,
     BENCHMARKS,
     INCOMPATIBLE_MODELS,
     RECOMMENDED_MODELS,
@@ -11,7 +15,6 @@ from .models import (
 
 __all__ = [
     "AsyncGeneralVisionAgent",
-    "AsyncGeminiAgent",
     "BENCHMARKS",
     "INCOMPATIBLE_MODELS",
     "RECOMMENDED_MODELS",

--- a/AutoGLM_GUI/agents/general_vision/action_mapper.py
+++ b/AutoGLM_GUI/agents/general_vision/action_mapper.py
@@ -1,0 +1,5 @@
+"""Preferred action-mapper entry point for the general vision agent."""
+
+from ..gemini.action_mapper import tool_call_to_action
+
+__all__ = ["tool_call_to_action"]

--- a/AutoGLM_GUI/agents/general_vision/async_agent.py
+++ b/AutoGLM_GUI/agents/general_vision/async_agent.py
@@ -1,0 +1,5 @@
+"""Preferred async agent entry point for general vision models."""
+
+from ..gemini.async_agent import AsyncGeneralVisionAgent
+
+__all__ = ["AsyncGeneralVisionAgent"]

--- a/AutoGLM_GUI/agents/general_vision/models.py
+++ b/AutoGLM_GUI/agents/general_vision/models.py
@@ -1,17 +1,16 @@
-"""Legacy compatibility exports for the general vision agent implementation."""
+"""Preferred model catalog entry point for the general vision agent."""
 
-from .async_agent import AsyncGeminiAgent, AsyncGeneralVisionAgent
-from .models import (
+from ..gemini.models import (
     BENCHMARKS,
     INCOMPATIBLE_MODELS,
     RECOMMENDED_MODELS,
+    ModelBenchmark,
     get_compatible_benchmarks,
     get_fastest_models,
 )
 
 __all__ = [
-    "AsyncGeneralVisionAgent",
-    "AsyncGeminiAgent",
+    "ModelBenchmark",
     "BENCHMARKS",
     "INCOMPATIBLE_MODELS",
     "RECOMMENDED_MODELS",

--- a/AutoGLM_GUI/agents/general_vision/prompts.py
+++ b/AutoGLM_GUI/agents/general_vision/prompts.py
@@ -1,0 +1,5 @@
+"""Preferred prompt entry point for the general vision agent."""
+
+from ..gemini.prompts import get_system_prompt
+
+__all__ = ["get_system_prompt"]

--- a/AutoGLM_GUI/agents/general_vision/tools.py
+++ b/AutoGLM_GUI/agents/general_vision/tools.py
@@ -1,0 +1,5 @@
+"""Preferred tool-schema entry point for the general vision agent."""
+
+from ..gemini.tools import DEVICE_TOOLS
+
+__all__ = ["DEVICE_TOOLS"]

--- a/frontend/src/routes/chat.tsx
+++ b/frontend/src/routes/chat.tsx
@@ -98,7 +98,7 @@ const AGENT_PRESETS = [
   },
   {
     name: 'gemini',
-    displayName: 'Gemini Agent',
+    displayName: 'General Vision Agent',
     description: '通用视觉模型，支持 Gemini/GPT-4o 等，使用 Function Calling',
     icon: Sparkles,
     defaultConfig: {},

--- a/frontend/src/routes/chat.tsx
+++ b/frontend/src/routes/chat.tsx
@@ -97,7 +97,7 @@ const AGENT_PRESETS = [
     },
   },
   {
-    name: 'gemini',
+    name: 'general-vision',
     displayName: 'General Vision Agent',
     description: '通用视觉模型，支持 Gemini/GPT-4o 等，使用 Function Calling',
     icon: Sparkles,

--- a/tests/test_general_vision_agent.py
+++ b/tests/test_general_vision_agent.py
@@ -1,7 +1,7 @@
-"""Tests for Gemini Agent components."""
+"""Tests for general vision agent components."""
 
-from AutoGLM_GUI.agents.gemini.action_mapper import tool_call_to_action
-from AutoGLM_GUI.agents.gemini.tools import DEVICE_TOOLS
+from AutoGLM_GUI.agents.general_vision.action_mapper import tool_call_to_action
+from AutoGLM_GUI.agents.general_vision.tools import DEVICE_TOOLS
 
 
 class TestDeviceTools:
@@ -119,18 +119,18 @@ class TestActionMapper:
 
 
 class TestAgentRegistration:
-    def test_gemini_registered(self):
+    def test_general_vision_registered(self):
         from AutoGLM_GUI.agents import is_agent_type_registered
 
-        assert is_agent_type_registered("gemini")
         assert is_agent_type_registered("general-vision")
+        assert is_agent_type_registered("gemini")
 
-    def test_gemini_in_list(self):
+    def test_general_vision_in_list(self):
         from AutoGLM_GUI.agents import list_agent_types
 
         types = list_agent_types()
-        assert "gemini" in types
         assert "general-vision" in types
+        assert "gemini" in types
 
 
 class TestEventTypes:

--- a/tests/test_general_vision_e2e.py
+++ b/tests/test_general_vision_e2e.py
@@ -1,16 +1,16 @@
-"""E2E test for Gemini Agent with real API + mock device.
+"""E2E test for the general vision agent with real API + mock device.
 
 Tests the full pipeline:
-  Mock Device → AsyncGeminiAgent → Real Gemini API → Function Calling → Action Execution
+  Mock Device → AsyncGeneralVisionAgent → Real Gemini API → Function Calling → Action Execution
 
 Records timing for each phase.
 """
 
 import asyncio
 import base64
-import os
 import io
 import json
+import os
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -19,12 +19,9 @@ from unittest.mock import MagicMock
 import pytest
 from PIL import Image
 
-from AutoGLM_GUI.agents.gemini.async_agent import AsyncGeminiAgent
+from AutoGLM_GUI.agents.general_vision.async_agent import AsyncGeneralVisionAgent
 from AutoGLM_GUI.config import AgentConfig, ModelConfig
 from AutoGLM_GUI.device_protocol import Screenshot
-
-
-# ===== Timing Recorder =====
 
 
 @dataclass
@@ -58,26 +55,19 @@ class TimingTracker:
         return "\n".join(lines)
 
 
-# ===== Mock Device =====
-
-
 def create_mock_device() -> MagicMock:
     """Create a mock device that returns a fake Android home screen screenshot."""
     device = MagicMock()
     device.device_id = "mock-e2e-001"
 
-    # Generate a simple test image (simulating a phone screen)
     img = Image.new("RGB", (1080, 2400), color=(30, 30, 30))
-    # Draw some colored rectangles to simulate app icons
     from PIL import ImageDraw
 
     draw = ImageDraw.Draw(img)
-    # Row of "app icons"
     colors = [(66, 133, 244), (52, 168, 83), (234, 67, 53), (251, 188, 4)]
     for i, color in enumerate(colors):
         x = 100 + i * 250
         draw.rectangle([x, 1800, x + 180, 1980], fill=color)
-    # "WeChat" green icon
     draw.rectangle([100, 1400, 280, 1580], fill=(7, 193, 96))
     draw.text((120, 1590), "WeChat", fill=(255, 255, 255))
 
@@ -106,13 +96,9 @@ def create_mock_device() -> MagicMock:
     return device
 
 
-# ===== E2E Test =====
-
-
 async def run_e2e_test():
     tracker = TimingTracker()
 
-    # 1. Setup
     tracker.start("1. Create mock device")
     device = create_mock_device()
     tracker.stop()
@@ -130,14 +116,13 @@ async def run_e2e_test():
         lang="cn",
         verbose=True,
     )
-    agent = AsyncGeminiAgent(
+    agent = AsyncGeneralVisionAgent(
         model_config=model_config,
         agent_config=agent_config,
         device=device,
     )
     tracker.stop()
 
-    # 2. Run task via stream
     task = "打开微信"
     print(f"\n📱 Task: {task}")
     print("-" * 50)
@@ -183,7 +168,6 @@ async def run_e2e_test():
 
     tracker.stop()
 
-    # 3. Verify results
     tracker.start("4. Verify results")
 
     event_types = [e["type"] for e in events]
@@ -195,7 +179,6 @@ async def run_e2e_test():
     print(f"   Has done: {has_done}")
     print(f"   Total events: {len(events)}")
 
-    # Check device was called
     device_calls = []
     if device.tap.called:
         device_calls.append(f"tap({device.tap.call_args})")
@@ -212,29 +195,27 @@ async def run_e2e_test():
 
     tracker.stop()
 
-    # 4. Print timing summary
     print(tracker.summary())
 
-    # 5. Assertions
     assert has_done, "Should have a 'done' event"
     assert len(events) >= 2, "Should have at least step + done events"
 
     return tracker
 
 
-def test_gemini_e2e_launch_wechat():
-    """E2E: Gemini Agent receives 'open WeChat' task, calls real API, executes on mock device."""
+def test_general_vision_e2e_launch_wechat():
+    """E2E: general vision agent receives 'open WeChat' and executes on mock device."""
     api_key = os.environ.get("OPENAI_API_KEY")
     base_url = os.environ.get("OPENAI_BASE_URL", "")
 
     if not api_key or api_key == "test-key":
         pytest.skip(
-            "Skipping live Gemini E2E: OPENAI_API_KEY is not configured with a real key"
+            "Skipping live general vision E2E: OPENAI_API_KEY is not configured with a real key"
         )
 
     if "api.openai.com" in base_url and not api_key.startswith("sk-"):
         pytest.skip(
-            "Skipping live Gemini E2E: OPENAI_BASE_URL points to OpenAI but key format looks invalid"
+            "Skipping live general vision E2E: OPENAI_BASE_URL points to OpenAI but key format looks invalid"
         )
 
     tracker = asyncio.run(run_e2e_test())


### PR DESCRIPTION
## Summary
- introduce `general_vision` as the preferred internal package and class naming
- switch factory and frontend preset key to `general-vision` while keeping `gemini` as a compatibility alias
- rename agent tests to `general_vision` and update imports/docs to the generic naming

## Compatibility
- keep `register_agent("gemini", ...)` as a backward-compatible alias
- keep `AsyncGeminiAgent = AsyncGeneralVisionAgent` for legacy imports
- keep actual Google model ids like `gemini-2.5-flash` unchanged

## Validation
- uv run pytest -q tests/test_general_vision_agent.py tests/test_general_vision_e2e.py
- pnpm run type-check
- pnpm run build