### PR TITLE
fix: preserve custom service selection when editing base URL

### DIFF
--- a/frontend/src/routes/chat.tsx
+++ b/frontend/src/routes/chat.tsx
@@ -148,6 +148,23 @@ const DECISION_PRESETS = [
   },
 ] as const;
 
+function getSelectedVisionPreset(baseUrl: string) {
+  return (
+    VISION_PRESETS.find(
+      preset => preset.name !== 'custom' && preset.config.base_url === baseUrl
+    )?.name ?? 'custom'
+  );
+}
+
+function getSelectedDecisionPreset(baseUrl: string) {
+  return (
+    DECISION_PRESETS.find(
+      preset =>
+        preset.name !== 'custom' && preset.config.decision_base_url === baseUrl
+    )?.name ?? 'custom'
+  );
+}
+
 // Search params type for URL persistence
 type ChatSearchParams = {
   serial?: string;
@@ -257,6 +274,10 @@ function ChatComponent() {
     decision_model_name: '',
     decision_api_key: '',
   });
+  const selectedVisionPreset = getSelectedVisionPreset(tempConfig.base_url);
+  const selectedDecisionPreset = getSelectedDecisionPreset(
+    tempConfig.decision_base_url
+  );
 
   useEffect(() => {
     const loadConfiguration = async () => {
@@ -598,15 +619,22 @@ function ChatComponent() {
                         onClick={() =>
                           setTempConfig(prev => ({
                             ...prev,
-                            base_url: preset.config.base_url,
-                            model_name: preset.config.model_name,
+                            ...(preset.name === 'custom'
+                              ? getSelectedVisionPreset(prev.base_url) ===
+                                'custom'
+                                ? {}
+                                : {
+                                    base_url: preset.config.base_url,
+                                    model_name: preset.config.model_name,
+                                  }
+                              : {
+                                  base_url: preset.config.base_url,
+                                  model_name: preset.config.model_name,
+                                }),
                           }))
                         }
                         className={`w-full text-left p-3 rounded-lg border transition-all ${
-                          tempConfig.base_url === preset.config.base_url &&
-                          (preset.name !== 'custom' ||
-                            (preset.name === 'custom' &&
-                              tempConfig.base_url === ''))
+                          selectedVisionPreset === preset.name
                             ? 'border-[#1d9bf0] bg-[#1d9bf0]/5'
                             : 'border-slate-200 dark:border-slate-700 hover:border-[#1d9bf0]/50 hover:bg-slate-50 dark:hover:bg-slate-800/50'
                         }`}
@@ -614,10 +642,7 @@ function ChatComponent() {
                         <div className="flex items-center gap-2">
                           <Server
                             className={`w-4 h-4 ${
-                              tempConfig.base_url === preset.config.base_url &&
-                              (preset.name !== 'custom' ||
-                                (preset.name === 'custom' &&
-                                  tempConfig.base_url === ''))
+                              selectedVisionPreset === preset.name
                                 ? 'text-[#1d9bf0]'
                                 : 'text-slate-400 dark:text-slate-500'
                             }`}
@@ -922,17 +947,27 @@ function ChatComponent() {
                         onClick={() =>
                           setTempConfig(prev => ({
                             ...prev,
-                            decision_base_url: preset.config.decision_base_url,
-                            decision_model_name:
-                              preset.config.decision_model_name,
+                            ...(preset.name === 'custom'
+                              ? getSelectedDecisionPreset(
+                                  prev.decision_base_url
+                                ) === 'custom'
+                                ? {}
+                                : {
+                                    decision_base_url:
+                                      preset.config.decision_base_url,
+                                    decision_model_name:
+                                      preset.config.decision_model_name,
+                                  }
+                              : {
+                                  decision_base_url:
+                                    preset.config.decision_base_url,
+                                  decision_model_name:
+                                    preset.config.decision_model_name,
+                                }),
                           }))
                         }
                         className={`w-full text-left p-3 rounded-lg border transition-all ${
-                          tempConfig.decision_base_url ===
-                            preset.config.decision_base_url &&
-                          (preset.name !== 'custom' ||
-                            (preset.name === 'custom' &&
-                              tempConfig.decision_base_url === ''))
+                          selectedDecisionPreset === preset.name
                             ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-950/50'
                             : 'border-slate-200 dark:border-slate-700 hover:border-indigo-500/50 hover:bg-indigo-50 dark:hover:bg-indigo-950/30'
                         }`}
@@ -940,11 +975,7 @@ function ChatComponent() {
                         <div className="flex items-center gap-2">
                           <Server
                             className={`w-4 h-4 ${
-                              tempConfig.decision_base_url ===
-                                preset.config.decision_base_url &&
-                              (preset.name !== 'custom' ||
-                                (preset.name === 'custom' &&
-                                  tempConfig.decision_base_url === ''))
+                              selectedDecisionPreset === preset.name
                                 ? 'text-indigo-600 dark:text-indigo-400'
                                 : 'text-slate-400 dark:text-slate-500'
                             }`}


### PR DESCRIPTION
 ## Summary

  修复模型配置中“自建服务”预设的状态同步问题。

  当用户选择“自建服务”后，输入自定义 `Base URL` 不应导致该预设自动取消选中，也不应在再次点击“自建服务”时清空用户已输入的地
  址。

  Closes #339

  ## Problem

  在配置模型时，视觉模型和决策模型都提供了官方预设和“自建服务”预设。

  原来的前端逻辑把“当前是否选中自建服务”隐式绑定到了以下条件上：

  - 视觉模型：`base_url === ''`
  - 决策模型：`decision_base_url === ''`

  这会导致一个问题：

  1. 用户先切换到“自建服务”
  2. 开始输入自定义 `Base URL`
  3. 一旦输入了内容，URL 就不再是空字符串
  4. 前端因此误判当前不再是“自建服务”
  5. 选中态丢失，后续再次点击“自建服务”时还可能把用户输入的值重置掉

  这就是 issue 中“输入 Base URL 后自建服务自动取消勾选、重新选择后又清空已填写内容”的根因。

  ## Fix

  这次修复将“当前选中的预设”改为显式识别，而不是通过 URL 是否为空来反推：

  - 如果当前 URL 匹配某个内置预设，则认为选中了该预设
  - 如果当前 URL 不匹配任何内置预设，则认为当前就是 `custom`

  同时调整了 `custom` 预设的点击行为：

  - 如果当前已经是 `custom`，再次点击时不再清空用户已输入的内容
  - 如果当前是官方预设，首次切换到 `custom` 时，仍保留原有默认值初始化行为

  该修复同时覆盖了：

  - 视觉模型预设
  - 决策模型预设

  ## Result

  修复后：

  - 输入自定义 `Base URL` 时，“自建服务”会保持选中状态
  - 已填写的自定义地址不会因为再次点击“自建服务”而被清空
  - 官方预设和自定义预设之间的切换行为更稳定、符合预期

  ## Testing

  已在本地完成前端检查：

  - `scripts/lint.py --frontend --check-only`
  - `pnpm lint`
  - `pnpm format:check`
  - `pnpm type-check`

<img width="2880" height="1800" alt="10903468619889600658" src="https://github.com/user-attachments/assets/92357523-3deb-44b7-bd87-ca78c9142486" />

<img width="2880" height="1800" alt="16617698278061337807" src="https://github.com/user-attachments/assets/683d8749-8647-4a74-96bd-d66d65261c93" />

