### PR TITLE
fix: isolate classic/layered task history and fix layered metadata (#349)

### DIFF
--- a/AutoGLM_GUI/api/history.py
+++ b/AutoGLM_GUI/api/history.py
@@ -1,5 +1,6 @@
 """History API routes."""
 
+import json
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
@@ -17,6 +18,18 @@ from AutoGLM_GUI.schemas import (
 from AutoGLM_GUI.task_store import TERMINAL_TASK_STATUSES, TaskStatus, task_store
 
 router = APIRouter()
+
+# Maps the chat execution mode to the task-run executor keys and the legacy
+# ``ConversationRecord.source`` values that belong to it.  Used to keep the
+# per-mode history popovers (classic vs. layered) from showing each other's runs.
+_MODE_EXECUTOR_KEYS: dict[str, set[str]] = {
+    "classic": {"classic_chat"},
+    "layered": {"layered_chat"},
+}
+_MODE_LEGACY_SOURCES: dict[str, set[str]] = {
+    "classic": {"chat"},
+    "layered": {"layered"},
+}
 
 
 def _build_history_record_response(record: ConversationRecord) -> HistoryRecordResponse:
@@ -54,6 +67,15 @@ def _build_history_record_response(record: ConversationRecord) -> HistoryRecordR
     )
 
 
+def _tool_result_text(payload: dict[str, Any]) -> str:
+    result = payload.get("result")
+    if isinstance(result, str):
+        return result
+    if result is None:
+        return ""
+    return json.dumps(result, ensure_ascii=False)
+
+
 def _build_history_record_from_task(record: dict[str, Any]) -> HistoryRecordResponse:
     events = task_store.list_task_events(record["id"])
     step_timings: list[StepTimingSummaryResponse] = []
@@ -64,23 +86,59 @@ def _build_history_record_from_task(record: dict[str, Any]) -> HistoryRecordResp
             timestamp=record["created_at"],
         )
     ]
+    # Sequence index for layered tool-call cycles so the UI can group a tool
+    # call together with its result under a single "step".
+    layered_step = 0
     for event in events:
-        if event["event_type"] != "step":
-            continue
+        event_type = event["event_type"]
         payload = event["payload"]
-        messages.append(
-            MessageRecordResponse(
-                role="assistant",
-                content="",
-                timestamp=event["created_at"],
-                thinking=payload.get("thinking"),
-                action=payload.get("action"),
-                step=payload.get("step"),
+        if event_type == "step":
+            messages.append(
+                MessageRecordResponse(
+                    role="assistant",
+                    content="",
+                    timestamp=event["created_at"],
+                    thinking=payload.get("thinking"),
+                    action=payload.get("action"),
+                    step=payload.get("step"),
+                )
             )
-        )
-        timings = payload.get("timings")
-        if isinstance(timings, dict):
-            step_timings.append(StepTimingSummaryResponse(**timings))
+            timings = payload.get("timings")
+            if isinstance(timings, dict):
+                step_timings.append(StepTimingSummaryResponse(**timings))
+        elif event_type == "tool_call":
+            layered_step += 1
+            messages.append(
+                MessageRecordResponse(
+                    role="assistant",
+                    content="",
+                    timestamp=event["created_at"],
+                    action={
+                        "tool_name": payload.get("tool_name"),
+                        "tool_args": payload.get("tool_args", {}),
+                    },
+                    step=layered_step,
+                )
+            )
+        elif event_type == "tool_result":
+            messages.append(
+                MessageRecordResponse(
+                    role="assistant",
+                    content=_tool_result_text(payload),
+                    timestamp=event["created_at"],
+                    step=layered_step or None,
+                )
+            )
+        elif event_type == "message":
+            content = payload.get("content")
+            if content:
+                messages.append(
+                    MessageRecordResponse(
+                        role="assistant",
+                        content=str(content),
+                        timestamp=event["created_at"],
+                    )
+                )
 
     source_detail = record.get("session_id") or ""
     if record["source"] == "scheduled" and record.get("scheduled_task_id"):
@@ -134,12 +192,28 @@ def _is_terminal_task_record(record: dict[str, Any]) -> bool:
     return record["status"] in TERMINAL_TASK_STATUSES
 
 
-def _list_merged_history(serialno: str) -> list[HistoryRecordResponse]:
+def _list_merged_history(
+    serialno: str, mode: str | None = None
+) -> list[HistoryRecordResponse]:
     task_records, _ = task_store.list_tasks(
         device_serial=serialno, limit=10000, offset=0
     )
     history_total = history_manager.get_total_count(serialno)
     legacy_records = history_manager.list_records(serialno, history_total, 0)
+
+    if mode is not None:
+        allowed_executor_keys = _MODE_EXECUTOR_KEYS.get(mode, set())
+        allowed_legacy_sources = _MODE_LEGACY_SOURCES.get(mode, set())
+        task_records = [
+            record
+            for record in task_records
+            if record.get("executor_key") in allowed_executor_keys
+        ]
+        legacy_records = [
+            record
+            for record in legacy_records
+            if record.source in allowed_legacy_sources
+        ]
 
     merged = [
         _build_history_record_from_task(record)
@@ -153,14 +227,18 @@ def _list_merged_history(serialno: str) -> list[HistoryRecordResponse]:
 
 @router.get("/api/history/{serialno}", response_model=HistoryListResponse)
 def list_history(
-    serialno: str, limit: int = 50, offset: int = 0
+    serialno: str, limit: int = 50, offset: int = 0, mode: str | None = None
 ) -> HistoryListResponse:
     if limit < 1 or limit > 100:
         raise HTTPException(status_code=400, detail="limit must be between 1 and 100")
     if offset < 0:
         raise HTTPException(status_code=400, detail="offset must be non-negative")
+    if mode is not None and mode not in _MODE_EXECUTOR_KEYS:
+        raise HTTPException(
+            status_code=400, detail="mode must be 'classic' or 'layered'"
+        )
 
-    merged_records = _list_merged_history(serialno)
+    merged_records = _list_merged_history(serialno, mode)
     total = len(merged_records)
     records = merged_records[offset : offset + limit]
 

--- a/AutoGLM_GUI/layered_agent_service.py
+++ b/AutoGLM_GUI/layered_agent_service.py
@@ -387,12 +387,18 @@ class LayeredTaskRun:
                         if self._current_tool_call
                         else "unknown"
                     )
+                    result_text, steps, sub_success = self._parse_tool_output(output)
+                    tool_result_payload: dict[str, Any] = {
+                        "tool_name": tool_name,
+                        "result": result_text,
+                    }
+                    if steps:
+                        tool_result_payload["steps"] = steps
+                    if sub_success is not None:
+                        tool_result_payload["success"] = sub_success
                     yield {
                         "type": "tool_result",
-                        "payload": {
-                            "tool_name": tool_name,
-                            "result": output,
-                        },
+                        "payload": tool_result_payload,
                     }
                     self._current_tool_call = None
                 elif item_type == "message_output_item":
@@ -437,6 +443,27 @@ class LayeredTaskRun:
             with _active_runs_lock:
                 _active_runs.pop(self.task_id, None)
             self.finished = True
+
+    @staticmethod
+    def _parse_tool_output(output: Any) -> tuple[str, int, bool | None]:
+        """Unpack a tool output into ``(text, steps, sub_success)``.
+
+        The ``chat`` tool returns a JSON envelope ``{"result", "steps", "success"}``
+        describing the inner phone-agent run.  Other tools (e.g. ``list_devices``)
+        return plain strings, in which case ``steps`` is ``0`` and ``sub_success``
+        is ``None``.
+        """
+        text = output if isinstance(output, str) else str(output)
+        try:
+            parsed = json.loads(text)
+        except (ValueError, TypeError):
+            return text, 0, None
+        if isinstance(parsed, dict) and "steps" in parsed:
+            raw_steps = parsed.get("steps", 0)
+            steps = int(raw_steps) if isinstance(raw_steps, (int, float)) else 0
+            success = parsed.get("success")
+            return text, steps, success if isinstance(success, bool) else None
+        return text, 0, None
 
     def _parse_tool_call(self, item: Any) -> dict[str, Any]:
         tool_name = "unknown"

--- a/AutoGLM_GUI/task_manager.py
+++ b/AutoGLM_GUI/task_manager.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.metrics import record_trace_latency_metrics
-from AutoGLM_GUI.models.history import ConversationRecord, TraceSummaryRecord
 from AutoGLM_GUI.task_store import (
     TERMINAL_TASK_STATUSES,
     TaskRecord,
@@ -498,7 +497,6 @@ class TaskManager:
         await self._execute_layered_task(
             task,
             session_id=str(task["session_id"] or task["id"]),
-            record_history=True,
             clear_session_after_run=False,
             metrics_source="layered",
         )
@@ -508,14 +506,11 @@ class TaskManager:
         task: TaskRecord,
         *,
         session_id: str,
-        record_history: bool,
         clear_session_after_run: bool,
         metrics_source: str,
     ) -> None:
         from datetime import datetime
 
-        from AutoGLM_GUI.device_manager import DeviceManager
-        from AutoGLM_GUI.history_manager import history_manager
         from AutoGLM_GUI.layered_agent_service import (
             reset_session as reset_layered_session,
             start_run,
@@ -527,6 +522,7 @@ class TaskManager:
         final_status = TaskStatus.FAILED.value
         final_message = ""
         stop_reason = "error"
+        step_count = 0
         run = None
 
         try:
@@ -549,7 +545,11 @@ class TaskManager:
                         role="assistant",
                     )
 
-                    if event_type == "done":
+                    if event_type == "tool_result":
+                        sub_steps = event_payload.get("steps", 0)
+                        if isinstance(sub_steps, (int, float)):
+                            step_count += int(sub_steps)
+                    elif event_type == "done":
                         final_message = str(event_payload.get("content", ""))
                         final_status = (
                             TaskStatus.SUCCEEDED.value
@@ -620,7 +620,7 @@ class TaskManager:
             status=final_status,
             final_message=final_message,
             stop_reason=stop_reason,
-            step_count=0,
+            step_count=step_count,
         )
 
         end_time = datetime.now()
@@ -634,39 +634,12 @@ class TaskManager:
             trace_summary=trace_summary_dict,
             step_summaries=[],
         )
-
-        if record_history:
-            device_manager = DeviceManager.get_instance()
-            serialno = device_manager.get_serial_by_device_id(str(task["device_id"]))
-            if serialno:
-                record = ConversationRecord(
-                    task_text=str(task["input_text"]),
-                    final_message=final_message,
-                    success=final_status == TaskStatus.SUCCEEDED.value,
-                    steps=0,
-                    start_time=start_time,
-                    end_time=end_time,
-                    duration_ms=duration_ms,
-                    source="layered",
-                    source_detail=session_id,
-                    error_message=(
-                        None
-                        if final_status == TaskStatus.SUCCEEDED.value
-                        else final_message
-                    ),
-                    trace_id=trace_id,
-                    trace_summary=TraceSummaryRecord.from_dict(trace_summary_dict)
-                    if trace_summary_dict
-                    else None,
-                )
-                await asyncio.to_thread(history_manager.add_record, serialno, record)
         trace_module.clear_trace_data(trace_id)
 
     async def _execute_scheduled_layered_workflow(self, task: TaskRecord) -> None:
         await self._execute_layered_task(
             task,
             session_id=str(task["id"]),
-            record_history=False,
             clear_session_after_run=True,
             metrics_source="scheduled",
         )

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1105,10 +1105,11 @@ export interface HistoryListResponse {
 export async function listHistory(
   serialno: string,
   limit: number = 50,
-  offset: number = 0
+  offset: number = 0,
+  mode?: 'classic' | 'layered'
 ): Promise<HistoryListResponse> {
   const res = await axios.get<HistoryListResponse>(`/api/history/${serialno}`, {
-    params: { limit, offset },
+    params: { limit, offset, ...(mode ? { mode } : {}) },
   });
   return res.data;
 }

--- a/frontend/src/components/ChatKitPanel.tsx
+++ b/frontend/src/components/ChatKitPanel.tsx
@@ -28,6 +28,7 @@ import {
   getTaskSession,
   listWorkflows,
   getErrorMessage,
+  getTask,
   listHistory,
   clearHistory as clearHistoryApi,
   deleteHistoryRecord,
@@ -348,7 +349,7 @@ export function ChatKitPanel({
     if (showHistoryPopover) {
       const loadItems = async () => {
         try {
-          const data = await listHistory(deviceSerial, 20, 0);
+          const data = await listHistory(deviceSerial, 20, 0, 'layered');
           setHistoryItems(data.records);
         } catch (error) {
           console.error('Failed to load history:', error);
@@ -364,14 +365,14 @@ export function ChatKitPanel({
     setShowWorkflowPopover(false);
   };
 
-  const handleSelectHistory = (record: HistoryRecordResponse) => {
+  const handleSelectHistory = async (record: HistoryRecordResponse) => {
     const userMessage: Message = {
       id: `${record.id}-user`,
       role: 'user',
       content: record.task_text,
       timestamp: new Date(record.start_time),
     };
-    const agentMessage: Message = {
+    const fallbackAgentMessage: Message = {
       id: `${record.id}-agent`,
       role: 'assistant',
       content: record.final_message,
@@ -382,10 +383,23 @@ export function ChatKitPanel({
       success: record.success,
       isStreaming: false,
     };
-    setMessages([userMessage, agentMessage]);
+
     setShowHistoryPopover(false);
     setShowScrollToBottom(false);
     isNearBottomRef.current = true;
+
+    // Task-backed records carry their full event trail, so rebuild the
+    // conversation (with the tool-call steps) exactly like the live view.
+    // Older legacy records aren't task-backed, so fall back to a flat render.
+    try {
+      const [task, { events }] = await Promise.all([
+        getTask(record.id),
+        listTaskEvents(record.id),
+      ]);
+      setMessages(buildMessagePair(reconcileTaskRun(task, events), events));
+    } catch {
+      setMessages([userMessage, fallbackAgentMessage]);
+    }
   };
 
   const handleClearHistory = async () => {

--- a/frontend/src/components/DevicePanel.tsx
+++ b/frontend/src/components/DevicePanel.tsx
@@ -238,7 +238,7 @@ export function DevicePanel({
     if (showHistoryPopover) {
       const loadItems = async () => {
         try {
-          const data = await listHistory(deviceSerial, 20, 0);
+          const data = await listHistory(deviceSerial, 20, 0, 'classic');
           setHistoryItems(data.records);
         } catch (error) {
           console.error('Failed to load history:', error);

--- a/frontend/src/routes/history.tsx
+++ b/frontend/src/routes/history.tsx
@@ -618,6 +618,18 @@ function HistoryComponent() {
                                     </pre>
                                   </div>
                                 )}
+
+                              {/* Assistant text (layered tool results / messages) */}
+                              {msg.content &&
+                                (msg.step === null ||
+                                  msg.step === undefined ||
+                                  expandedSteps.has(msg.step)) && (
+                                  <div className="p-3 bg-slate-50 dark:bg-slate-900 rounded-lg">
+                                    <p className="text-sm text-slate-700 dark:text-slate-300 whitespace-pre-wrap">
+                                      {msg.content}
+                                    </p>
+                                  </div>
+                                )}
                             </div>
                           </div>
                         )}

--- a/tests/test_history_api.py
+++ b/tests/test_history_api.py
@@ -279,6 +279,218 @@ def test_history_excludes_active_task_records(
     assert all(record["id"] != "task-active" for record in data["records"])
 
 
+def test_list_history_filters_by_classic_mode(
+    client: TestClient, fake_task_store: FakeTaskStore
+) -> None:
+    fake_task_store.tasks["classic-task"] = {
+        "id": "classic-task",
+        "source": "chat",
+        "executor_key": "classic_chat",
+        "session_id": "sess-c",
+        "scheduled_task_id": None,
+        "workflow_uuid": None,
+        "schedule_fire_id": None,
+        "device_id": "dev-1",
+        "device_serial": "device-1",
+        "status": "SUCCEEDED",
+        "input_text": "经典任务",
+        "final_message": "完成",
+        "error_message": None,
+        "step_count": 3,
+        "created_at": "2026-02-01T10:00:00",
+        "started_at": "2026-02-01T10:00:01",
+        "finished_at": "2026-02-01T10:00:05",
+    }
+    fake_task_store.tasks["layered-task"] = {
+        "id": "layered-task",
+        "source": "chat",
+        "executor_key": "layered_chat",
+        "session_id": "sess-l",
+        "scheduled_task_id": None,
+        "workflow_uuid": None,
+        "schedule_fire_id": None,
+        "device_id": "dev-1",
+        "device_serial": "device-1",
+        "status": "SUCCEEDED",
+        "input_text": "分层任务",
+        "final_message": "完成",
+        "error_message": None,
+        "step_count": 6,
+        "created_at": "2026-02-02T10:00:00",
+        "started_at": "2026-02-02T10:00:01",
+        "finished_at": "2026-02-02T10:00:30",
+    }
+
+    response = client.get("/api/history/device-1", params={"mode": "classic"})
+
+    assert response.status_code == 200
+    ids = {record["id"] for record in response.json()["records"]}
+    assert "classic-task" in ids
+    assert "layered-task" not in ids
+    # legacy record rec-1 (source="chat") belongs to classic mode
+    assert "rec-1" in ids
+    # legacy record rec-2 (source="scheduled") is not a classic chat record
+    assert "rec-2" not in ids
+
+
+def test_list_history_filters_by_layered_mode(
+    client: TestClient,
+    fake_task_store: FakeTaskStore,
+    fake_history_manager: FakeHistoryManager,
+) -> None:
+    fake_task_store.tasks["classic-task"] = {
+        "id": "classic-task",
+        "source": "chat",
+        "executor_key": "classic_chat",
+        "session_id": "sess-c",
+        "scheduled_task_id": None,
+        "workflow_uuid": None,
+        "schedule_fire_id": None,
+        "device_id": "dev-1",
+        "device_serial": "device-1",
+        "status": "SUCCEEDED",
+        "input_text": "经典任务",
+        "final_message": "完成",
+        "error_message": None,
+        "step_count": 3,
+        "created_at": "2026-02-01T10:00:00",
+        "started_at": "2026-02-01T10:00:01",
+        "finished_at": "2026-02-01T10:00:05",
+    }
+    fake_task_store.tasks["layered-task"] = {
+        "id": "layered-task",
+        "source": "chat",
+        "executor_key": "layered_chat",
+        "session_id": "sess-l",
+        "scheduled_task_id": None,
+        "workflow_uuid": None,
+        "schedule_fire_id": None,
+        "device_id": "dev-1",
+        "device_serial": "device-1",
+        "status": "SUCCEEDED",
+        "input_text": "分层任务",
+        "final_message": "完成",
+        "error_message": None,
+        "step_count": 6,
+        "created_at": "2026-02-02T10:00:00",
+        "started_at": "2026-02-02T10:00:01",
+        "finished_at": "2026-02-02T10:00:30",
+    }
+    fake_history_manager.records["device-1"].append(
+        ConversationRecord(
+            id="legacy-layered",
+            task_text="旧分层任务",
+            final_message="完成",
+            success=True,
+            steps=0,
+            start_time=datetime(2026, 1, 3, 9, 0, 0),
+            end_time=datetime(2026, 1, 3, 9, 0, 5),
+            duration_ms=5000,
+            source="layered",
+            source_detail="sess-old",
+            messages=[],
+        )
+    )
+
+    response = client.get("/api/history/device-1", params={"mode": "layered"})
+
+    assert response.status_code == 200
+    ids = {record["id"] for record in response.json()["records"]}
+    assert "layered-task" in ids
+    assert "legacy-layered" in ids
+    assert "classic-task" not in ids
+    assert "rec-1" not in ids
+    assert "rec-2" not in ids
+
+
+def test_list_history_rejects_invalid_mode(client: TestClient) -> None:
+    response = client.get("/api/history/device-1", params={"mode": "bogus"})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "mode must be 'classic' or 'layered'"
+
+
+def test_history_converts_layered_tool_events_to_messages(
+    client: TestClient, fake_task_store: FakeTaskStore
+) -> None:
+    fake_task_store.tasks["layered-task"] = {
+        "id": "layered-task",
+        "source": "chat",
+        "executor_key": "layered_chat",
+        "session_id": "sess-l",
+        "scheduled_task_id": None,
+        "workflow_uuid": None,
+        "schedule_fire_id": None,
+        "device_id": "dev-1",
+        "device_serial": "device-1",
+        "status": "SUCCEEDED",
+        "input_text": "整理桌面",
+        "final_message": "已完成",
+        "error_message": None,
+        "step_count": 7,
+        "created_at": "2026-02-05T10:00:00",
+        "started_at": "2026-02-05T10:00:01",
+        "finished_at": "2026-02-05T10:00:30",
+    }
+    fake_task_store.events["layered-task"] = [
+        {
+            "task_id": "layered-task",
+            "seq": 1,
+            "event_type": "tool_call",
+            "role": "assistant",
+            "payload": {
+                "tool_name": "chat",
+                "tool_args": {"device_id": "dev-1", "message": "打开设置"},
+            },
+            "created_at": "2026-02-05T10:00:05",
+        },
+        {
+            "task_id": "layered-task",
+            "seq": 2,
+            "event_type": "tool_result",
+            "role": "assistant",
+            "payload": {
+                "tool_name": "chat",
+                "result": "已打开设置",
+                "steps": 4,
+                "success": True,
+            },
+            "created_at": "2026-02-05T10:00:15",
+        },
+        {
+            "task_id": "layered-task",
+            "seq": 3,
+            "event_type": "message",
+            "role": "assistant",
+            "payload": {"content": "继续下一步"},
+            "created_at": "2026-02-05T10:00:16",
+        },
+        {
+            "task_id": "layered-task",
+            "seq": 4,
+            "event_type": "done",
+            "role": "assistant",
+            "payload": {"message": "已完成", "steps": 7, "success": True},
+            "created_at": "2026-02-05T10:00:30",
+        },
+    ]
+
+    response = client.get("/api/history/device-1/layered-task")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["steps"] == 7
+    messages = data["messages"]
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == "整理桌面"
+    tool_call_messages = [message for message in messages if message.get("action")]
+    assert any(
+        message["action"].get("tool_name") == "chat" for message in tool_call_messages
+    )
+    assert any("已打开设置" in (message.get("content") or "") for message in messages)
+    assert any(message.get("content") == "继续下一步" for message in messages)
+
+
 def test_list_history_validates_limit_and_offset(client: TestClient) -> None:
     limit_response = client.get("/api/history/device-1", params={"limit": 101})
     assert limit_response.status_code == 400

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+import pytest
+
 from AutoGLM_GUI.task_manager import TaskManager
 from AutoGLM_GUI.task_store import TaskStatus, TaskStore
 
@@ -218,6 +220,106 @@ def test_task_manager_marks_running_tasks_interrupted_on_start(tmp_path: Path) -
 
     asyncio.run(manager.shutdown())
     store.close()
+
+
+def test_execute_layered_chat_counts_inner_steps_and_skips_legacy_history(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import AutoGLM_GUI.device_manager as device_manager_module
+    import AutoGLM_GUI.history_manager as history_manager_module
+    import AutoGLM_GUI.layered_agent_service as layered_service
+
+    class FakeRun:
+        def __init__(self) -> None:
+            self.final_output = "已完成整理"
+
+        def cancel(self) -> None:  # pragma: no cover - not exercised here
+            pass
+
+        async def stream_events(self):
+            yield {
+                "type": "tool_call",
+                "payload": {"tool_name": "chat", "tool_args": {}},
+            }
+            yield {
+                "type": "tool_result",
+                "payload": {
+                    "tool_name": "chat",
+                    "result": "已打开设置",
+                    "steps": 4,
+                    "success": True,
+                },
+            }
+            yield {
+                "type": "tool_call",
+                "payload": {"tool_name": "chat", "tool_args": {}},
+            }
+            yield {
+                "type": "tool_result",
+                "payload": {
+                    "tool_name": "chat",
+                    "result": "已切换 Wi-Fi",
+                    "steps": 3,
+                    "success": True,
+                },
+            }
+            yield {"type": "message", "payload": {"content": "继续下一步"}}
+            yield {
+                "type": "done",
+                "payload": {"content": "已完成整理", "success": True},
+            }
+
+    def fake_start_run(*, task_id: str, session_id: str, message: str) -> FakeRun:
+        return FakeRun()
+
+    monkeypatch.setattr(layered_service, "start_run", fake_start_run)
+
+    legacy_history_calls: list[tuple[object, ...]] = []
+
+    class FakeHistoryManager:
+        def add_record(self, *args: object, **kwargs: object) -> None:
+            legacy_history_calls.append((args, kwargs))
+
+    monkeypatch.setattr(history_manager_module, "history_manager", FakeHistoryManager())
+
+    class FakeDeviceManager:
+        def get_serial_by_device_id(self, device_id: str) -> str:
+            return "serial-a"
+
+    monkeypatch.setattr(
+        device_manager_module.DeviceManager,
+        "get_instance",
+        staticmethod(lambda: FakeDeviceManager()),
+    )
+
+    async def scenario() -> None:
+        store = TaskStore(tmp_path / "tasks.db")
+        manager = TaskManager(store)
+        await manager.start()
+        session = await manager.create_chat_session(
+            device_id="device-a",
+            device_serial="serial-a",
+            mode="layered",
+        )
+        task = await manager.submit_chat_task(
+            session_id=str(session["id"]),
+            device_id="device-a",
+            device_serial="serial-a",
+            message="整理一下手机",
+        )
+
+        final_task = await manager.wait_for_task(str(task["id"]), timeout=5)
+
+        assert final_task is not None
+        assert final_task["status"] == TaskStatus.SUCCEEDED.value
+        assert final_task["step_count"] == 7
+
+        await manager.shutdown()
+        store.close()
+
+    asyncio.run(scenario())
+
+    assert legacy_history_calls == []
 
 
 def test_submit_chat_task_uses_layered_executor_for_layered_sessions(


### PR DESCRIPTION
## 问题

Closes #349

前端经典模式（`DevicePanel`）和分层模式（`ChatKitPanel`）的「任务历史」弹窗共用同一份按设备合并的历史，互相污染。此外分层模式还有几个连带问题：

1. **历史互相污染** —— 两个模式的弹窗显示一样的记录，没按模式隔离
2. **过程消息丢失** —— 分层历史只剩用户消息 + 最终结果，工具调用等中间过程没了
3. **Step 数恒为 0** —— `_execute_layered_task` 把 `step_count` 写死成 0
4. **分层任务双写历史**（issue 未提，顺带发现）—— 同一个分层任务既进 `task_store` 又进 `history_manager`，在历史里出现两次

## 改动

### 后端
- **`api/history.py`**：`GET /api/history/{serialno}` 新增可选 `mode=classic|layered`，按 `task_run.executor_key`（`classic_chat`/`layered_chat`）和 legacy `ConversationRecord.source` 过滤；非法值返回 400。不带 `mode` 时行为不变（`/history` 总览页照旧）。`_build_history_record_from_task` 除原有的 `step` 事件外，新增把分层的 `tool_call`（→ `action={tool_name,tool_args}` + 序号 `step`）/ `tool_result`（→ `content=结果文本`，同一 `step`）/ `message`（→ `content`）事件转成消息。
- **`task_manager.py`**：`_execute_layered_task` 累加每个 `tool_result` 的内层步数作为该任务的 `step_count`（与经典模式语义一致）；移除向 `history_manager` 双写 `ConversationRecord` 的逻辑（连带去掉 `record_history` 参数和不再使用的导入）。
- **`layered_agent_service.py`**：`LayeredTaskRun` 解析 `chat` 工具返回的 JSON 信封，把内层 agent 的 `steps`/`success` 作为结构化字段放进 `tool_result` 事件 payload（`result` 原始字符串保留，SSE 兼容层与前端不受影响）。

### 前端
- **`api.ts`**：`listHistory` 新增可选 `mode` 参数。
- **`DevicePanel.tsx` / `ChatKitPanel.tsx`**：任务历史弹窗分别传 `'classic'` / `'layered'`。
- **`ChatKitPanel.tsx`**：`handleSelectHistory` 改为 `getTask` + `listTaskEvents`，复用现成的 `reconcileTaskRun` + `buildMessagePair` 把分层历史会话连同工具调用步骤完整还原；旧 legacy 记录取不到则回退到扁平渲染。
- **`history.tsx`**：详情弹窗给 assistant 消息补上 `content` 渲染（经典模式 assistant `content` 一直是空串，不受影响）。

### 测试
- `tests/test_history_api.py`：新增 4 个 —— `mode=classic` / `mode=layered` 过滤、非法 `mode` 返回 400、分层事件转成 messages。
- `tests/test_task_manager.py`：新增 1 个 —— 分层任务跑完后 `step_count` 等于内层步数之和，且不再调用 `history_manager.add_record`。

## 验证
- `pytest tests/`（忽略 integration）：280 passed, 1 skipped
- 前端 `tsc --noEmit`、`eslint`：通过
- `ruff check` / `pyright`：通过

## 备注
本次只修「今后」的数据。之前已存在的分层历史（`step_count=0`、无过程消息的 legacy 记录）不会被回溯修复。