### PR TITLE
fix: stop stale screenshots leaking into GLM agent requests (#348)

### DIFF
--- a/AutoGLM_GUI/agents/glm/async_agent.py
+++ b/AutoGLM_GUI/agents/glm/async_agent.py
@@ -19,6 +19,19 @@ from AutoGLM_GUI.trace import trace_span
 from .parser import GLMParser
 
 
+def _count_image_parts(messages: list[dict[str, Any]]) -> int:
+    count = 0
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, list):
+            count += sum(
+                1
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "image_url"
+            )
+    return count
+
+
 class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
     """异步 GLM Agent，通过流式文本 + 自定义格式解析执行操作。"""
 
@@ -38,6 +51,10 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
             confirmation_callback=confirmation_callback,
             takeover_callback=takeover_callback,
         )
+        # Task text is stashed here and merged into the first per-step user
+        # message (together with that step's screenshot), matching the
+        # official Open-AutoGLM layout.
+        self._pending_task: str | None = None
 
     def _get_default_system_prompt(self, lang: str) -> str:
         return get_system_prompt(lang)
@@ -45,13 +62,10 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
     def _prepare_initial_context(
         self, task: str, screenshot_base64: str, current_app: str
     ) -> None:
-        screen_info = MessageBuilder.build_screen_info(current_app)
-        initial_message = f"{task}\n\n** Screen Info **\n\n{screen_info}"
-        self._context.append(
-            MessageBuilder.create_user_message(
-                text=initial_message, image_base64=screenshot_base64
-            )
-        )
+        # Do not add a screenshot here: the first per-step screenshot is the
+        # current one and it is attached in _execute_step(). This keeps the
+        # invariant that every LLM request carries exactly one image.
+        self._pending_task = task
 
     async def _execute_step(self) -> AsyncGenerator[dict[str, Any], None]:
         """执行单步：获取截图 → 流式调用 LLM → 解析文本 → 执行动作。"""
@@ -90,8 +104,20 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
             "step.build_message",
             attrs={"step": self._step_count, "agent_type": self.__class__.__name__},
         ):
+            # 清除历史消息中残留的截图，保证本次请求只包含当前屏幕这一张图。
+            self._context = [
+                MessageBuilder.remove_images_from_message(message)
+                for message in self._context
+            ]
+
             screen_info = MessageBuilder.build_screen_info(current_app)
-            text_content = f"** Screen Info **\n\n{screen_info}"
+            if self._step_count == 1 and self._pending_task is not None:
+                text_content = (
+                    f"{self._pending_task}\n\n** Screen Info **\n\n{screen_info}"
+                )
+                self._pending_task = None
+            else:
+                text_content = f"** Screen Info **\n\n{screen_info}"
             self._context.append(
                 MessageBuilder.create_user_message(
                     text=text_content, image_base64=screenshot.base64_data
@@ -99,6 +125,14 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
             )
 
         # 3. 流式调用 OpenAI
+        image_count = _count_image_parts(self._context)
+        if image_count != 1:
+            logger.warning(
+                "GLM request should carry exactly one screenshot, got %d (step %d)",
+                image_count,
+                self._step_count,
+            )
+
         try:
             if self.agent_config.verbose:
                 msgs = get_messages(self.agent_config.lang)

--- a/AutoGLM_GUI/model/message_builder.py
+++ b/AutoGLM_GUI/model/message_builder.py
@@ -15,14 +15,15 @@ class MessageBuilder:
         if image_base64 is None:
             return {"role": "user", "content": text}
 
+        # Image first, then text — matches the official Open-AutoGLM input layout.
         return {
             "role": "user",
             "content": [
-                {"type": "text", "text": text},
                 {
                     "type": "image_url",
                     "image_url": {"url": f"data:image/png;base64,{image_base64}"},
                 },
+                {"type": "text", "text": text},
             ],
         }
 
@@ -51,18 +52,23 @@ class MessageBuilder:
 
     @staticmethod
     def remove_images_from_message(message: dict[str, Any]) -> dict[str, Any]:
-        if message["role"] != "user":
+        """Drop image parts from a message, keeping the text parts as a list.
+
+        Mirrors the official Open-AutoGLM behaviour: after a request the
+        screenshot is stripped from the user turn so that history never
+        carries stale images into later requests. String content (system /
+        assistant turns) is returned unchanged.
+        """
+        content = message.get("content")
+        if not isinstance(content, list):
             return message
 
-        content = message["content"]
-        if isinstance(content, str):
-            return message
-
-        text_parts = [part for part in content if part["type"] == "text"]
-        if len(text_parts) == 1:
-            return {"role": "user", "content": text_parts[0]["text"]}
-
-        return {"role": "user", "content": text_parts}
+        text_parts = [
+            part
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        ]
+        return {**message, "content": text_parts}
 
     @staticmethod
     def build_screen_info(current_app: str) -> str:

--- a/tests/test_glm_async_agent.py
+++ b/tests/test_glm_async_agent.py
@@ -1,0 +1,167 @@
+"""Tests for AsyncGLMAgent multimodal context handling.
+
+Regression coverage for issue #348: a stale initial screenshot leaked into
+every LLM request (the per-step ``remove_images_from_message`` only stripped
+the *last* message), so ``autoglm-phone`` saw two screenshots per turn and
+produced wrong ``Tap`` coordinates. Each request must carry exactly one
+screenshot — the current one — and history must not retain images.
+"""
+
+import asyncio
+import copy
+from typing import Any
+
+from AutoGLM_GUI.actions import ActionResult
+from AutoGLM_GUI.agents.glm.async_agent import AsyncGLMAgent
+from AutoGLM_GUI.config import AgentConfig, ModelConfig
+from AutoGLM_GUI.device_protocol import Screenshot
+from AutoGLM_GUI.model import MessageBuilder
+
+
+def _count_images(messages: list[dict[str, Any]]) -> int:
+    count = 0
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, list):
+            count += sum(
+                1
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "image_url"
+            )
+    return count
+
+
+def _text_part(message: dict[str, Any]) -> str:
+    return next(
+        part["text"]
+        for part in message["content"]
+        if isinstance(part, dict) and part.get("type") == "text"
+    )
+
+
+class _FakeDevice:
+    device_id = "fake-001"
+
+    def __init__(self) -> None:
+        self._n = 0
+
+    def get_screenshot(self, timeout: int = 10) -> Screenshot:
+        self._n += 1
+        return Screenshot(base64_data=f"img{self._n}", width=1080, height=2400)
+
+    def get_current_app(self) -> str:
+        return "com.example.app"
+
+
+def _make_agent() -> AsyncGLMAgent:
+    return AsyncGLMAgent(
+        model_config=ModelConfig(),
+        agent_config=AgentConfig(max_steps=10, verbose=False),
+        device=_FakeDevice(),
+    )
+
+
+async def _drain(agen) -> None:
+    async for _ in agen:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# MessageBuilder
+# ---------------------------------------------------------------------------
+
+
+def test_create_user_message_puts_image_first():
+    msg = MessageBuilder.create_user_message("hello", image_base64="abc")
+    assert [part["type"] for part in msg["content"]] == ["image_url", "text"]
+    assert msg["content"][1]["text"] == "hello"
+
+
+def test_remove_images_keeps_text_parts_as_list():
+    msg = MessageBuilder.create_user_message("hello", image_base64="abc")
+    stripped = MessageBuilder.remove_images_from_message(msg)
+
+    assert isinstance(stripped["content"], list)
+    assert _count_images([stripped]) == 0
+    assert stripped["content"] == [{"type": "text", "text": "hello"}]
+
+
+def test_remove_images_passes_through_string_content():
+    msg = MessageBuilder.create_assistant_message("done")
+    assert MessageBuilder.remove_images_from_message(msg) == msg
+
+
+# ---------------------------------------------------------------------------
+# AsyncGLMAgent context invariant
+# ---------------------------------------------------------------------------
+
+
+def test_each_request_carries_exactly_one_image(monkeypatch):
+    agent = _make_agent()
+
+    captured: list[list[dict[str, Any]]] = []
+    raw_responses = iter(
+        [
+            "I will tap the icon.\ndo(action=Tap(element=[500, 500]))",
+            "All done.\nfinish(message=ok)",
+        ]
+    )
+
+    async def fake_stream(messages):
+        captured.append(copy.deepcopy(messages))
+        yield {"type": "raw", "content": next(raw_responses)}
+
+    action_results = iter(
+        [
+            ActionResult(success=True, should_finish=False, message=None),
+            ActionResult(success=True, should_finish=True, message="ok"),
+        ]
+    )
+
+    monkeypatch.setattr(agent, "_stream_openai", fake_stream)
+    monkeypatch.setattr(
+        agent.action_handler, "execute", lambda *a, **k: next(action_results)
+    )
+
+    async def run() -> None:
+        agent._prepare_initial_context("play a song", "img0", "com.android.launcher")
+        await _drain(agent._execute_step())
+        await _drain(agent._execute_step())
+
+    asyncio.run(run())
+
+    assert len(captured) == 2
+    for request in captured:
+        assert _count_images(request) == 1
+        # the lone image must sit on the last (current) user message
+        assert request[-1]["role"] == "user"
+        assert any(
+            isinstance(p, dict) and p.get("type") == "image_url"
+            for p in request[-1]["content"]
+        )
+
+    # task text is part of the first request, not repeated afterwards
+    assert "play a song" in _text_part(captured[0][-1])
+    assert "play a song" not in _text_part(captured[1][-1])
+
+
+def test_context_retains_no_images_after_step(monkeypatch):
+    agent = _make_agent()
+
+    async def fake_stream(messages):
+        yield {"type": "raw", "content": "do(action=Tap(element=[1, 1]))"}
+
+    monkeypatch.setattr(agent, "_stream_openai", fake_stream)
+    monkeypatch.setattr(
+        agent.action_handler,
+        "execute",
+        lambda *a, **k: ActionResult(success=True, should_finish=False, message=None),
+    )
+
+    async def run() -> None:
+        agent._prepare_initial_context("task", "img0", "app")
+        await _drain(agent._execute_step())
+
+    asyncio.run(run())
+
+    assert _count_images(agent._context) == 0


### PR DESCRIPTION
## 背景

Issue #348：使用官方 `autoglm-phone` 模型时 `Tap` 点击坐标异常、必现。

## 根因

`AsyncGLMAgent` 每个 step 收尾只对 `self._context[-1]` 做 `remove_images_from_message`，
但 `_prepare_initial_context()` 添加的「初始任务截图」永远不是最后一条消息，因此会一直残留在
context 里。结果每次发给 `autoglm-phone` 的请求都带**两张截图**（永远的初始截图 + 当前截图），
模型在多图上下文下做视觉 grounding 时混淆，输出错误的归一化 `Tap` 坐标 —— 这正是 issue 截图里
「文字说点 A、坐标却落到 B、且时对时错」的现象。坐标换算层（`ActionHandler`，0–1000 线性换算）
与官方一致，不是问题所在。

官方 Open-AutoGLM 的不变量是：每次请求只包含「当前屏幕」这一张图，请求后立即把该轮 user message
的截图移除。本仓库没维持住这个约束。

## 改动

- **`AutoGLM_GUI/agents/glm/async_agent.py`**
  - 每个 step 构建当前截图消息前，先对**整个 context** 执行 `remove_images_from_message`，保证每次请求 image 数恒为 1
  - `_prepare_initial_context()` 不再塞截图，只把 task 暂存到 `_pending_task`；首步在 `_execute_step()` 把 `task + 当前截图` 合成同一条 user message（对齐官方布局）
  - 调 LLM 前加诊断日志：context 内 image 数 ≠ 1 时 `logger.warning`
- **`AutoGLM_GUI/model/message_builder.py`**
  - `create_user_message`：图片在前、文本在后（贴近官方输入分布）
  - `remove_images_from_message`：保留 OpenAI list-of-parts 格式（不再折叠成裸字符串），对 `image_url` 判断更健壮
- **`tests/test_glm_async_agent.py`**：新增回归测试，断言每次 LLM 请求恰好 1 张图、图挂在最后一条 user message 上、task 文本只出现在首轮、一步执行后 context 内无残留图片

## 验证

- `uv run pytest tests/test_glm_async_agent.py` → 5 passed
- `uv run pytest tests/ -k "not e2e" --ignore=tests/integration` → 280 passed
- `uv run ruff check` 改动文件 → 全部通过

## 备注（未在本 PR 处理）

- `build_screen_info()` 自带 `** Screen Info **` 头、调用处又拼了一遍，导致双重标题 —— 这是本 issue 之前就存在的小瑕疵，保持原样以免改动模型输入文本
- `AsyncGeminiAgent` 存在同类的初始截图残留问题，但走通用视觉模型、不在 #348 范畴，本 PR 未处理

Closes #348