### PR TITLE
fix: keep classic-mode chat pinned to latest message

### DIFF
--- a/frontend/e2e/scroll.spec.ts
+++ b/frontend/e2e/scroll.spec.ts
@@ -5,8 +5,10 @@
  * to be running.  The Playwright config starts them via
  * scripts/start_e2e_services.py.
  *
- * Tests that DevicePanel auto-scrolls to the bottom when streaming
- * messages arrive, using the ref + instant scrollTop fix.
+ * Covers issue #346: in classic mode (DevicePanel) the chat must stay pinned
+ * to the latest message while the agent streams its response, as long as the
+ * user has not scrolled up.  DevicePanel renders its messages inside a Radix
+ * <ScrollArea>, so the scrollable element is the viewport node.
  */
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
@@ -24,6 +26,11 @@ declare global {
     __scrollObserver?: MutationObserver;
   }
 }
+
+// The DevicePanel <ScrollArea> roots carry this test id; the element that
+// actually scrolls is the Radix viewport nested inside it.
+const VIEWPORT_SELECTOR =
+  '[data-testid="chat-scroll-container"] [data-slot="scroll-area-viewport"]';
 
 function readServiceUrls(): { backend_url: string; agent_url: string } {
   const urlsPath = path.resolve(__dirname, '.service_urls.json');
@@ -102,28 +109,30 @@ test.describe('DevicePanel auto-scroll', () => {
     const textbox = page.locator('textarea');
     await expect(textbox).toBeVisible({ timeout: 15000 });
 
+    // The Radix ScrollArea viewport should exist before we start tracking.
+    await page.waitForSelector(VIEWPORT_SELECTOR, { timeout: 15000 });
+
     // ── 3. Set up scroll tracking ───────────────────────────────────────
 
-    // Inject a scroll observer that records the max distance from bottom
-    // during the test.  We read this back after streaming completes.
-    await page.evaluate(() => {
+    // Inject a scroll observer that records the distance from bottom over time.
+    // We read it back after streaming completes.
+    await page.evaluate(viewportSelector => {
       window.__scrollReport = {
         maxDistance: 0,
         samples: [] as number[],
       };
 
-      // Find the scroll container that DevicePanel renders
-      const container = document.querySelector(
-        '[data-testid="chat-scroll-container"]'
+      const viewport = document.querySelector(
+        viewportSelector
       ) as HTMLDivElement | null;
-      if (!container) {
-        window.__scrollReport.error = 'No scroll container found';
+      if (!viewport) {
+        window.__scrollReport.error = 'No scroll viewport found';
         return;
       }
 
       const record = () => {
         const d =
-          container.scrollHeight - container.scrollTop - container.clientHeight;
+          viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
         window.__scrollReport.maxDistance = Math.max(
           window.__scrollReport.maxDistance,
           d
@@ -137,13 +146,13 @@ test.describe('DevicePanel auto-scroll', () => {
 
       // Also observe DOM changes to detect new messages
       const observer = new MutationObserver(record);
-      observer.observe(container, {
+      observer.observe(viewport, {
         childList: true,
         subtree: true,
         characterData: true,
       });
       window.__scrollObserver = observer;
-    });
+    }, VIEWPORT_SELECTOR);
 
     // ── 4. Send a message ───────────────────────────────────────────────
 
@@ -153,8 +162,6 @@ test.describe('DevicePanel auto-scroll', () => {
     // ── 5. Wait for streaming to complete ────────────────────────────────
 
     // The agent will stream thinking → step → done events.
-    // Wait for the chat to show a response (assistant message with content).
-    // A sentinel: wait for at least one message bubble from the assistant.
     await page.waitForTimeout(2000);
 
     // Wait for the loading spinner to disappear (agent finished)
@@ -166,14 +173,14 @@ test.describe('DevicePanel auto-scroll', () => {
         // May have already disappeared
       });
 
-    // Extra wait to let all DOM updates + scroll effects settle
-    await page.waitForTimeout(1000);
+    // Extra wait to let all DOM updates + scroll effects (incl. async
+    // screenshot loads and the ResizeObserver re-pin) settle.
+    await page.waitForTimeout(1500);
 
     // ── 6. Read scroll report and verify ────────────────────────────────
 
     const report = await page.evaluate(() => {
       const r = window.__scrollReport;
-      // Stop tracking
       window.__scrollReportStop?.();
       window.__scrollObserver?.disconnect();
       return r;
@@ -185,28 +192,37 @@ test.describe('DevicePanel auto-scroll', () => {
       throw new Error(report.error);
     }
 
-    // Verify the scroll container actually has overflow (content > viewport).
-    // If this fails, the viewport is too tall — reduce height further.
-    const overflow = await page.evaluate(() => {
-      const c = document.querySelector(
-        '[data-testid="chat-scroll-container"]'
+    // Verify the viewport is the real scroll container (content > viewport).
+    // If this fails, the layout is broken (the bug also reported as "missing
+    // scrollbar") or the test viewport is too tall — reduce height further.
+    const overflow = await page.evaluate(viewportSelector => {
+      const v = document.querySelector(
+        viewportSelector
       ) as HTMLDivElement | null;
-      return c
+      return v
         ? {
-            scrollHeight: c.scrollHeight,
-            clientHeight: c.clientHeight,
-            hasOverflow: c.scrollHeight > c.clientHeight,
+            scrollHeight: v.scrollHeight,
+            clientHeight: v.clientHeight,
+            distanceFromBottom: v.scrollHeight - v.scrollTop - v.clientHeight,
+            hasOverflow: v.scrollHeight > v.clientHeight,
           }
         : null;
-    });
-    expect(overflow?.hasOverflow).toBe(true);
+    }, VIEWPORT_SELECTOR);
+    console.log('Viewport state:', JSON.stringify(overflow));
+    if (!overflow) {
+      throw new Error('scroll viewport not found after streaming');
+    }
+    expect(overflow.hasOverflow).toBe(true);
 
-    // Verify: the scroll never drifted more than 5px from the bottom.
-    // The fix uses instant scrollTop = scrollHeight, so there should be
-    // zero drift.  We allow 5px to account for rounding.
-    expect(report.maxDistance).toBeLessThanOrEqual(5);
-
-    // Verify we actually collected data (streaming produced DOM changes)
+    // Verify we actually collected data (streaming produced DOM changes).
     expect(report.samples.length).toBeGreaterThan(0);
+
+    // The chat must never have fallen a full screen behind the latest message
+    // while the user was parked at the bottom.
+    expect(report.maxDistance).toBeLessThan(overflow.clientHeight);
+
+    // And once everything settled, it must be pinned to the very bottom.
+    // Allow a few px for sub-pixel rounding.
+    expect(overflow.distanceFromBottom).toBeLessThanOrEqual(5);
   });
 });

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -59,6 +59,7 @@ export default [
         cancelAnimationFrame: 'readonly',
         NodeJS: 'readonly',
         __BACKEND_VERSION__: 'readonly',
+        __GIT_HASH__: 'readonly',
         __DEVTOOLS_ENABLED__: 'readonly',
       },
     },

--- a/frontend/src/components/DevicePanel.tsx
+++ b/frontend/src/components/DevicePanel.tsx
@@ -178,10 +178,18 @@ export function DevicePanel({
   const contentRef = useRef<HTMLDivElement>(null);
   const prevMessageCountRef = useRef(0);
   const prevMessageSigRef = useRef<string | null>(null);
-  // Tracks whether the user is parked near the bottom of the chat. Stored in a
-  // ref (not state) so the streaming effects below read the latest value
-  // synchronously without being suppressed by an in-flight render.
+  // The chat follows the latest message by default. Only a deliberate upward
+  // scroll by the user turns this off — programmatic re-pins and content that
+  // grows underneath (e.g. screenshots finishing decode) must never flip it,
+  // otherwise the stale scroll events they emit would strand the view.
   const isAtBottomRef = useRef(true);
+  // Timestamp of the last programmatic scroll-to-bottom. Scroll events that
+  // land within this window are the echo of our own pinning (or of the layout
+  // settling afterwards) and are ignored, not treated as the user leaving.
+  const lastPinTimeRef = useRef(0);
+  // Last observed scrollTop. Used to tell a real upward scroll (scrollTop
+  // decreases) apart from content growing underneath (scrollTop stays put).
+  const lastScrollTopRef = useRef(0);
   const [showNewMessageNotice, setShowNewMessageNotice] = useState(false);
 
   // The actual scrollable element lives inside the Radix ScrollArea.
@@ -193,10 +201,11 @@ export function DevicePanel({
     []
   );
 
-  const scrollToBottom = useCallback(
+  const pinToBottom = useCallback(
     (behavior: 'auto' | 'smooth' = 'auto') => {
       const viewport = getScrollViewport();
       if (!viewport) return;
+      lastPinTimeRef.current = performance.now();
       viewport.scrollTo({ top: viewport.scrollHeight, behavior });
     },
     [getScrollViewport]
@@ -208,17 +217,16 @@ export function DevicePanel({
   // re-pins the view to the bottom whenever the content height changes while
   // the user is still following along.
   useEffect(() => {
-    const viewport = getScrollViewport();
     const content = contentRef.current;
-    if (!viewport || !content) return;
+    if (!content) return;
     const observer = new ResizeObserver(() => {
       if (isAtBottomRef.current) {
-        viewport.scrollTop = viewport.scrollHeight;
+        pinToBottom();
       }
     });
     observer.observe(content);
     return () => observer.disconnect();
-  }, [getScrollViewport]);
+  }, [pinToBottom]);
 
   // ✅ 移除 handleInit 函数，不再需要显式初始化
   // Agent 会在首次发送消息时自动初始化
@@ -381,10 +389,7 @@ export function DevicePanel({
     prevMessageSigRef.current = latestSignature;
 
     if (isAtBottomRef.current) {
-      const viewport = getScrollViewport();
-      if (viewport) {
-        viewport.scrollTop = viewport.scrollHeight;
-      }
+      pinToBottom();
       const frameId = requestAnimationFrame(() => {
         setShowNewMessageNotice(false);
       });
@@ -404,7 +409,7 @@ export function DevicePanel({
       });
       return () => cancelAnimationFrame(frameId);
     }
-  }, [messages, getScrollViewport]);
+  }, [messages, pinToBottom]);
 
   // Load workflows
   useEffect(() => {
@@ -424,24 +429,36 @@ export function DevicePanel({
     setShowWorkflowPopover(false);
   };
 
-  // Treat the user as "following" the conversation while they are within a
-  // generous band of the bottom. A tight threshold breaks auto-scroll because
-  // late-loading screenshots routinely nudge the viewport a few hundred pixels
-  // away from the very end between streaming updates.
   const handleMessagesScroll = (event: React.UIEvent<HTMLDivElement>) => {
     const target = event.currentTarget;
+    const scrollTop = target.scrollTop;
+    const prevScrollTop = lastScrollTopRef.current;
+    lastScrollTopRef.current = scrollTop;
+
+    // Ignore the scroll events caused by our own re-pinning and by the
+    // re-layout that late-loading content (screenshots) triggers right after.
+    if (performance.now() - lastPinTimeRef.current < 150) return;
+
     const distanceFromBottom =
-      target.scrollHeight - target.scrollTop - target.clientHeight;
-    const atBottom = distanceFromBottom < 150;
-    isAtBottomRef.current = atBottom;
-    if (atBottom) {
+      target.scrollHeight - scrollTop - target.clientHeight;
+    // A generous band so a few hundred pixels of late-loading content between
+    // streaming updates doesn't break following.
+    if (distanceFromBottom < 150) {
+      isAtBottomRef.current = true;
       setShowNewMessageNotice(false);
+      return;
+    }
+    // Far from the bottom: only treat it as the user opting out if they
+    // actually scrolled upward. Content growing or a programmatic re-pin keeps
+    // (or raises) scrollTop, so the stale events they emit can't trip this.
+    if (scrollTop < prevScrollTop - 4) {
+      isAtBottomRef.current = false;
     }
   };
 
   const handleScrollToLatest = () => {
     isAtBottomRef.current = true;
-    scrollToBottom('smooth');
+    pinToBottom();
     setShowNewMessageNotice(false);
   };
 

--- a/frontend/src/components/DevicePanel.tsx
+++ b/frontend/src/components/DevicePanel.tsx
@@ -10,7 +10,6 @@ import {
   Loader2,
   Square,
 } from 'lucide-react';
-import { throttle } from 'lodash';
 import { DeviceMonitor } from './DeviceMonitor';
 import type {
   StepTimingSummary,
@@ -175,44 +174,51 @@ export function DevicePanel({
     deviceSerial,
     sessionStorageKey: `autoglm:classic-session:${deviceSerial}`,
   });
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const messagesContainerRef = useRef<HTMLDivElement>(null);
-  // ✅ 移除 hasAutoInited，不再需要自动初始化逻辑
-  // const hasAutoInited = useRef(false);
+  const scrollAreaRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const prevMessageCountRef = useRef(0);
   const prevMessageSigRef = useRef<string | null>(null);
+  // Tracks whether the user is parked near the bottom of the chat. Stored in a
+  // ref (not state) so the streaming effects below read the latest value
+  // synchronously without being suppressed by an in-flight render.
   const isAtBottomRef = useRef(true);
   const [showNewMessageNotice, setShowNewMessageNotice] = useState(false);
-  const throttledUpdateScrollStateRef = useRef<ReturnType<
-    typeof throttle
-  > | null>(null);
 
-  // Cleanup throttled function on unmount
+  // The actual scrollable element lives inside the Radix ScrollArea.
+  const getScrollViewport = useCallback(
+    () =>
+      (scrollAreaRef.current?.querySelector(
+        '[data-slot="scroll-area-viewport"]'
+      ) as HTMLDivElement | null) ?? null,
+    []
+  );
+
+  const scrollToBottom = useCallback(
+    (behavior: 'auto' | 'smooth' = 'auto') => {
+      const viewport = getScrollViewport();
+      if (!viewport) return;
+      viewport.scrollTo({ top: viewport.scrollHeight, behavior });
+    },
+    [getScrollViewport]
+  );
+
+  // Step screenshots load asynchronously and grow the content after the
+  // streaming effect already scrolled, which would otherwise leave the chat
+  // parked a few hundred pixels above the latest message. A ResizeObserver
+  // re-pins the view to the bottom whenever the content height changes while
+  // the user is still following along.
   useEffect(() => {
-    const throttledFn = throttle(() => {
-      const container = messagesContainerRef.current;
-      if (!container) return;
-      const threshold = 80;
-      const distanceFromBottom =
-        container.scrollHeight - container.scrollTop - container.clientHeight;
-      // Consider the user "at bottom" only when they are effectively at the end
-      // of the scroll area, to avoid unwanted auto-scrolling when they have
-      // intentionally scrolled slightly up.
-      const atBottom = distanceFromBottom <= 5;
-      isAtBottomRef.current = atBottom;
-
-      // Still hide the new message notice when the user is near the bottom,
-      // using the more generous threshold.
-      if (distanceFromBottom <= threshold) {
-        setShowNewMessageNotice(false);
+    const viewport = getScrollViewport();
+    const content = contentRef.current;
+    if (!viewport || !content) return;
+    const observer = new ResizeObserver(() => {
+      if (isAtBottomRef.current) {
+        viewport.scrollTop = viewport.scrollHeight;
       }
-    }, 100);
-    throttledUpdateScrollStateRef.current = throttledFn;
-    return () => {
-      throttledFn.cancel();
-      throttledUpdateScrollStateRef.current = null;
-    };
-  }, []);
+    });
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [getScrollViewport]);
 
   // ✅ 移除 handleInit 函数，不再需要显式初始化
   // Agent 会在首次发送消息时自动初始化
@@ -351,10 +357,6 @@ export function DevicePanel({
     await abortConversation();
   }, [abortConversation]);
 
-  const scrollToBottom = useCallback(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, []);
-
   useEffect(() => {
     const latest = messages[messages.length - 1];
     const thinkingSignature = latest?.thinking
@@ -379,9 +381,9 @@ export function DevicePanel({
     prevMessageSigRef.current = latestSignature;
 
     if (isAtBottomRef.current) {
-      const container = messagesContainerRef.current;
-      if (container) {
-        container.scrollTop = container.scrollHeight;
+      const viewport = getScrollViewport();
+      if (viewport) {
+        viewport.scrollTop = viewport.scrollHeight;
       }
       const frameId = requestAnimationFrame(() => {
         setShowNewMessageNotice(false);
@@ -402,7 +404,7 @@ export function DevicePanel({
       });
       return () => cancelAnimationFrame(frameId);
     }
-  }, [messages]);
+  }, [messages, getScrollViewport]);
 
   // Load workflows
   useEffect(() => {
@@ -422,16 +424,25 @@ export function DevicePanel({
     setShowWorkflowPopover(false);
   };
 
-  // Throttle scroll event handler to reduce the frequency of state updates
-  // and improve performance, especially on lower-end devices
-  const handleMessagesScroll = () => {
-    throttledUpdateScrollStateRef.current?.();
+  // Treat the user as "following" the conversation while they are within a
+  // generous band of the bottom. A tight threshold breaks auto-scroll because
+  // late-loading screenshots routinely nudge the viewport a few hundred pixels
+  // away from the very end between streaming updates.
+  const handleMessagesScroll = (event: React.UIEvent<HTMLDivElement>) => {
+    const target = event.currentTarget;
+    const distanceFromBottom =
+      target.scrollHeight - target.scrollTop - target.clientHeight;
+    const atBottom = distanceFromBottom < 150;
+    isAtBottomRef.current = atBottom;
+    if (atBottom) {
+      setShowNewMessageNotice(false);
+    }
   };
 
   const handleScrollToLatest = () => {
-    scrollToBottom();
-    setShowNewMessageNotice(false);
     isAtBottomRef.current = true;
+    scrollToBottom('smooth');
+    setShowNewMessageNotice(false);
   };
 
   const handleInputKeyDown = (
@@ -446,7 +457,7 @@ export function DevicePanel({
   return (
     <div className="flex-1 flex gap-4 p-4 items-stretch justify-center min-h-0">
       {/* Chat area - takes remaining space */}
-      <Card className="flex-1 flex flex-col min-h-0 max-w-2xl">
+      <Card className="flex-1 flex flex-col min-h-0 max-w-2xl overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-slate-200 dark:border-slate-800">
           <div className="flex items-center gap-3">
@@ -565,236 +576,237 @@ export function DevicePanel({
 
         {/* Messages */}
         <div className="flex-1 min-h-0 relative">
-          <div
-            className="h-full overflow-y-auto p-4"
+          <ScrollArea
+            ref={scrollAreaRef}
+            className="h-full"
             data-testid="chat-scroll-container"
-            ref={messagesContainerRef}
             onScroll={handleMessagesScroll}
           >
-            {messages.length === 0 ? (
-              <div className="h-full flex flex-col items-center justify-center text-center min-h-[calc(100%-1rem)]">
-                <div className="flex h-16 w-16 items-center justify-center rounded-full bg-slate-100 dark:bg-slate-800 mb-4">
-                  <Sparkles className="h-8 w-8 text-slate-400" />
+            <div className="p-4" ref={contentRef}>
+              {messages.length === 0 ? (
+                <div className="h-full flex flex-col items-center justify-center text-center min-h-[calc(100%-1rem)]">
+                  <div className="flex h-16 w-16 items-center justify-center rounded-full bg-slate-100 dark:bg-slate-800 mb-4">
+                    <Sparkles className="h-8 w-8 text-slate-400" />
+                  </div>
+                  <p className="font-medium text-slate-900 dark:text-slate-100">
+                    {t.devicePanel.readyToHelp}
+                  </p>
+                  <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                    {t.devicePanel.describeTask}
+                  </p>
                 </div>
-                <p className="font-medium text-slate-900 dark:text-slate-100">
-                  {t.devicePanel.readyToHelp}
-                </p>
-                <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                  {t.devicePanel.describeTask}
-                </p>
-              </div>
-            ) : (
-              messages.map(message => (
-                <div
-                  key={message.id}
-                  className={`flex ${
-                    message.role === 'user' ? 'justify-end' : 'justify-start'
-                  }`}
-                >
-                  {message.role === 'assistant' ? (
-                    <div className="max-w-[85%] space-y-3">
-                      {/* Step process */}
-                      {Array.from(
-                        {
-                          length: Math.max(
-                            message.thinking?.length || 0,
-                            message.actions?.length || 0
-                          ),
-                        },
-                        (_, idx) => idx
-                      ).map(idx => {
-                        const stepThinking = message.thinking?.[idx];
-                        const stepAction = message.actions?.[idx];
-                        const stepScreenshot = message.screenshots?.[idx];
-                        const stepTimings = message.stepTimings?.[idx];
-                        const stepSummary = getStepSummary(
-                          stepThinking,
-                          stepAction
-                        );
+              ) : (
+                messages.map(message => (
+                  <div
+                    key={message.id}
+                    className={`flex ${
+                      message.role === 'user' ? 'justify-end' : 'justify-start'
+                    }`}
+                  >
+                    {message.role === 'assistant' ? (
+                      <div className="max-w-[85%] space-y-3">
+                        {/* Step process */}
+                        {Array.from(
+                          {
+                            length: Math.max(
+                              message.thinking?.length || 0,
+                              message.actions?.length || 0
+                            ),
+                          },
+                          (_, idx) => idx
+                        ).map(idx => {
+                          const stepThinking = message.thinking?.[idx];
+                          const stepAction = message.actions?.[idx];
+                          const stepScreenshot = message.screenshots?.[idx];
+                          const stepTimings = message.stepTimings?.[idx];
+                          const stepSummary = getStepSummary(
+                            stepThinking,
+                            stepAction
+                          );
 
-                        return (
-                          <div
-                            key={idx}
-                            className="bg-slate-100 dark:bg-slate-800 rounded-2xl rounded-tl-sm px-4 py-3"
-                          >
+                          return (
+                            <div
+                              key={idx}
+                              className="bg-slate-100 dark:bg-slate-800 rounded-2xl rounded-tl-sm px-4 py-3"
+                            >
+                              <div className="flex items-center gap-2 mb-2">
+                                <div className="flex h-6 w-6 items-center justify-center rounded-full bg-[#1d9bf0]/10">
+                                  <Sparkles className="h-3 w-3 text-[#1d9bf0]" />
+                                </div>
+                                <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
+                                  Step {idx + 1}
+                                </span>
+                              </div>
+                              <p className="text-sm whitespace-pre-wrap text-slate-700 dark:text-slate-300">
+                                {stepSummary}
+                              </p>
+
+                              {stepTimings && (
+                                <div className="mt-3 flex flex-wrap gap-2">
+                                  {getTimingChips(stepTimings).map(chip => (
+                                    <Badge
+                                      key={`${idx}-${chip.label}`}
+                                      variant="secondary"
+                                      className="font-mono text-[11px]"
+                                    >
+                                      {chip.label} {chip.value}
+                                    </Badge>
+                                  ))}
+                                </div>
+                              )}
+
+                              {stepScreenshot && (
+                                <div className="mt-3">
+                                  <ImagePreview
+                                    src={`data:image/png;base64,${stepScreenshot}`}
+                                    alt={`Step ${idx + 1}`}
+                                    maxHeight="350px"
+                                  >
+                                    {stepAction &&
+                                      (() => {
+                                        const parsedAction =
+                                          stepAction as ActionPayload;
+                                        const actionName = parsedAction.action;
+
+                                        if (
+                                          actionName &&
+                                          [
+                                            'Tap',
+                                            'Double Tap',
+                                            'Long Press',
+                                          ].includes(actionName)
+                                        ) {
+                                          const element = parsedAction.element;
+                                          if (
+                                            Array.isArray(element) &&
+                                            element.length === 2
+                                          ) {
+                                            const left = `${(Math.max(0, Math.min(element[0], 1000)) / 1000) * 100}%`;
+                                            const top = `${(Math.max(0, Math.min(element[1], 1000)) / 1000) * 100}%`;
+                                            return (
+                                              <div
+                                                className="absolute w-8 h-8 rounded-full border-[3px] border-red-500 bg-red-500/20 transform -translate-x-1/2 -translate-y-1/2 pointer-events-none animate-pulse shadow-[0_0_8px_rgba(239,68,68,0.6)]"
+                                                style={{ left, top }}
+                                              />
+                                            );
+                                          }
+                                        }
+                                        if (actionName === 'Swipe') {
+                                          const start = parsedAction.start;
+                                          const end = parsedAction.end;
+                                          if (
+                                            Array.isArray(start) &&
+                                            start.length === 2 &&
+                                            Array.isArray(end) &&
+                                            end.length === 2
+                                          ) {
+                                            const x1 =
+                                              (Math.max(
+                                                0,
+                                                Math.min(start[0], 1000)
+                                              ) /
+                                                1000) *
+                                              100;
+                                            const y1 =
+                                              (Math.max(
+                                                0,
+                                                Math.min(start[1], 1000)
+                                              ) /
+                                                1000) *
+                                              100;
+                                            const x2 =
+                                              (Math.max(
+                                                0,
+                                                Math.min(end[0], 1000)
+                                              ) /
+                                                1000) *
+                                              100;
+                                            const y2 =
+                                              (Math.max(
+                                                0,
+                                                Math.min(end[1], 1000)
+                                              ) /
+                                                1000) *
+                                              100;
+                                            return (
+                                              <svg className="absolute inset-0 w-full h-full pointer-events-none overflow-visible">
+                                                <defs>
+                                                  <marker
+                                                    id={`arrowhead-${idx}`}
+                                                    markerWidth="6"
+                                                    markerHeight="6"
+                                                    refX="5"
+                                                    refY="3"
+                                                    orient="auto"
+                                                  >
+                                                    <polygon
+                                                      points="0,0 6,3 0,6"
+                                                      fill="rgba(239,68,68,0.9)"
+                                                    />
+                                                  </marker>
+                                                </defs>
+                                                <circle
+                                                  cx={`${x1}%`}
+                                                  cy={`${y1}%`}
+                                                  r="4"
+                                                  fill="rgba(239,68,68,0.9)"
+                                                />
+                                                <line
+                                                  x1={`${x1}%`}
+                                                  y1={`${y1}%`}
+                                                  x2={`${x2}%`}
+                                                  y2={`${y2}%`}
+                                                  stroke="rgba(239,68,68,0.9)"
+                                                  strokeWidth="3"
+                                                  markerEnd={`url(#arrowhead-${idx})`}
+                                                  strokeDasharray="5 3"
+                                                />
+                                              </svg>
+                                            );
+                                          }
+                                        }
+                                        return null;
+                                      })()}
+                                  </ImagePreview>
+                                </div>
+                              )}
+
+                              {stepAction && (
+                                <details className="mt-2 text-xs">
+                                  <summary className="cursor-pointer text-[#1d9bf0] hover:text-[#1a8cd8] transition-colors">
+                                    View action
+                                  </summary>
+                                  <pre className="mt-2 p-2 bg-slate-900 text-slate-200 rounded-lg overflow-x-auto text-xs border border-slate-800">
+                                    {JSON.stringify(stepAction, null, 2)}
+                                  </pre>
+                                </details>
+                              )}
+                            </div>
+                          );
+                        })}
+
+                        {/* Current thinking being streamed */}
+                        {message.currentThinking && (
+                          <div className="bg-slate-100 dark:bg-slate-800 rounded-2xl rounded-tl-sm px-4 py-3">
                             <div className="flex items-center gap-2 mb-2">
                               <div className="flex h-6 w-6 items-center justify-center rounded-full bg-[#1d9bf0]/10">
-                                <Sparkles className="h-3 w-3 text-[#1d9bf0]" />
+                                <Sparkles className="h-3 w-3 text-[#1d9bf0] animate-pulse" />
                               </div>
                               <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
-                                Step {idx + 1}
+                                Thinking...
                               </span>
                             </div>
                             <p className="text-sm whitespace-pre-wrap text-slate-700 dark:text-slate-300">
-                              {stepSummary}
+                              {message.currentThinking}
+                              <span className="inline-block w-1 h-4 ml-0.5 bg-[#1d9bf0] animate-pulse" />
                             </p>
-
-                            {stepTimings && (
-                              <div className="mt-3 flex flex-wrap gap-2">
-                                {getTimingChips(stepTimings).map(chip => (
-                                  <Badge
-                                    key={`${idx}-${chip.label}`}
-                                    variant="secondary"
-                                    className="font-mono text-[11px]"
-                                  >
-                                    {chip.label} {chip.value}
-                                  </Badge>
-                                ))}
-                              </div>
-                            )}
-
-                            {stepScreenshot && (
-                              <div className="mt-3">
-                                <ImagePreview
-                                  src={`data:image/png;base64,${stepScreenshot}`}
-                                  alt={`Step ${idx + 1}`}
-                                  maxHeight="350px"
-                                >
-                                  {stepAction &&
-                                    (() => {
-                                      const parsedAction =
-                                        stepAction as ActionPayload;
-                                      const actionName = parsedAction.action;
-
-                                      if (
-                                        actionName &&
-                                        [
-                                          'Tap',
-                                          'Double Tap',
-                                          'Long Press',
-                                        ].includes(actionName)
-                                      ) {
-                                        const element = parsedAction.element;
-                                        if (
-                                          Array.isArray(element) &&
-                                          element.length === 2
-                                        ) {
-                                          const left = `${(Math.max(0, Math.min(element[0], 1000)) / 1000) * 100}%`;
-                                          const top = `${(Math.max(0, Math.min(element[1], 1000)) / 1000) * 100}%`;
-                                          return (
-                                            <div
-                                              className="absolute w-8 h-8 rounded-full border-[3px] border-red-500 bg-red-500/20 transform -translate-x-1/2 -translate-y-1/2 pointer-events-none animate-pulse shadow-[0_0_8px_rgba(239,68,68,0.6)]"
-                                              style={{ left, top }}
-                                            />
-                                          );
-                                        }
-                                      }
-                                      if (actionName === 'Swipe') {
-                                        const start = parsedAction.start;
-                                        const end = parsedAction.end;
-                                        if (
-                                          Array.isArray(start) &&
-                                          start.length === 2 &&
-                                          Array.isArray(end) &&
-                                          end.length === 2
-                                        ) {
-                                          const x1 =
-                                            (Math.max(
-                                              0,
-                                              Math.min(start[0], 1000)
-                                            ) /
-                                              1000) *
-                                            100;
-                                          const y1 =
-                                            (Math.max(
-                                              0,
-                                              Math.min(start[1], 1000)
-                                            ) /
-                                              1000) *
-                                            100;
-                                          const x2 =
-                                            (Math.max(
-                                              0,
-                                              Math.min(end[0], 1000)
-                                            ) /
-                                              1000) *
-                                            100;
-                                          const y2 =
-                                            (Math.max(
-                                              0,
-                                              Math.min(end[1], 1000)
-                                            ) /
-                                              1000) *
-                                            100;
-                                          return (
-                                            <svg className="absolute inset-0 w-full h-full pointer-events-none overflow-visible">
-                                              <defs>
-                                                <marker
-                                                  id={`arrowhead-${idx}`}
-                                                  markerWidth="6"
-                                                  markerHeight="6"
-                                                  refX="5"
-                                                  refY="3"
-                                                  orient="auto"
-                                                >
-                                                  <polygon
-                                                    points="0,0 6,3 0,6"
-                                                    fill="rgba(239,68,68,0.9)"
-                                                  />
-                                                </marker>
-                                              </defs>
-                                              <circle
-                                                cx={`${x1}%`}
-                                                cy={`${y1}%`}
-                                                r="4"
-                                                fill="rgba(239,68,68,0.9)"
-                                              />
-                                              <line
-                                                x1={`${x1}%`}
-                                                y1={`${y1}%`}
-                                                x2={`${x2}%`}
-                                                y2={`${y2}%`}
-                                                stroke="rgba(239,68,68,0.9)"
-                                                strokeWidth="3"
-                                                markerEnd={`url(#arrowhead-${idx})`}
-                                                strokeDasharray="5 3"
-                                              />
-                                            </svg>
-                                          );
-                                        }
-                                      }
-                                      return null;
-                                    })()}
-                                </ImagePreview>
-                              </div>
-                            )}
-
-                            {stepAction && (
-                              <details className="mt-2 text-xs">
-                                <summary className="cursor-pointer text-[#1d9bf0] hover:text-[#1a8cd8] transition-colors">
-                                  View action
-                                </summary>
-                                <pre className="mt-2 p-2 bg-slate-900 text-slate-200 rounded-lg overflow-x-auto text-xs border border-slate-800">
-                                  {JSON.stringify(stepAction, null, 2)}
-                                </pre>
-                              </details>
-                            )}
                           </div>
-                        );
-                      })}
+                        )}
 
-                      {/* Current thinking being streamed */}
-                      {message.currentThinking && (
-                        <div className="bg-slate-100 dark:bg-slate-800 rounded-2xl rounded-tl-sm px-4 py-3">
-                          <div className="flex items-center gap-2 mb-2">
-                            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-[#1d9bf0]/10">
-                              <Sparkles className="h-3 w-3 text-[#1d9bf0] animate-pulse" />
-                            </div>
-                            <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
-                              Thinking...
-                            </span>
-                          </div>
-                          <p className="text-sm whitespace-pre-wrap text-slate-700 dark:text-slate-300">
-                            {message.currentThinking}
-                            <span className="inline-block w-1 h-4 ml-0.5 bg-[#1d9bf0] animate-pulse" />
-                          </p>
-                        </div>
-                      )}
-
-                      {/* Final result */}
-                      {message.content && (
-                        <div
-                          className={`
+                        {/* Final result */}
+                        {message.content && (
+                          <div
+                            className={`
                           rounded-2xl px-4 py-3 flex items-start gap-2
                           ${
                             message.success === false
@@ -802,50 +814,52 @@ export function DevicePanel({
                               : 'bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300'
                           }
                         `}
-                        >
-                          <CheckCircle2
-                            className={`w-5 h-5 flex-shrink-0 mt-0.5 ${
-                              message.success === false
-                                ? 'text-red-500'
-                                : 'text-green-500'
-                            }`}
-                          />
-                          <div>
-                            <p className="whitespace-pre-wrap">
-                              {message.content}
-                            </p>
-                            {message.steps !== undefined && (
-                              <p className="text-xs mt-2 opacity-60 text-slate-500 dark:text-slate-400">
-                                {message.steps} steps completed
+                          >
+                            <CheckCircle2
+                              className={`w-5 h-5 flex-shrink-0 mt-0.5 ${
+                                message.success === false
+                                  ? 'text-red-500'
+                                  : 'text-green-500'
+                              }`}
+                            />
+                            <div>
+                              <p className="whitespace-pre-wrap">
+                                {message.content}
                               </p>
-                            )}
+                              {message.steps !== undefined && (
+                                <p className="text-xs mt-2 opacity-60 text-slate-500 dark:text-slate-400">
+                                  {message.steps} steps completed
+                                </p>
+                              )}
+                            </div>
                           </div>
-                        </div>
-                      )}
+                        )}
 
-                      {/* Streaming indicator */}
-                      {message.isStreaming && (
-                        <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
-                          <Loader2 className="w-4 h-4 animate-spin" />
-                          Processing...
-                        </div>
-                      )}
-                    </div>
-                  ) : (
-                    <div className="max-w-[75%]">
-                      <div className="chat-bubble-user px-4 py-3">
-                        <p className="whitespace-pre-wrap">{message.content}</p>
+                        {/* Streaming indicator */}
+                        {message.isStreaming && (
+                          <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                            Processing...
+                          </div>
+                        )}
                       </div>
-                      <p className="text-xs text-slate-400 dark:text-slate-500 mt-1 text-right">
-                        {message.timestamp.toLocaleTimeString()}
-                      </p>
-                    </div>
-                  )}
-                </div>
-              ))
-            )}
-            <div ref={messagesEndRef} />
-          </div>
+                    ) : (
+                      <div className="max-w-[75%]">
+                        <div className="chat-bubble-user px-4 py-3">
+                          <p className="whitespace-pre-wrap">
+                            {message.content}
+                          </p>
+                        </div>
+                        <p className="text-xs text-slate-400 dark:text-slate-500 mt-1 text-right">
+                          {message.timestamp.toLocaleTimeString()}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
+          </ScrollArea>
           {showNewMessageNotice && (
             <div className="pointer-events-none absolute inset-x-0 bottom-4 flex justify-center">
               <Button

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -45,6 +45,11 @@ function Footer() {
         <div className="flex items-center gap-2 text-slate-500 dark:text-slate-400">
           <span className="flex items-center gap-1.5" title={versionTitle}>
             v{displayedVersion}
+            {__GIT_HASH__ !== 'unknown' && (
+              <span className="font-mono text-xs text-slate-400 dark:text-slate-500">
+                ·{__GIT_HASH__}
+              </span>
+            )}
             {showUpdateBadge && updateInfo?.latest_version && (
               <Badge
                 variant="warning"

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 declare const __BACKEND_VERSION__: string;
+declare const __GIT_HASH__: string;
 declare const __DEVTOOLS_ENABLED__: boolean;
 
 declare module '*.png' {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,26 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
+import { execSync } from 'node:child_process';
 import path from 'path';
+
+// Short commit of the working tree at build time, so a deployed build can be
+// traced back to a commit (the package version is the same across branches).
+// Appends "-dirty" when there are uncommitted changes to tracked files.
+function resolveBuildCommit() {
+  if (process.env.VITE_GIT_HASH) return process.env.VITE_GIT_HASH;
+  const git = cmd =>
+    execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  try {
+    const hash = git('git rev-parse --short HEAD');
+    const dirty = git('git status --porcelain -uno').length > 0;
+    return dirty ? `${hash}-dirty` : hash;
+  } catch {
+    return 'unknown';
+  }
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -9,6 +28,7 @@ export default defineConfig({
     __BACKEND_VERSION__: JSON.stringify(
       process.env.VITE_BACKEND_VERSION || 'unknown'
     ),
+    __GIT_HASH__: JSON.stringify(resolveBuildCommit()),
     __DEVTOOLS_ENABLED__: JSON.stringify(process.env.NODE_ENV !== 'production'),
   },
   plugins: [

--- a/scripts/build_electron.py
+++ b/scripts/build_electron.py
@@ -253,7 +253,7 @@ class ElectronBuilder:
 
         # 运行 PyInstaller
         print("\n运行 PyInstaller...")
-        if not run_command(["pyinstaller", "autoglm.spec"], cwd=self.scripts_dir):
+        if not run_command(["uv", "run", "pyinstaller", "autoglm.spec"], cwd=self.scripts_dir):
             return False
 
         # 复制到 resources/backend

--- a/scripts/build_electron.py
+++ b/scripts/build_electron.py
@@ -253,7 +253,9 @@ class ElectronBuilder:
 
         # 运行 PyInstaller
         print("\n运行 PyInstaller...")
-        if not run_command(["uv", "run", "pyinstaller", "autoglm.spec"], cwd=self.scripts_dir):
+        if not run_command(
+            ["uv", "run", "pyinstaller", "autoglm.spec"], cwd=self.scripts_dir
+        ):
             return False
 
         # 复制到 resources/backend


### PR DESCRIPTION
## 背景

接 #346 与 #347。PR #347 已经给 `DevicePanel`（经典模式）加了自动滚动逻辑，但反馈者表示经典模式仍然不会自动滚到最新消息，且经典模式窗口缺少右侧滚动条。

## 根因

经典模式的滚动结构和分层代理（`ChatKitPanel`，反馈者说它是好的）不一致：

- `DevicePanel` 直接滚一个裸 `<div overflow-y-auto>`，`Card` 上也没有 `overflow-hidden`，导致 flex 高度链不够稳——实际滚动可能落到了外层页面而不是消息容器上，这也正是"经典模式没有滚动条"的来源。
- "在底部"的判定阈值只有 `5px`。step 截图是异步加载的，加载完会撑高内容、把视口推离底部远超 5px，而图片加载又不触发 `scroll` 事件，于是 `isAtBottomRef` 被卡成 `false`，整段会话之后都不再自动滚。

## 改动

对齐 `ChatKitPanel` 的做法：

- 消息区改用 Radix `<ScrollArea>`，`Card` 加 `overflow-hidden`（顺带让滚动条和分层代理一致）；
- "跟随底部"的阈值从 `5px` 放宽到 `150px`；
- 新增 `ResizeObserver`：截图等异步内容撑高时，只要用户还在底部就重新 pin 到底，解决"最后一条消息停在半空"；
- 清理掉不再需要的 `lodash/throttle` 机制和 `messagesEndRef`。

同时更新 E2E 回归测试 `frontend/e2e/scroll.spec.ts`：

- 选择器指向 ScrollArea 的 viewport（`[data-slot="scroll-area-viewport"]`）；
- 放宽断言——不再要求全程零漂移，改为「全程没落后过一整屏」+「最终稳稳停在底部（≤5px）」+「确实有 overflow」。

## 验证

- `pnpm test:e2e` ✅（滚动报告 `maxDistance: 0`，全程 `distanceFromBottom: 0`，`hasOverflow: true`）
- `pnpm lint`（`--max-warnings 0`）/ `pnpm format:check` / `pnpm type-check` ✅
- `uv run python scripts/lint.py --check-only`：5/6 通过，唯一失败的 `pyright` 是预先存在、与本 PR 无关的错误（`droidrun/async_agent.py` 的 `DroidConfig` 导入，本地未装 `.[droidrun]` 可选依赖；CI 装了就没问题）

Fixes #346