### PR TITLE
Add backend trace observability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,27 @@
 - Electron app build (CI mode): `uv run python scripts/build_electron.py --publish never`
 - Docker compose runtime (deploy-style): `docker-compose up -d`
 
+## Debugging and observability
+### Trace files
+- Backend tracing is enabled by default unless `AUTOGLM_TRACE_ENABLED` is set to `0`, `false`, `no`, or `off`.
+- Trace spans are written as JSONL to `logs/trace_{date}.jsonl` by default. Override the path with `AUTOGLM_TRACE_FILE`, for example: `AUTOGLM_TRACE_FILE=/tmp/autoglm_trace_{date}.jsonl`.
+- Each task run stores its `trace_id` in `task_runs.trace_id`. The same value is returned by `/api/tasks/*` and `/api/history/*`.
+- To inspect one task, get its `trace_id` from the task or history response, then filter the JSONL trace file by that value.
+
+### Trace coverage
+- Model calls: classic agents emit `step.llm`; layered planner streaming emits `model.call` and `layered.planner.*`.
+- Tool calls: layered planner emits `tool.call` and `tool.result`; Gemini function calling emits `tool.call`.
+- ADB/device calls: device wrappers and low-level ADB operations emit `device.*` and `adb.*` spans.
+- Memory and persistence: MAI trajectory memory emits `memory.read` and `memory.write`; layered planner SQLite sessions emit `memory.read`, `memory.write`, `memory.delete`, and `memory.clear`; task/history writes emit `task_store.*` and `history.*`.
+- Task summaries: task completion appends a `trace_summary` event and records Prometheus latency metrics from the same trace data.
+
+### Debugging workflow
+- Reproduce the issue with the backend running normally.
+- Find the task in `/api/tasks/{task_id}` or `/api/history/{serialno}/{record_id}` and copy `trace_id`.
+- Filter `logs/trace_{date}.jsonl` for that `trace_id`; inspect span names, parent span ids, durations, and `attrs`.
+- Use step timing chips in history for a quick breakdown of screenshot, app detection, LLM, parsing, action execution, ADB, sleep, and other time.
+- Use `/api/metrics` for aggregate Prometheus histograms after tasks complete.
+
 ## Do / Don’t
 ### Do
 - Prefer minimal, localized changes; follow existing patterns in nearby files.

--- a/AutoGLM_GUI/agents/gemini/async_agent.py
+++ b/AutoGLM_GUI/agents/gemini/async_agent.py
@@ -14,7 +14,7 @@ from AutoGLM_GUI.actions import ActionResult
 from AutoGLM_GUI.agents.base import AsyncAgentBase
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.model import MessageBuilder
-from AutoGLM_GUI.trace import trace_span
+from AutoGLM_GUI.trace import summarize_text, trace_span
 
 from .action_mapper import tool_call_to_action
 from .prompts import get_system_prompt
@@ -127,7 +127,21 @@ class AsyncGeminiAgent(AsyncAgentBase):
             "step.parse_action",
             attrs={"step": self._step_count, "agent_type": self.__class__.__name__},
         ):
-            action = tool_call_to_action(tool_name, tool_args)
+            with trace_span(
+                "tool.call",
+                attrs={
+                    "step": self._step_count,
+                    "caller": "gemini_model",
+                    "tool_name": tool_name,
+                    "tool_arg_keys": sorted(tool_args.keys()),
+                    "tool_args_preview": summarize_text(
+                        json.dumps(tool_args, ensure_ascii=False, default=str),
+                        limit=512,
+                    ),
+                },
+            ) as span:
+                action = tool_call_to_action(tool_name, tool_args)
+                span.set_attribute("action_name", action.get("action"))
 
         if self.agent_config.verbose:
             logger.debug(f"🎯 Tool call: {tool_name}({tool_args})")
@@ -239,7 +253,8 @@ class AsyncGeminiAgent(AsyncAgentBase):
             tool_call = message.tool_calls[0]
             tool_name = tool_call.function.name  # type: ignore[union-attr]
             try:
-                tool_args = json.loads(tool_call.function.arguments)  # type: ignore[union-attr]
+                parsed_args = json.loads(tool_call.function.arguments)  # type: ignore[union-attr]
+                tool_args = parsed_args if isinstance(parsed_args, dict) else {}
             except json.JSONDecodeError as e:
                 logger.warning(
                     f"Failed to parse tool arguments for {tool_name}: {e}. "

--- a/AutoGLM_GUI/agents/mai/async_agent.py
+++ b/AutoGLM_GUI/agents/mai/async_agent.py
@@ -113,11 +113,20 @@ class AsyncMAIAgent(AsyncAgentBase):
             pil_image = Image.open(BytesIO(screenshot_bytes))
             screen_info = MessageBuilder.build_screen_info(current_app)
 
-            messages = self._build_messages(
-                instruction=self.traj_memory.task_goal,
-                screen_info=screen_info,
-                current_screenshot_base64=screenshot.base64_data,
-            )
+            with trace_span(
+                "memory.read",
+                attrs={
+                    "step": self._step_count,
+                    "memory_type": "mai_traj",
+                    "history_n": self._history_n,
+                    "stored_steps": len(self.traj_memory.steps),
+                },
+            ):
+                messages = self._build_messages(
+                    instruction=self.traj_memory.task_goal,
+                    screen_info=screen_info,
+                    current_screenshot_base64=screenshot.base64_data,
+                )
 
         # 3. 带重试的 LLM 调用 + 解析
         max_retries = 3
@@ -252,7 +261,17 @@ class AsyncMAIAgent(AsyncAgentBase):
                 screenshot_bytes=screenshot_bytes,
                 structured_action={"action_json": raw_action},
             )
-            self.traj_memory.add_step(traj_step)
+            with trace_span(
+                "memory.write",
+                attrs={
+                    "step": self._step_count,
+                    "memory_type": "mai_traj",
+                    "item_type": "TrajStep",
+                    "history_n": self._history_n,
+                    "model_name": self.model_config.model_name,
+                },
+            ):
+                self.traj_memory.add_step(traj_step)
 
         # 5. 执行动作
         try:

--- a/AutoGLM_GUI/api/history.py
+++ b/AutoGLM_GUI/api/history.py
@@ -92,6 +92,20 @@ def _trace_summary_from_payload(
     return TraceSummaryResponse(**summary)
 
 
+def _step_timings_from_trace_payload(
+    payload: dict[str, Any],
+) -> list[StepTimingSummaryResponse]:
+    raw_step_summaries = payload.get("step_summaries")
+    if not isinstance(raw_step_summaries, list):
+        return []
+
+    step_timings: list[StepTimingSummaryResponse] = []
+    for raw_step_summary in raw_step_summaries:
+        if isinstance(raw_step_summary, dict):
+            step_timings.append(StepTimingSummaryResponse(**raw_step_summary))
+    return step_timings
+
+
 def _trace_summary_from_step_timings(
     trace_id: str | None,
     step_timings: list[StepTimingSummaryResponse],
@@ -158,6 +172,14 @@ def _build_history_record_from_task(record: dict[str, Any]) -> HistoryRecordResp
                 step_timings.append(StepTimingSummaryResponse(**timings))
         elif event_type == "trace_summary":
             trace_summary = _trace_summary_from_payload(payload)
+            existing_timing_keys = {
+                (timing.trace_id, timing.step) for timing in step_timings
+            }
+            for timing in _step_timings_from_trace_payload(payload):
+                timing_key = (timing.trace_id, timing.step)
+                if timing_key not in existing_timing_keys:
+                    step_timings.append(timing)
+                    existing_timing_keys.add(timing_key)
         elif event_type == "tool_call":
             layered_step += 1
             messages.append(

--- a/AutoGLM_GUI/api/history.py
+++ b/AutoGLM_GUI/api/history.py
@@ -30,6 +30,7 @@ _MODE_LEGACY_SOURCES: dict[str, set[str]] = {
     "classic": {"chat"},
     "layered": {"layered"},
 }
+_TRACE_SUMMARY_FIELDS = set(TraceSummaryResponse.model_fields)
 
 
 def _build_history_record_response(record: ConversationRecord) -> HistoryRecordResponse:
@@ -76,9 +77,58 @@ def _tool_result_text(payload: dict[str, Any]) -> str:
     return json.dumps(result, ensure_ascii=False)
 
 
+def _trace_summary_from_payload(
+    payload: dict[str, Any],
+) -> TraceSummaryResponse | None:
+    raw_summary = payload.get("summary", payload)
+    if not isinstance(raw_summary, dict):
+        return None
+    summary = {
+        key: raw_summary[key] for key in _TRACE_SUMMARY_FIELDS if key in raw_summary
+    }
+    missing = _TRACE_SUMMARY_FIELDS - set(summary)
+    if missing:
+        return None
+    return TraceSummaryResponse(**summary)
+
+
+def _trace_summary_from_step_timings(
+    trace_id: str | None,
+    step_timings: list[StepTimingSummaryResponse],
+) -> TraceSummaryResponse | None:
+    if not step_timings:
+        return None
+    resolved_trace_id = trace_id or step_timings[0].trace_id
+    return TraceSummaryResponse(
+        trace_id=resolved_trace_id,
+        steps=len(step_timings),
+        total_duration_ms=round(sum(t.total_duration_ms for t in step_timings), 3),
+        screenshot_duration_ms=round(
+            sum(t.screenshot_duration_ms for t in step_timings), 3
+        ),
+        current_app_duration_ms=round(
+            sum(t.current_app_duration_ms for t in step_timings), 3
+        ),
+        llm_duration_ms=round(sum(t.llm_duration_ms for t in step_timings), 3),
+        parse_action_duration_ms=round(
+            sum(t.parse_action_duration_ms for t in step_timings), 3
+        ),
+        execute_action_duration_ms=round(
+            sum(t.execute_action_duration_ms for t in step_timings), 3
+        ),
+        update_context_duration_ms=round(
+            sum(t.update_context_duration_ms for t in step_timings), 3
+        ),
+        adb_duration_ms=round(sum(t.adb_duration_ms for t in step_timings), 3),
+        sleep_duration_ms=round(sum(t.sleep_duration_ms for t in step_timings), 3),
+        other_duration_ms=round(sum(t.other_duration_ms for t in step_timings), 3),
+    )
+
+
 def _build_history_record_from_task(record: dict[str, Any]) -> HistoryRecordResponse:
     events = task_store.list_task_events(record["id"])
     step_timings: list[StepTimingSummaryResponse] = []
+    trace_summary: TraceSummaryResponse | None = None
     messages: list[MessageRecordResponse] = [
         MessageRecordResponse(
             role="user",
@@ -106,6 +156,8 @@ def _build_history_record_from_task(record: dict[str, Any]) -> HistoryRecordResp
             timings = payload.get("timings")
             if isinstance(timings, dict):
                 step_timings.append(StepTimingSummaryResponse(**timings))
+        elif event_type == "trace_summary":
+            trace_summary = _trace_summary_from_payload(payload)
         elif event_type == "tool_call":
             layered_step += 1
             messages.append(
@@ -155,6 +207,11 @@ def _build_history_record_from_task(record: dict[str, Any]) -> HistoryRecordResp
     success = record["status"] == TaskStatus.SUCCEEDED.value
     end_time = record.get("finished_at")
     start_time = record.get("started_at") or record["created_at"]
+    trace_id = str(record["trace_id"]) if record.get("trace_id") is not None else None
+    if trace_summary is None:
+        trace_summary = _trace_summary_from_step_timings(trace_id, step_timings)
+    if trace_id is None and trace_summary is not None:
+        trace_id = trace_summary.trace_id
 
     duration_ms = 0
     if end_time:
@@ -181,9 +238,9 @@ def _build_history_record_from_task(record: dict[str, Any]) -> HistoryRecordResp
         error_message=str(record["error_message"])
         if record.get("error_message") is not None
         else None,
-        trace_id=None,
+        trace_id=trace_id,
         step_timings=step_timings,
-        trace_summary=None,
+        trace_summary=trace_summary,
         messages=messages,
     )
 

--- a/AutoGLM_GUI/api/tasks.py
+++ b/AutoGLM_GUI/api/tasks.py
@@ -78,6 +78,9 @@ def _task_run_response(record: TaskRecord) -> TaskRunResponse:
         stop_reason=str(record.get("stop_reason"))
         if record.get("stop_reason") is not None
         else None,
+        trace_id=str(record.get("trace_id"))
+        if record.get("trace_id") is not None
+        else None,
         step_count=int(record["step_count"]),
         created_at=str(record["created_at"]),
         started_at=str(record["started_at"])

--- a/AutoGLM_GUI/history_manager.py
+++ b/AutoGLM_GUI/history_manager.py
@@ -11,6 +11,7 @@ from typing import Self
 
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.models.history import ConversationRecord, DeviceHistory
+from AutoGLM_GUI.trace import trace_span
 
 # ADB serialno 合法字符：字母数字、下划线、破折号、冒号、点
 # USB: ABC123DEF456
@@ -103,27 +104,47 @@ class HistoryManager:
         path = self._get_history_path(history.serialno)
         temp_path = path.with_suffix(".tmp")
 
-        try:
-            history.last_updated = datetime.now()
-            with open(temp_path, "w", encoding="utf-8") as f:
-                json.dump(history.to_dict(), f, indent=2, ensure_ascii=False)
-            temp_path.replace(path)
+        with trace_span(
+            "history.file.write",
+            attrs={
+                "serialno": history.serialno,
+                "record_count": len(history.records),
+                "path": path,
+            },
+        ):
+            try:
+                history.last_updated = datetime.now()
+                with open(temp_path, "w", encoding="utf-8") as f:
+                    json.dump(history.to_dict(), f, indent=2, ensure_ascii=False)
+                temp_path.replace(path)
 
-            self._file_cache[history.serialno] = history
-            self._file_mtime[history.serialno] = path.stat().st_mtime
-            logger.debug(f"Saved {len(history.records)} records for {history.serialno}")
-            return True
-        except Exception as e:
-            logger.error(f"Failed to save history for {history.serialno}: {e}")
-            if temp_path.exists():
-                temp_path.unlink()
-            return False
+                self._file_cache[history.serialno] = history
+                self._file_mtime[history.serialno] = path.stat().st_mtime
+                logger.debug(
+                    f"Saved {len(history.records)} records for {history.serialno}"
+                )
+                return True
+            except Exception as e:
+                logger.error(f"Failed to save history for {history.serialno}: {e}")
+                if temp_path.exists():
+                    temp_path.unlink()
+                return False
 
     def add_record(self, serialno: str, record: ConversationRecord) -> None:
-        history = self._load_history(serialno)
-        history.records.insert(0, record)
-        self._save_history(history)
-        logger.info(f"Added history record for {serialno}: {record.id}")
+        with trace_span(
+            "history.record.add",
+            attrs={
+                "serialno": serialno,
+                "record_id": record.id,
+                "source": record.source,
+                "trace_id": record.trace_id,
+                "step_count": record.steps,
+            },
+        ):
+            history = self._load_history(serialno)
+            history.records.insert(0, record)
+            self._save_history(history)
+            logger.info(f"Added history record for {serialno}: {record.id}")
 
     def list_records(
         self, serialno: str, limit: int = 50, offset: int = 0
@@ -136,27 +157,39 @@ class HistoryManager:
         return next((r for r in history.records if r.id == record_id), None)
 
     def delete_record(self, serialno: str, record_id: str) -> bool:
-        history = self._load_history(serialno)
-        original_len = len(history.records)
-        history.records = [r for r in history.records if r.id != record_id]
+        with trace_span(
+            "history.record.delete",
+            attrs={"serialno": serialno, "record_id": record_id},
+        ) as span:
+            history = self._load_history(serialno)
+            original_len = len(history.records)
+            history.records = [r for r in history.records if r.id != record_id]
 
-        if len(history.records) < original_len:
-            self._save_history(history)
-            logger.info(f"Deleted history record {record_id} for {serialno}")
-            return True
+            if len(history.records) < original_len:
+                self._save_history(history)
+                logger.info(f"Deleted history record {record_id} for {serialno}")
+                span.set_attribute("deleted", True)
+                return True
 
-        logger.warning(f"Record {record_id} not found for {serialno}")
-        return False
+            logger.warning(f"Record {record_id} not found for {serialno}")
+            span.set_attribute("deleted", False)
+            return False
 
     def clear_device_history(self, serialno: str) -> bool:
         path = self._get_history_path(serialno)
-        if path.exists():
-            path.unlink()
-            self._file_cache.pop(serialno, None)
-            self._file_mtime.pop(serialno, None)
-            logger.info(f"Cleared all history for {serialno}")
-            return True
-        return False
+        with trace_span(
+            "history.device.clear",
+            attrs={"serialno": serialno, "path": path},
+        ) as span:
+            if path.exists():
+                path.unlink()
+                self._file_cache.pop(serialno, None)
+                self._file_mtime.pop(serialno, None)
+                logger.info(f"Cleared all history for {serialno}")
+                span.set_attribute("cleared", True)
+                return True
+            span.set_attribute("cleared", False)
+            return False
 
     def get_total_count(self, serialno: str) -> int:
         history = self._load_history(serialno)

--- a/AutoGLM_GUI/layered_agent_service.py
+++ b/AutoGLM_GUI/layered_agent_service.py
@@ -15,7 +15,7 @@ from openai import AsyncOpenAI
 
 from AutoGLM_GUI.config_manager import config_manager
 from AutoGLM_GUI.logger import logger
-from AutoGLM_GUI.trace import summarize_text, trace_span
+from AutoGLM_GUI.trace import TraceSpan, summarize_text, trace_span
 
 if TYPE_CHECKING:
     from agents.result import RunResultStreaming
@@ -73,7 +73,58 @@ PLANNER_INSTRUCTIONS = """## 核心目标
 """
 
 
-_sessions: dict[str, SQLiteSession] = {}
+class TracedSQLiteSession(SQLiteSession):
+    """SQLiteSession wrapper that exposes planner memory operations as spans."""
+
+    async def get_items(self, limit: int | None = None) -> list[Any]:
+        with trace_span(
+            "memory.read",
+            attrs={
+                "memory_type": "layered_session",
+                "session_id": self.session_id,
+                "limit": limit,
+            },
+        ) as span:
+            items = await super().get_items(limit)
+            span.set_attribute("item_count", len(items))
+            return items
+
+    async def add_items(self, items: list[Any]) -> None:
+        with trace_span(
+            "memory.write",
+            attrs={
+                "memory_type": "layered_session",
+                "session_id": self.session_id,
+                "item_count": len(items),
+            },
+        ):
+            await super().add_items(items)
+
+    async def pop_item(self) -> Any | None:
+        with trace_span(
+            "memory.delete",
+            attrs={
+                "memory_type": "layered_session",
+                "session_id": self.session_id,
+                "operation": "pop_item",
+            },
+        ) as span:
+            item = await super().pop_item()
+            span.set_attribute("deleted", item is not None)
+            return item
+
+    async def clear_session(self) -> None:
+        with trace_span(
+            "memory.clear",
+            attrs={
+                "memory_type": "layered_session",
+                "session_id": self.session_id,
+            },
+        ):
+            await super().clear_session()
+
+
+_sessions: dict[str, TracedSQLiteSession] = {}
 _active_runs: dict[str, "RunResultStreaming"] = {}
 _active_runs_lock = threading.Lock()
 
@@ -84,15 +135,29 @@ _cached_config_hash: str | None = None
 
 def _get_or_create_session(session_id: str) -> SQLiteSession:
     if session_id not in _sessions:
-        _sessions[session_id] = SQLiteSession(session_id)
-        logger.info(f"[LayeredAgent] Created new session: {session_id}")
+        with trace_span(
+            "memory.session.create",
+            attrs={
+                "memory_type": "layered_session",
+                "session_id": session_id,
+            },
+        ):
+            _sessions[session_id] = TracedSQLiteSession(session_id)
+            logger.info(f"[LayeredAgent] Created new session: {session_id}")
     return _sessions[session_id]
 
 
 def reset_session(session_id: str) -> bool:
     if session_id in _sessions:
-        del _sessions[session_id]
-        logger.info(f"[LayeredAgent] Cleared session: {session_id}")
+        with trace_span(
+            "memory.session.drop",
+            attrs={
+                "memory_type": "layered_session",
+                "session_id": session_id,
+            },
+        ):
+            del _sessions[session_id]
+            logger.info(f"[LayeredAgent] Cleared session: {session_id}")
         return True
     return False
 
@@ -360,70 +425,177 @@ class LayeredTaskRun:
     async def stream_events(self) -> AsyncIterator[dict[str, Any]]:
         from agents.stream_events import RawResponsesStreamEvent, RunItemStreamEvent
 
+        model_span: TraceSpan | None = None
+        raw_event_count = 0
+
+        def close_model_span() -> None:
+            nonlocal model_span, raw_event_count
+            if model_span is not None:
+                model_span.__exit__(None, None, None)
+                model_span = None
+                raw_event_count = 0
+
         try:
-            async for event in self.result.stream_events():
-                if isinstance(event, RawResponsesStreamEvent):
-                    continue
-                if not isinstance(event, RunItemStreamEvent):
-                    continue
-
-                item = event.item
-                item_type = getattr(item, "type", None)
-
-                if item_type == "tool_call_item":
-                    event_payload = self._parse_tool_call(item)
-                    self._current_tool_call = {
-                        "name": event_payload["tool_name"],
-                        "args": event_payload["tool_args"],
-                    }
-                    yield {
-                        "type": "tool_call",
-                        "payload": event_payload,
-                    }
-                elif item_type == "tool_call_output_item":
-                    output = getattr(item, "output", "")
-                    tool_name = (
-                        self._current_tool_call["name"]
-                        if self._current_tool_call
-                        else "unknown"
-                    )
-                    result_text, steps, sub_success = self._parse_tool_output(output)
-                    tool_result_payload: dict[str, Any] = {
-                        "tool_name": tool_name,
-                        "result": result_text,
-                    }
-                    if steps:
-                        tool_result_payload["steps"] = steps
-                    if sub_success is not None:
-                        tool_result_payload["success"] = sub_success
-                    yield {
-                        "type": "tool_result",
-                        "payload": tool_result_payload,
-                    }
-                    self._current_tool_call = None
-                elif item_type == "message_output_item":
-                    content = self._extract_message_content(item)
-                    if content:
-                        yield {
-                            "type": "message",
-                            "payload": {"content": content},
-                        }
-
-            self.final_output = (
-                self.result.final_output if hasattr(self.result, "final_output") else ""
-            )
-            self.success = True
-            yield {
-                "type": "done",
-                "payload": {
-                    "content": self.final_output,
-                    "success": True,
+            with trace_span(
+                "layered.planner.stream",
+                attrs={
+                    "task_id": self.task_id,
+                    "session_id": self.session_id,
                 },
-            }
+            ) as stream_span:
+                async for event in self.result.stream_events():
+                    if isinstance(event, RawResponsesStreamEvent):
+                        if model_span is None:
+                            model_span = trace_span(
+                                "model.call",
+                                attrs={
+                                    "model_role": "layered_planner",
+                                    "task_id": self.task_id,
+                                    "session_id": self.session_id,
+                                },
+                            )
+                            model_span.__enter__()
+                        raw_event_count += 1
+                        raw_data = getattr(event, "data", None)
+                        raw_event_type = getattr(raw_data, "type", None)
+                        model_span.set_attributes(
+                            {
+                                "raw_event_count": raw_event_count,
+                                "last_raw_event_type": raw_event_type
+                                or type(raw_data).__name__,
+                            }
+                        )
+                        continue
+
+                    close_model_span()
+                    if not isinstance(event, RunItemStreamEvent):
+                        continue
+
+                    item = event.item
+                    item_type = getattr(item, "type", None)
+
+                    if item_type == "tool_call_item":
+                        with trace_span(
+                            "tool.call",
+                            attrs={
+                                "task_id": self.task_id,
+                                "session_id": self.session_id,
+                                "caller": "layered_planner",
+                            },
+                        ) as span:
+                            event_payload = self._parse_tool_call(item)
+                            tool_args = event_payload["tool_args"]
+                            span.set_attributes(
+                                {
+                                    "tool_name": event_payload["tool_name"],
+                                    "tool_arg_keys": sorted(tool_args.keys())
+                                    if isinstance(tool_args, dict)
+                                    else [],
+                                    "tool_args_preview": summarize_text(
+                                        json.dumps(
+                                            tool_args,
+                                            ensure_ascii=False,
+                                            default=str,
+                                        ),
+                                        limit=512,
+                                    ),
+                                }
+                            )
+                            self._current_tool_call = {
+                                "name": event_payload["tool_name"],
+                                "args": event_payload["tool_args"],
+                            }
+                        yield {
+                            "type": "tool_call",
+                            "payload": event_payload,
+                        }
+                    elif item_type == "tool_call_output_item":
+                        output = getattr(item, "output", "")
+                        tool_name = (
+                            self._current_tool_call["name"]
+                            if self._current_tool_call
+                            else "unknown"
+                        )
+                        with trace_span(
+                            "tool.result",
+                            attrs={
+                                "task_id": self.task_id,
+                                "session_id": self.session_id,
+                                "caller": "layered_planner",
+                                "tool_name": tool_name,
+                            },
+                        ) as span:
+                            result_text, steps, sub_success = self._parse_tool_output(
+                                output
+                            )
+                            span.set_attributes(
+                                {
+                                    "steps": steps,
+                                    "success": sub_success,
+                                    "result_preview": summarize_text(result_text, 512),
+                                }
+                            )
+                            tool_result_payload: dict[str, Any] = {
+                                "tool_name": tool_name,
+                                "result": result_text,
+                            }
+                            if steps:
+                                tool_result_payload["steps"] = steps
+                            if sub_success is not None:
+                                tool_result_payload["success"] = sub_success
+                            self._current_tool_call = None
+                        yield {
+                            "type": "tool_result",
+                            "payload": tool_result_payload,
+                        }
+                    elif item_type == "message_output_item":
+                        with trace_span(
+                            "layered.planner.message",
+                            attrs={
+                                "task_id": self.task_id,
+                                "session_id": self.session_id,
+                            },
+                        ) as span:
+                            content = self._extract_message_content(item)
+                            span.set_attribute(
+                                "content_preview",
+                                summarize_text(content, 512),
+                            )
+                        if content:
+                            yield {
+                                "type": "message",
+                                "payload": {"content": content},
+                            }
+
+                close_model_span()
+                self.final_output = (
+                    self.result.final_output
+                    if hasattr(self.result, "final_output")
+                    else ""
+                )
+                self.success = True
+                stream_span.set_attributes(
+                    {
+                        "success": True,
+                        "final_output_preview": summarize_text(
+                            self.final_output,
+                            512,
+                        ),
+                    }
+                )
+                yield {
+                    "type": "done",
+                    "payload": {
+                        "content": self.final_output,
+                        "success": True,
+                    },
+                }
         except asyncio.CancelledError:
+            close_model_span()
             self.cancelled = True
             raise
         except Exception as exc:
+            close_model_span()
             if self.cancelled:
                 self.final_output = "Task cancelled by user"
                 self.success = False
@@ -520,7 +692,10 @@ class LayeredTaskRun:
     @staticmethod
     def _parse_json_args(args_val: Any) -> dict[str, Any]:
         try:
-            return json.loads(args_val) if isinstance(args_val, str) else args_val
+            parsed = json.loads(args_val) if isinstance(args_val, str) else args_val
+            if isinstance(parsed, dict):
+                return parsed
+            return {"value": parsed}
         except Exception:
             return {"raw": str(args_val)}
 
@@ -548,12 +723,22 @@ def start_run(
     session = _get_or_create_session(session_id)
     effective_config = config_manager.get_effective_config()
     max_turns = effective_config.layered_max_turns
-    result = Runner.run_streamed(
-        agent,
-        message,
-        max_turns=max_turns if max_turns is not None else 100000,
-        session=session,
-    )
+    resolved_max_turns = max_turns if max_turns is not None else 100000
+    with trace_span(
+        "layered.planner.run_streamed",
+        attrs={
+            "task_id": task_id,
+            "session_id": session_id,
+            "max_turns": resolved_max_turns,
+            "message_preview": summarize_text(message, 512),
+        },
+    ):
+        result = Runner.run_streamed(
+            agent,
+            message,
+            max_turns=resolved_max_turns,
+            session=session,
+        )
 
     with _active_runs_lock:
         _active_runs[task_id] = result

--- a/AutoGLM_GUI/schemas.py
+++ b/AutoGLM_GUI/schemas.py
@@ -838,6 +838,7 @@ class TaskRunResponse(BaseModel):
     final_message: str | None = None
     error_message: str | None = None
     stop_reason: str | None = None
+    trace_id: str | None = None
     step_count: int
     created_at: str
     started_at: str | None = None

--- a/AutoGLM_GUI/task_manager.py
+++ b/AutoGLM_GUI/task_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -265,6 +266,78 @@ class TaskManager:
         except TypeError:
             manager.unregister_abort_handler(device_id)
 
+    async def _record_trace_artifacts(
+        self,
+        *,
+        task_id: str,
+        trace_id: str,
+        metrics_source: str,
+        step_count: int,
+        total_duration_ms: int,
+    ) -> None:
+        try:
+            step_summaries = trace_module.list_step_timing_summaries(trace_id=trace_id)
+            trace_summary_dict = trace_module.get_trace_timing_summary(
+                trace_id=trace_id,
+                total_duration_ms=total_duration_ms,
+                steps=step_count,
+            )
+            if trace_summary_dict is not None:
+                await asyncio.to_thread(
+                    self.store.append_event,
+                    task_id=task_id,
+                    event_type="trace_summary",
+                    payload={
+                        "summary": trace_summary_dict,
+                        "step_summaries": step_summaries,
+                    },
+                    role="system",
+                )
+            record_trace_latency_metrics(
+                source=metrics_source,
+                trace_summary=trace_summary_dict,
+                step_summaries=step_summaries,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to persist trace artifacts for task %s",
+                task_id,
+                exc_info=True,
+            )
+
+    async def _finalize_traced_task(
+        self,
+        *,
+        task_id: str,
+        trace_id: str,
+        status: str,
+        final_message: str,
+        stop_reason: str | None,
+        step_count: int,
+        metrics_source: str,
+        start_perf: float,
+    ) -> None:
+        total_duration_ms = int((time.perf_counter() - start_perf) * 1000)
+        try:
+            with trace_module.trace_context(trace_id, reset_stack=False):
+                await self._finalize_task(
+                    task_id=task_id,
+                    status=status,
+                    final_message=final_message,
+                    stop_reason=stop_reason,
+                    step_count=step_count,
+                    trace_id=trace_id,
+                )
+                await self._record_trace_artifacts(
+                    task_id=task_id,
+                    trace_id=trace_id,
+                    metrics_source=metrics_source,
+                    step_count=step_count,
+                    total_duration_ms=total_duration_ms,
+                )
+        finally:
+            trace_module.clear_trace_data(trace_id)
+
     async def _device_worker(self, device_id: str) -> None:
         try:
             while not self._shutdown:
@@ -307,6 +380,7 @@ class TaskManager:
         session_id = task["session_id"] or task_id
         context = f"chat:{session_id}"
         trace_id = trace_module.create_trace_id()
+        start_perf = time.perf_counter()
         acquired = False
         final_status = TaskStatus.FAILED.value
         final_message = ""
@@ -316,6 +390,7 @@ class TaskManager:
 
         try:
             with trace_module.trace_context(trace_id):
+                await asyncio.to_thread(self.store.set_task_trace_id, task_id, trace_id)
                 acquired = await manager.acquire_device_async(
                     device_id,
                     auto_initialize=True,
@@ -417,22 +492,15 @@ class TaskManager:
                 final_message = "Task cancelled by user"
                 final_status = TaskStatus.CANCELLED.value
                 stop_reason = "user_stopped"
-                await asyncio.to_thread(
-                    self.store.append_event,
+                await self._finalize_traced_task(
                     task_id=task_id,
-                    event_type="cancelled",
-                    payload={
-                        "message": final_message,
-                        "stop_reason": stop_reason,
-                    },
-                    role="assistant",
-                )
-                await self._finalize_task(
-                    task_id=task_id,
+                    trace_id=trace_id,
                     status=final_status,
                     final_message=final_message,
                     stop_reason=stop_reason,
                     step_count=step_count,
+                    metrics_source="chat",
+                    start_perf=start_perf,
                 )
                 return
             raise
@@ -440,37 +508,16 @@ class TaskManager:
             final_message = f"Device {device_id} is busy. Please wait."
             final_status = TaskStatus.FAILED.value
             stop_reason = "device_busy"
-            await asyncio.to_thread(
-                self.store.append_event,
-                task_id=task_id,
-                event_type="error",
-                payload={"message": final_message, "stop_reason": stop_reason},
-                role="assistant",
-            )
         except AgentInitializationError as exc:
             final_message = (
                 f"初始化失败: {exc}. 请检查全局配置 (base_url, api_key, model_name)"
             )
             final_status = TaskStatus.FAILED.value
             stop_reason = "initialization_failed"
-            await asyncio.to_thread(
-                self.store.append_event,
-                task_id=task_id,
-                event_type="error",
-                payload={"message": final_message, "stop_reason": stop_reason},
-                role="assistant",
-            )
         except Exception as exc:
             final_message = str(exc)
             final_status = TaskStatus.FAILED.value
             stop_reason = "error"
-            await asyncio.to_thread(
-                self.store.append_event,
-                task_id=task_id,
-                event_type="error",
-                payload={"message": final_message, "stop_reason": stop_reason},
-                role="assistant",
-            )
         finally:
             self._cancel_requested.discard(task_id)
             self._abort_handlers.pop(task_id, None)
@@ -485,12 +532,15 @@ class TaskManager:
             if acquired:
                 manager.release_device(device_id, context=context)
 
-        await self._finalize_task(
+        await self._finalize_traced_task(
             task_id=task_id,
+            trace_id=trace_id,
             status=final_status,
             final_message=final_message,
             stop_reason=stop_reason,
             step_count=step_count,
+            metrics_source="chat",
+            start_perf=start_perf,
         )
 
     async def _execute_layered_chat(self, task: TaskRecord) -> None:
@@ -509,8 +559,6 @@ class TaskManager:
         clear_session_after_run: bool,
         metrics_source: str,
     ) -> None:
-        from datetime import datetime
-
         from AutoGLM_GUI.layered_agent_service import (
             reset_session as reset_layered_session,
             start_run,
@@ -518,7 +566,7 @@ class TaskManager:
 
         task_id = str(task["id"])
         trace_id = trace_module.create_trace_id()
-        start_time = datetime.now()
+        start_perf = time.perf_counter()
         final_status = TaskStatus.FAILED.value
         final_message = ""
         stop_reason = "error"
@@ -527,6 +575,7 @@ class TaskManager:
 
         try:
             with trace_module.trace_context(trace_id):
+                await asyncio.to_thread(self.store.set_task_trace_id, task_id, trace_id)
                 run = start_run(
                     task_id=task_id,
                     session_id=session_id,
@@ -588,53 +637,26 @@ class TaskManager:
                 final_message = "Task cancelled by user"
                 final_status = TaskStatus.CANCELLED.value
                 stop_reason = "user_stopped"
-                await asyncio.to_thread(
-                    self.store.append_event,
-                    task_id=task_id,
-                    event_type="cancelled",
-                    payload={
-                        "message": final_message,
-                        "stop_reason": stop_reason,
-                    },
-                    role="assistant",
-                )
             else:
                 final_message = str(exc)
                 final_status = TaskStatus.FAILED.value
                 stop_reason = "error"
-                await asyncio.to_thread(
-                    self.store.append_event,
-                    task_id=task_id,
-                    event_type="error",
-                    payload={"message": final_message, "stop_reason": stop_reason},
-                    role="assistant",
-                )
         finally:
             self._cancel_requested.discard(task_id)
             self._abort_handlers.pop(task_id, None)
             if clear_session_after_run:
                 reset_layered_session(session_id)
 
-        await self._finalize_task(
+        await self._finalize_traced_task(
             task_id=task_id,
+            trace_id=trace_id,
             status=final_status,
             final_message=final_message,
             stop_reason=stop_reason,
             step_count=step_count,
+            metrics_source=metrics_source,
+            start_perf=start_perf,
         )
-
-        end_time = datetime.now()
-        duration_ms = int((end_time - start_time).total_seconds() * 1000)
-        trace_summary_dict = trace_module.get_trace_timing_summary(
-            trace_id=trace_id,
-            total_duration_ms=duration_ms,
-        )
-        record_trace_latency_metrics(
-            source=metrics_source,
-            trace_summary=trace_summary_dict,
-            step_summaries=[],
-        )
-        trace_module.clear_trace_data(trace_id)
 
     async def _execute_scheduled_layered_workflow(self, task: TaskRecord) -> None:
         await self._execute_layered_task(
@@ -649,9 +671,11 @@ class TaskManager:
         from AutoGLM_GUI.phone_agent_manager import PhoneAgentManager
 
         manager = PhoneAgentManager.get_instance()
-        task_id = task["id"]
-        device_id = task["device_id"]
+        task_id = str(task["id"])
+        device_id = str(task["device_id"])
         context = "scheduled"
+        trace_id = trace_module.create_trace_id()
+        start_perf = time.perf_counter()
         acquired = False
         final_status = TaskStatus.FAILED.value
         final_message = ""
@@ -660,167 +684,146 @@ class TaskManager:
         abort_registered = False
 
         try:
-            acquired = await manager.acquire_device_async(
-                device_id,
-                auto_initialize=True,
-                context=context,
-            )
-            agent = await asyncio.to_thread(
-                manager.get_agent_with_context,
-                device_id,
-                context=context,
-                agent_type=None,
-            )
+            with trace_module.trace_context(trace_id):
+                await asyncio.to_thread(self.store.set_task_trace_id, task_id, trace_id)
+                acquired = await manager.acquire_device_async(
+                    device_id,
+                    auto_initialize=True,
+                    context=context,
+                )
+                agent = await asyncio.to_thread(
+                    manager.get_agent_with_context,
+                    device_id,
+                    context=context,
+                    agent_type=None,
+                )
 
-            async def cancel_handler() -> None:
-                await agent.cancel()
+                async def cancel_handler() -> None:
+                    await agent.cancel()
 
-            self._abort_handlers[task_id] = cancel_handler
-            self._register_abort_handler(
-                manager,
-                device_id,
-                cancel_handler,
-                context=context,
-            )
-            abort_registered = True
-            agent.reset()
+                self._abort_handlers[task_id] = cancel_handler
+                self._register_abort_handler(
+                    manager,
+                    device_id,
+                    cancel_handler,
+                    context=context,
+                )
+                abort_registered = True
+                agent.reset()
 
-            # Early cancel: if cancel was requested before streaming started
-            if task_id in self._cancel_requested:
-                final_message = "Task cancelled by user"
-                final_status = TaskStatus.CANCELLED.value
-                stop_reason = "user_stopped"
-            else:
-                async for event in agent.stream(task["input_text"]):
-                    event_type = event["type"]
-                    event_data = dict(event.get("data", {}))
-                    if event_type == "thinking":
-                        await asyncio.to_thread(
-                            self.store.append_event,
-                            task_id=task_id,
-                            event_type="thinking",
-                            payload=event_data,
-                            role="assistant",
-                        )
-                    elif event_type == "step":
-                        step_count = max(step_count, int(event_data.get("step", 0)))
-                        await asyncio.to_thread(
-                            self.store.append_event,
-                            task_id=task_id,
-                            event_type="step",
-                            payload=event_data,
-                            role="assistant",
-                        )
-                    elif event_type == "done":
-                        final_message = str(event_data.get("message", "Task completed"))
-                        final_status = (
-                            TaskStatus.SUCCEEDED.value
-                            if event_data.get("success", False)
-                            else TaskStatus.FAILED.value
-                        )
-                        stop_reason = str(
-                            event_data.get(
-                                "stop_reason",
-                                "completed"
-                                if event_data.get("success", False)
-                                else "error",
+                # Early cancel: if cancel was requested before streaming started
+                if task_id in self._cancel_requested:
+                    final_message = "Task cancelled by user"
+                    final_status = TaskStatus.CANCELLED.value
+                    stop_reason = "user_stopped"
+                else:
+                    async for event in agent.stream(task["input_text"]):
+                        event_type = event["type"]
+                        event_data = dict(event.get("data", {}))
+                        if event_type == "thinking":
+                            await asyncio.to_thread(
+                                self.store.append_event,
+                                task_id=task_id,
+                                event_type="thinking",
+                                payload=event_data,
+                                role="assistant",
                             )
-                        )
-                        step_count = int(event_data.get("steps", step_count))
-                    elif event_type == "error":
-                        final_message = str(event_data.get("message", "Task failed"))
-                        final_status = TaskStatus.FAILED.value
-                        stop_reason = str(event_data.get("stop_reason", "error"))
-                        await asyncio.to_thread(
-                            self.store.append_event,
-                            task_id=task_id,
-                            event_type="error",
-                            payload={
-                                "message": final_message,
-                                "stop_reason": stop_reason,
-                            },
-                            role="assistant",
-                        )
-                    elif event_type == "cancelled":
-                        final_message = str(
-                            event_data.get("message", "Task cancelled by user")
-                        )
-                        final_status = TaskStatus.CANCELLED.value
-                        stop_reason = str(event_data.get("stop_reason", "user_stopped"))
+                        elif event_type == "step":
+                            step_count = max(
+                                step_count,
+                                int(event_data.get("step", 0)),
+                            )
+                            timings = trace_module.get_step_timing_summary(
+                                step_count,
+                                trace_id=trace_id,
+                            )
+                            if timings is not None:
+                                event_data = {**event_data, "timings": timings}
+                            await asyncio.to_thread(
+                                self.store.append_event,
+                                task_id=task_id,
+                                event_type="step",
+                                payload=event_data,
+                                role="assistant",
+                            )
+                        elif event_type == "done":
+                            final_message = str(
+                                event_data.get("message", "Task completed")
+                            )
+                            final_status = (
+                                TaskStatus.SUCCEEDED.value
+                                if event_data.get("success", False)
+                                else TaskStatus.FAILED.value
+                            )
+                            stop_reason = str(
+                                event_data.get(
+                                    "stop_reason",
+                                    "completed"
+                                    if event_data.get("success", False)
+                                    else "error",
+                                )
+                            )
+                            step_count = int(event_data.get("steps", step_count))
+                        elif event_type == "error":
+                            final_message = str(
+                                event_data.get("message", "Task failed")
+                            )
+                            final_status = TaskStatus.FAILED.value
+                            stop_reason = str(event_data.get("stop_reason", "error"))
+                            await asyncio.to_thread(
+                                self.store.append_event,
+                                task_id=task_id,
+                                event_type="error",
+                                payload={
+                                    "message": final_message,
+                                    "stop_reason": stop_reason,
+                                },
+                                role="assistant",
+                            )
+                        elif event_type == "cancelled":
+                            final_message = str(
+                                event_data.get("message", "Task cancelled by user")
+                            )
+                            final_status = TaskStatus.CANCELLED.value
+                            stop_reason = str(
+                                event_data.get("stop_reason", "user_stopped")
+                            )
 
-            if not final_message:
-                final_message = "Task finished without a final response"
-                final_status = TaskStatus.FAILED.value
-                stop_reason = "error"
+                if not final_message:
+                    final_message = "Task finished without a final response"
+                    final_status = TaskStatus.FAILED.value
+                    stop_reason = "error"
 
-            # If cancel was requested but the stream exited normally,
-            # override status to CANCELLED.
-            if (
-                task_id in self._cancel_requested
-                and final_status != TaskStatus.CANCELLED.value
-            ):
-                final_message = "Task cancelled by user"
-                final_status = TaskStatus.CANCELLED.value
-                stop_reason = "user_stopped"
+                # If cancel was requested but the stream exited normally,
+                # override status to CANCELLED.
+                if (
+                    task_id in self._cancel_requested
+                    and final_status != TaskStatus.CANCELLED.value
+                ):
+                    final_message = "Task cancelled by user"
+                    final_status = TaskStatus.CANCELLED.value
+                    stop_reason = "user_stopped"
         except asyncio.CancelledError:
             if task_id in self._cancel_requested:
                 final_message = "Task cancelled by user"
                 final_status = TaskStatus.CANCELLED.value
                 stop_reason = "user_stopped"
-                await asyncio.to_thread(
-                    self.store.append_event,
-                    task_id=task_id,
-                    event_type="cancelled",
-                    payload={
-                        "message": final_message,
-                        "stop_reason": stop_reason,
-                    },
-                    role="assistant",
-                )
-                await self._finalize_task(
-                    task_id=task_id,
-                    status=final_status,
-                    final_message=final_message,
-                    stop_reason=stop_reason,
-                    step_count=step_count,
-                )
-                return
-            raise
+            else:
+                raise
         except DeviceBusyError:
             final_message = f"Device {device_id} is busy. Please wait."
             final_status = TaskStatus.FAILED.value
             stop_reason = "device_busy"
-            await asyncio.to_thread(
-                self.store.append_event,
-                task_id=task_id,
-                event_type="error",
-                payload={"message": final_message, "stop_reason": stop_reason},
-                role="assistant",
-            )
         except AgentInitializationError as exc:
             final_message = (
                 f"初始化失败: {exc}. 请检查全局配置 (base_url, api_key, model_name)"
             )
             final_status = TaskStatus.FAILED.value
             stop_reason = "initialization_failed"
-            await asyncio.to_thread(
-                self.store.append_event,
-                task_id=task_id,
-                event_type="error",
-                payload={"message": final_message, "stop_reason": stop_reason},
-                role="assistant",
-            )
         except Exception as exc:
             final_message = str(exc)
             final_status = TaskStatus.FAILED.value
             stop_reason = "error"
-            await asyncio.to_thread(
-                self.store.append_event,
-                task_id=task_id,
-                event_type="error",
-                payload={"message": final_message, "stop_reason": stop_reason},
-                role="assistant",
-            )
         finally:
             self._cancel_requested.discard(task_id)
             self._abort_handlers.pop(task_id, None)
@@ -835,12 +838,15 @@ class TaskManager:
             if acquired:
                 manager.release_device(device_id, context=context)
 
-        await self._finalize_task(
+        await self._finalize_traced_task(
             task_id=task_id,
+            trace_id=trace_id,
             status=final_status,
             final_message=final_message,
             stop_reason=stop_reason,
             step_count=step_count,
+            metrics_source="scheduled",
+            start_perf=start_perf,
         )
 
     async def _finalize_task(
@@ -851,6 +857,7 @@ class TaskManager:
         final_message: str,
         step_count: int,
         stop_reason: str | None = None,
+        trace_id: str | None = None,
     ) -> None:
         normalized_stop_reason = stop_reason
         if normalized_stop_reason is None:
@@ -903,6 +910,7 @@ class TaskManager:
             error_message=error_message,
             stop_reason=normalized_stop_reason,
             step_count=step_count,
+            trace_id=trace_id,
         )
         self._mark_task_complete(task_id)
 

--- a/AutoGLM_GUI/task_manager.py
+++ b/AutoGLM_GUI/task_manager.py
@@ -327,6 +327,7 @@ class TaskManager:
                     stop_reason=stop_reason,
                     step_count=step_count,
                     trace_id=trace_id,
+                    mark_complete=False,
                 )
                 await self._record_trace_artifacts(
                     task_id=task_id,
@@ -335,6 +336,7 @@ class TaskManager:
                     step_count=step_count,
                     total_duration_ms=total_duration_ms,
                 )
+                self._mark_task_complete(task_id)
         finally:
             trace_module.clear_trace_data(trace_id)
 
@@ -858,6 +860,7 @@ class TaskManager:
         step_count: int,
         stop_reason: str | None = None,
         trace_id: str | None = None,
+        mark_complete: bool = True,
     ) -> None:
         normalized_stop_reason = stop_reason
         if normalized_stop_reason is None:
@@ -912,7 +915,8 @@ class TaskManager:
             step_count=step_count,
             trace_id=trace_id,
         )
-        self._mark_task_complete(task_id)
+        if mark_complete:
+            self._mark_task_complete(task_id)
 
     async def _fail_task(self, task: TaskRecord, message: str) -> None:
         await asyncio.to_thread(

--- a/AutoGLM_GUI/task_store.py
+++ b/AutoGLM_GUI/task_store.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from .trace import current_trace_id, trace_span
+
 
 def _now_iso() -> str:
     return datetime.now().isoformat()
@@ -105,6 +107,7 @@ class TaskStore:
                 final_message TEXT NULL,
                 error_message TEXT NULL,
                 stop_reason TEXT NULL,
+                trace_id TEXT NULL,
                 step_count INTEGER NOT NULL DEFAULT 0,
                 created_at TEXT NOT NULL,
                 started_at TEXT NULL,
@@ -146,6 +149,8 @@ class TaskStore:
         }
         if "stop_reason" not in columns:
             self._conn.execute("ALTER TABLE task_runs ADD COLUMN stop_reason TEXT NULL")
+        if "trace_id" not in columns:
+            self._conn.execute("ALTER TABLE task_runs ADD COLUMN trace_id TEXT NULL")
         self._conn.commit()
 
     def _fetchone(self, query: str, params: tuple[Any, ...] = ()) -> sqlite3.Row | None:
@@ -189,27 +194,38 @@ class TaskStore:
         self._ensure_ready()
         now = _now_iso()
         record_id = session_id or str(uuid4())
-        with self._lock:
-            assert self._conn is not None
-            self._conn.execute(
-                """
-                INSERT INTO task_sessions (
-                    id, kind, mode, device_id, device_serial, status, created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    record_id,
-                    kind,
-                    mode,
-                    device_id,
-                    device_serial,
-                    status,
-                    now,
-                    now,
-                ),
-            )
-            self._conn.commit()
-            return self.get_session(record_id) or {}
+        with trace_span(
+            "task_store.session.create",
+            attrs={
+                "session_id": record_id,
+                "kind": kind,
+                "mode": mode,
+                "device_id": device_id,
+                "device_serial": device_serial,
+                "status": status,
+            },
+        ):
+            with self._lock:
+                assert self._conn is not None
+                self._conn.execute(
+                    """
+                    INSERT INTO task_sessions (
+                        id, kind, mode, device_id, device_serial, status, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        record_id,
+                        kind,
+                        mode,
+                        device_id,
+                        device_serial,
+                        status,
+                        now,
+                        now,
+                    ),
+                )
+                self._conn.commit()
+                return self.get_session(record_id) or {}
 
     def get_session(self, session_id: str) -> TaskSessionRecord | None:
         self._ensure_ready()
@@ -223,13 +239,17 @@ class TaskStore:
 
     def update_session_timestamp(self, session_id: str) -> None:
         self._ensure_ready()
-        with self._lock:
-            assert self._conn is not None
-            self._conn.execute(
-                "UPDATE task_sessions SET updated_at = ? WHERE id = ?",
-                (_now_iso(), session_id),
-            )
-            self._conn.commit()
+        with trace_span(
+            "task_store.session.touch",
+            attrs={"session_id": session_id},
+        ):
+            with self._lock:
+                assert self._conn is not None
+                self._conn.execute(
+                    "UPDATE task_sessions SET updated_at = ? WHERE id = ?",
+                    (_now_iso(), session_id),
+                )
+                self._conn.commit()
 
     def get_latest_open_chat_session(
         self, *, device_id: str, device_serial: str, mode: str = "classic"
@@ -254,18 +274,22 @@ class TaskStore:
 
     def archive_session(self, session_id: str) -> TaskSessionRecord | None:
         self._ensure_ready()
-        with self._lock:
-            assert self._conn is not None
-            self._conn.execute(
-                """
-                UPDATE task_sessions
-                SET status = ?, updated_at = ?
-                WHERE id = ?
-                """,
-                (TaskSessionStatus.ARCHIVED.value, _now_iso(), session_id),
-            )
-            self._conn.commit()
-            return self.get_session(session_id)
+        with trace_span(
+            "task_store.session.archive",
+            attrs={"session_id": session_id},
+        ):
+            with self._lock:
+                assert self._conn is not None
+                self._conn.execute(
+                    """
+                    UPDATE task_sessions
+                    SET status = ?, updated_at = ?
+                    WHERE id = ?
+                    """,
+                    (TaskSessionStatus.ARCHIVED.value, _now_iso(), session_id),
+                )
+                self._conn.commit()
+                return self.get_session(session_id)
 
     def _append_event_locked(
         self,
@@ -314,16 +338,26 @@ class TaskStore:
         role: str = "assistant",
     ) -> TaskEventRecord:
         self._ensure_ready()
-        with self._lock:
-            assert self._conn is not None
-            event = self._append_event_locked(
-                task_id=task_id,
-                event_type=event_type,
-                role=role,
-                payload=payload,
-            )
-            self._conn.commit()
-            return event
+        with trace_span(
+            "task_store.event.append",
+            attrs={
+                "task_id": task_id,
+                "event_type": event_type,
+                "role": role,
+                "payload_keys": sorted(payload.keys()),
+            },
+        ) as span:
+            with self._lock:
+                assert self._conn is not None
+                event = self._append_event_locked(
+                    task_id=task_id,
+                    event_type=event_type,
+                    role=role,
+                    payload=payload,
+                )
+                span.set_attribute("seq", event.get("seq"))
+                self._conn.commit()
+                return event
 
     def create_task_run(
         self,
@@ -339,48 +373,83 @@ class TaskStore:
         schedule_fire_id: str | None = None,
         status: str = TaskStatus.QUEUED.value,
         task_id: str | None = None,
+        trace_id: str | None = None,
     ) -> TaskRecord:
         self._ensure_ready()
         now = _now_iso()
         record_id = task_id or str(uuid4())
-        with self._lock:
-            assert self._conn is not None
-            self._conn.execute(
-                """
-                INSERT INTO task_runs (
-                    id, source, executor_key, session_id, scheduled_task_id, workflow_uuid,
-                    schedule_fire_id, device_id, device_serial, status, input_text,
-                    final_message, error_message, stop_reason, step_count, created_at, started_at, finished_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, 0, ?, NULL, NULL)
-                """,
-                (
-                    record_id,
-                    source,
-                    executor_key,
-                    session_id,
-                    scheduled_task_id,
-                    workflow_uuid,
-                    schedule_fire_id,
-                    device_id,
-                    device_serial,
-                    status,
-                    input_text,
-                    now,
-                ),
-            )
-            if session_id:
+        task_trace_id = trace_id or current_trace_id()
+        with trace_span(
+            "task_store.task.create",
+            attrs={
+                "task_id": record_id,
+                "source": source,
+                "executor_key": executor_key,
+                "session_id": session_id,
+                "scheduled_task_id": scheduled_task_id,
+                "workflow_uuid": workflow_uuid,
+                "schedule_fire_id": schedule_fire_id,
+                "device_id": device_id,
+                "device_serial": device_serial,
+                "status": status,
+                "trace_id": task_trace_id,
+            },
+        ):
+            with self._lock:
+                assert self._conn is not None
                 self._conn.execute(
-                    "UPDATE task_sessions SET updated_at = ? WHERE id = ?",
-                    (now, session_id),
+                    """
+                    INSERT INTO task_runs (
+                        id, source, executor_key, session_id, scheduled_task_id, workflow_uuid,
+                        schedule_fire_id, device_id, device_serial, status, input_text,
+                        final_message, error_message, stop_reason, trace_id, step_count,
+                        created_at, started_at, finished_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, 0, ?, NULL, NULL)
+                    """,
+                    (
+                        record_id,
+                        source,
+                        executor_key,
+                        session_id,
+                        scheduled_task_id,
+                        workflow_uuid,
+                        schedule_fire_id,
+                        device_id,
+                        device_serial,
+                        status,
+                        input_text,
+                        task_trace_id,
+                        now,
+                    ),
                 )
-            self._append_event_locked(
-                task_id=record_id,
-                event_type="status",
-                role="system",
-                payload={"status": status},
-            )
-            self._conn.commit()
-            return self.get_task(record_id) or {}
+                if session_id:
+                    self._conn.execute(
+                        "UPDATE task_sessions SET updated_at = ? WHERE id = ?",
+                        (now, session_id),
+                    )
+                self._append_event_locked(
+                    task_id=record_id,
+                    event_type="status",
+                    role="system",
+                    payload={"status": status},
+                )
+                self._conn.commit()
+                return self.get_task(record_id) or {}
+
+    def set_task_trace_id(self, task_id: str, trace_id: str) -> TaskRecord | None:
+        self._ensure_ready()
+        with trace_span(
+            "task_store.task.set_trace_id",
+            attrs={"task_id": task_id, "trace_id": trace_id},
+        ):
+            with self._lock:
+                assert self._conn is not None
+                self._conn.execute(
+                    "UPDATE task_runs SET trace_id = ? WHERE id = ?",
+                    (trace_id, task_id),
+                )
+                self._conn.commit()
+                return self.get_task(task_id)
 
     def get_task(self, task_id: str) -> TaskRecord | None:
         self._ensure_ready()
@@ -480,46 +549,53 @@ class TaskStore:
 
     def claim_next_queued_task(self, device_id: str) -> TaskRecord | None:
         self._ensure_ready()
-        with self._lock:
-            assert self._conn is not None
-            row = self._fetchone(
-                """
-                SELECT * FROM task_runs
-                WHERE device_id = ? AND status = ?
-                ORDER BY created_at ASC, id ASC
-                LIMIT 1
-                """,
-                (device_id, TaskStatus.QUEUED.value),
-            )
-            if row is None:
-                return None
+        with trace_span(
+            "task_store.task.claim",
+            attrs={"device_id": device_id, "target_status": TaskStatus.QUEUED.value},
+        ) as span:
+            with self._lock:
+                assert self._conn is not None
+                row = self._fetchone(
+                    """
+                    SELECT * FROM task_runs
+                    WHERE device_id = ? AND status = ?
+                    ORDER BY created_at ASC, id ASC
+                    LIMIT 1
+                    """,
+                    (device_id, TaskStatus.QUEUED.value),
+                )
+                if row is None:
+                    span.set_attribute("claimed", False)
+                    return None
 
-            now = _now_iso()
-            cursor = self._conn.execute(
-                """
-                UPDATE task_runs
-                SET status = ?, started_at = ?
-                WHERE id = ? AND status = ?
-                """,
-                (
-                    TaskStatus.RUNNING.value,
-                    now,
-                    row["id"],
-                    TaskStatus.QUEUED.value,
-                ),
-            )
-            if cursor.rowcount != 1:
-                self._conn.rollback()
-                return None
+                now = _now_iso()
+                cursor = self._conn.execute(
+                    """
+                    UPDATE task_runs
+                    SET status = ?, started_at = ?
+                    WHERE id = ? AND status = ?
+                    """,
+                    (
+                        TaskStatus.RUNNING.value,
+                        now,
+                        row["id"],
+                        TaskStatus.QUEUED.value,
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    self._conn.rollback()
+                    span.set_attribute("claimed", False)
+                    return None
 
-            self._append_event_locked(
-                task_id=row["id"],
-                event_type="status",
-                role="system",
-                payload={"status": TaskStatus.RUNNING.value},
-            )
-            self._conn.commit()
-            return self.get_task(str(row["id"]))
+                self._append_event_locked(
+                    task_id=row["id"],
+                    event_type="status",
+                    role="system",
+                    payload={"status": TaskStatus.RUNNING.value},
+                )
+                self._conn.commit()
+                span.set_attributes({"claimed": True, "task_id": str(row["id"])})
+                return self.get_task(str(row["id"]))
 
     def update_task_terminal(
         self,
@@ -530,105 +606,37 @@ class TaskStore:
         error_message: str | None,
         stop_reason: str | None = None,
         step_count: int = 0,
+        trace_id: str | None = None,
     ) -> TaskRecord | None:
         self._ensure_ready()
-        with self._lock:
-            assert self._conn is not None
-            self._conn.execute(
-                """
-                UPDATE task_runs
-                SET status = ?, final_message = ?, error_message = ?, stop_reason = ?, step_count = ?, finished_at = ?
-                WHERE id = ?
-                """,
-                (
-                    status,
-                    final_message,
-                    error_message,
-                    stop_reason,
-                    step_count,
-                    _now_iso(),
-                    task_id,
-                ),
-            )
-            self._append_event_locked(
-                task_id=task_id,
-                event_type="status",
-                role="system",
-                payload={"status": status},
-            )
-            self._conn.commit()
-            return self.get_task(task_id)
-
-    def cancel_queued_task(
-        self, task_id: str, message: str = "Task cancelled before execution"
-    ) -> TaskRecord | None:
-        self._ensure_ready()
-        with self._lock:
-            assert self._conn is not None
-            row = self._fetchone("SELECT * FROM task_runs WHERE id = ?", (task_id,))
-            if row is None or row["status"] != TaskStatus.QUEUED.value:
-                return None
-
-            finished_at = _now_iso()
-            self._conn.execute(
-                """
-                UPDATE task_runs
-                SET status = ?, final_message = ?, error_message = ?, stop_reason = ?, finished_at = ?
-                WHERE id = ?
-                """,
-                (
-                    TaskStatus.CANCELLED.value,
-                    message,
-                    message,
-                    "user_stopped",
-                    finished_at,
-                    task_id,
-                ),
-            )
-            self._append_event_locked(
-                task_id=task_id,
-                event_type="cancelled",
-                role="assistant",
-                payload={"message": message},
-            )
-            self._append_event_locked(
-                task_id=task_id,
-                event_type="status",
-                role="system",
-                payload={"status": TaskStatus.CANCELLED.value},
-            )
-            self._conn.commit()
-            return self.get_task(task_id)
-
-    def mark_running_tasks_interrupted(
-        self,
-        message: str = "Task interrupted because the service restarted",
-    ) -> int:
-        self._ensure_ready()
-        with self._lock:
-            assert self._conn is not None
-            rows = self._fetchall(
-                "SELECT id FROM task_runs WHERE status = ?",
-                (TaskStatus.RUNNING.value,),
-            )
-            if not rows:
-                return 0
-
-            now = _now_iso()
-            for row in rows:
-                task_id = str(row["id"])
+        task_trace_id = trace_id or current_trace_id()
+        with trace_span(
+            "task_store.task.finish",
+            attrs={
+                "task_id": task_id,
+                "status": status,
+                "stop_reason": stop_reason,
+                "step_count": step_count,
+                "trace_id": task_trace_id,
+            },
+        ):
+            with self._lock:
+                assert self._conn is not None
                 self._conn.execute(
                     """
                     UPDATE task_runs
-                    SET status = ?, final_message = ?, error_message = ?, stop_reason = ?, finished_at = ?
+                    SET status = ?, final_message = ?, error_message = ?, stop_reason = ?,
+                        step_count = ?, trace_id = COALESCE(?, trace_id), finished_at = ?
                     WHERE id = ?
                     """,
                     (
-                        TaskStatus.INTERRUPTED.value,
-                        message,
-                        message,
-                        "service_interrupted",
-                        now,
+                        status,
+                        final_message,
+                        error_message,
+                        stop_reason,
+                        step_count,
+                        task_trace_id,
+                        _now_iso(),
                         task_id,
                     ),
                 )
@@ -636,16 +644,107 @@ class TaskStore:
                     task_id=task_id,
                     event_type="status",
                     role="system",
-                    payload={"status": TaskStatus.INTERRUPTED.value},
+                    payload={"status": status},
+                )
+                self._conn.commit()
+                return self.get_task(task_id)
+
+    def cancel_queued_task(
+        self, task_id: str, message: str = "Task cancelled before execution"
+    ) -> TaskRecord | None:
+        self._ensure_ready()
+        with trace_span(
+            "task_store.task.cancel",
+            attrs={"task_id": task_id},
+        ) as span:
+            with self._lock:
+                assert self._conn is not None
+                row = self._fetchone("SELECT * FROM task_runs WHERE id = ?", (task_id,))
+                if row is None or row["status"] != TaskStatus.QUEUED.value:
+                    span.set_attribute("cancelled", False)
+                    return None
+
+                finished_at = _now_iso()
+                self._conn.execute(
+                    """
+                    UPDATE task_runs
+                    SET status = ?, final_message = ?, error_message = ?, stop_reason = ?, finished_at = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        TaskStatus.CANCELLED.value,
+                        message,
+                        message,
+                        "user_stopped",
+                        finished_at,
+                        task_id,
+                    ),
                 )
                 self._append_event_locked(
                     task_id=task_id,
-                    event_type="error",
+                    event_type="cancelled",
                     role="assistant",
                     payload={"message": message},
                 )
-            self._conn.commit()
-            return len(rows)
+                self._append_event_locked(
+                    task_id=task_id,
+                    event_type="status",
+                    role="system",
+                    payload={"status": TaskStatus.CANCELLED.value},
+                )
+                self._conn.commit()
+                span.set_attribute("cancelled", True)
+                return self.get_task(task_id)
+
+    def mark_running_tasks_interrupted(
+        self,
+        message: str = "Task interrupted because the service restarted",
+    ) -> int:
+        self._ensure_ready()
+        with trace_span("task_store.task.interrupt_running") as span:
+            with self._lock:
+                assert self._conn is not None
+                rows = self._fetchall(
+                    "SELECT id FROM task_runs WHERE status = ?",
+                    (TaskStatus.RUNNING.value,),
+                )
+                if not rows:
+                    span.set_attribute("interrupted_count", 0)
+                    return 0
+
+                now = _now_iso()
+                for row in rows:
+                    task_id = str(row["id"])
+                    self._conn.execute(
+                        """
+                        UPDATE task_runs
+                        SET status = ?, final_message = ?, error_message = ?, stop_reason = ?, finished_at = ?
+                        WHERE id = ?
+                        """,
+                        (
+                            TaskStatus.INTERRUPTED.value,
+                            message,
+                            message,
+                            "service_interrupted",
+                            now,
+                            task_id,
+                        ),
+                    )
+                    self._append_event_locked(
+                        task_id=task_id,
+                        event_type="status",
+                        role="system",
+                        payload={"status": TaskStatus.INTERRUPTED.value},
+                    )
+                    self._append_event_locked(
+                        task_id=task_id,
+                        event_type="error",
+                        role="assistant",
+                        payload={"message": message},
+                    )
+                self._conn.commit()
+                span.set_attribute("interrupted_count", len(rows))
+                return len(rows)
 
     def get_queued_device_ids(self) -> list[str]:
         self._ensure_ready()

--- a/frontend/e2e/trace-events.spec.ts
+++ b/frontend/e2e/trace-events.spec.ts
@@ -1,0 +1,308 @@
+/**
+ * Trace event integration E2E test.
+ *
+ * This test drives the real React UI with Playwright, while the existing
+ * E2E launcher runs the real backend plus mock LLM and mock device services.
+ * The frontend asserts visible debug output; the backend asserts persisted
+ * task events and trace artifacts.
+ */
+import {
+  test,
+  expect,
+  type APIRequestContext,
+  type APIResponse,
+} from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+type ServiceUrls = {
+  llm_url: string;
+  agent_url: string;
+  backend_url: string;
+  frontend_url: string;
+};
+
+type RemoteDeviceAddResponse = {
+  success: boolean;
+  serial: string;
+  message?: string;
+  error?: string;
+};
+
+type TaskRunResponse = {
+  id: string;
+  status: string;
+  trace_id: string | null;
+  step_count: number;
+  final_message: string | null;
+};
+
+type TaskEventRecord = {
+  task_id: string;
+  seq: number;
+  event_type: string;
+  payload: Record<string, unknown>;
+};
+
+type TaskEventListResponse = {
+  events: TaskEventRecord[];
+};
+
+type CommandAction = {
+  action: string;
+  [key: string]: unknown;
+};
+
+const TERMINAL_STATUSES = new Set([
+  'SUCCEEDED',
+  'FAILED',
+  'CANCELLED',
+  'INTERRUPTED',
+]);
+
+function readServiceUrls(): ServiceUrls {
+  const urlsPath = path.resolve(__dirname, '.service_urls.json');
+  if (!fs.existsSync(urlsPath)) {
+    throw new Error(
+      `.service_urls.json not found - ensure start_e2e_services.py is running`
+    );
+  }
+  return JSON.parse(fs.readFileSync(urlsPath, 'utf-8')) as ServiceUrls;
+}
+
+async function assertOk(response: APIResponse, label: string): Promise<void> {
+  if (!response.ok()) {
+    throw new Error(
+      `${label} failed with ${response.status()}: ${await response.text()}`
+    );
+  }
+}
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} was not an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+async function waitForTask(
+  request: APIRequestContext,
+  backendUrl: string,
+  taskId: string
+): Promise<TaskRunResponse> {
+  const deadline = Date.now() + 30000;
+  let latest: TaskRunResponse | null = null;
+
+  while (Date.now() < deadline) {
+    const response = await request.get(`${backendUrl}/api/tasks/${taskId}`);
+    await assertOk(response, 'get task');
+    latest = (await response.json()) as TaskRunResponse;
+    if (TERMINAL_STATUSES.has(latest.status)) {
+      return latest;
+    }
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  throw new Error(
+    `Task ${taskId} did not reach a terminal status. Latest: ${JSON.stringify(
+      latest
+    )}`
+  );
+}
+
+async function waitForTaskEvents(
+  request: APIRequestContext,
+  backendUrl: string,
+  taskId: string,
+  requiredEventTypes: string[]
+): Promise<TaskEventRecord[]> {
+  const deadline = Date.now() + 30000;
+  let latestEvents: TaskEventRecord[] = [];
+
+  while (Date.now() < deadline) {
+    const response = await request.get(
+      `${backendUrl}/api/tasks/${taskId}/events`
+    );
+    await assertOk(response, 'get task events');
+    latestEvents = ((await response.json()) as TaskEventListResponse).events;
+    const eventTypes = latestEvents.map(event => event.event_type);
+    if (requiredEventTypes.every(type => eventTypes.includes(type))) {
+      return latestEvents;
+    }
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  throw new Error(
+    `Task ${taskId} did not emit required events ${requiredEventTypes.join(
+      ', '
+    )}. Latest events: ${latestEvents
+      .map(event => event.event_type)
+      .join(', ')}`
+  );
+}
+
+test.describe('Trace debug surface', () => {
+  test('shows frontend debug output and persists backend trace events', async ({
+    page,
+    request,
+  }) => {
+    const { backend_url, agent_url, llm_url } = readServiceUrls();
+    const testDeviceId = 'mock_device_trace_events';
+
+    await assertOk(
+      await request.post(`${llm_url}/test/set_responses`, {
+        data: [
+          '用户要求点击屏幕下方的消息按钮。我看到底部导航栏有消息按钮。do(action="Tap", element=[499,966])',
+          '好的，点击成功，进入了消息页面。finish(message="已成功点击消息按钮！")',
+        ],
+      }),
+      'set mock LLM responses'
+    );
+    await assertOk(
+      await request.post(`${llm_url}/test/reset`),
+      'reset mock LLM'
+    );
+
+    const deviceResponse = await request.post(
+      `${backend_url}/api/devices/add_remote`,
+      {
+        data: { base_url: agent_url, device_id: testDeviceId },
+      }
+    );
+    await assertOk(deviceResponse, 'add remote device');
+    const deviceData = (await deviceResponse.json()) as RemoteDeviceAddResponse;
+    expect(deviceData.success).toBe(true);
+    expect(deviceData.serial).toBeTruthy();
+
+    await assertOk(
+      await request.post(`${agent_url}/test/reset`),
+      'reset mock device commands'
+    );
+
+    await assertOk(
+      await request.delete(`${backend_url}/api/config`),
+      'clear config'
+    );
+    await assertOk(
+      await request.post(`${backend_url}/api/config`, {
+        data: {
+          base_url: `${llm_url}/v1`,
+          model_name: 'mock-glm-model',
+          api_key: 'mock-key',
+          agent_type: 'glm-async',
+        },
+      }),
+      'save config'
+    );
+
+    await page.goto(
+      `/chat?serial=${encodeURIComponent(deviceData.serial)}&mode=classic`
+    );
+
+    const dialog = page.locator('[role="dialog"]');
+    if (await dialog.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await page.locator('[role="dialog"] button:has-text("Close")').click();
+    }
+
+    const textbox = page.locator('textarea');
+    await expect(textbox).toBeVisible({ timeout: 15000 });
+
+    const taskResponsePromise = page.waitForResponse(response => {
+      return (
+        response.request().method() === 'POST' &&
+        response.url().includes('/api/task-sessions/') &&
+        response.url().endsWith('/tasks')
+      );
+    });
+
+    await textbox.fill('点击屏幕下方的消息按钮');
+    await textbox.press('Meta+Enter');
+
+    const taskResponse = await taskResponsePromise;
+    await assertOk(taskResponse, 'submit task');
+    const submittedTask = (await taskResponse.json()) as TaskRunResponse;
+
+    await expect(
+      page.getByText('点击屏幕下方的消息按钮').first()
+    ).toBeVisible();
+    await expect(page.getByText('Step 1').first()).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(page.getByText(/^LLM /).first()).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(page.getByText(/^Action /).first()).toBeVisible({
+      timeout: 30000,
+    });
+    await page.getByText('View action').first().click();
+    await expect(page.getByText('"action": "Tap"').first()).toBeVisible();
+    await expect(
+      page.locator('p').filter({ hasText: '已成功点击消息按钮' }).first()
+    ).toBeVisible({ timeout: 30000 });
+
+    const finalTask = await waitForTask(request, backend_url, submittedTask.id);
+    expect(finalTask.status).toBe('SUCCEEDED');
+    expect(finalTask.trace_id).toBeTruthy();
+    expect(finalTask.step_count).toBeGreaterThanOrEqual(1);
+
+    const events = await waitForTaskEvents(
+      request,
+      backend_url,
+      submittedTask.id,
+      ['status', 'thinking', 'step', 'done', 'trace_summary']
+    );
+    const eventTypes = events.map(event => event.event_type);
+    expect(eventTypes).toContain('status');
+    expect(eventTypes).toContain('thinking');
+    expect(eventTypes).toContain('step');
+    expect(eventTypes).toContain('done');
+    expect(eventTypes).toContain('trace_summary');
+
+    const stepEvent = events.find(event => event.event_type === 'step');
+    if (!stepEvent) {
+      throw new Error('step event not found');
+    }
+    const action = asRecord(stepEvent.payload.action, 'step action');
+    expect(action.action).toBe('Tap');
+    const timings = asRecord(stepEvent.payload.timings, 'step timings');
+    expect(typeof timings.total_duration_ms).toBe('number');
+    expect(typeof timings.llm_duration_ms).toBe('number');
+    expect(typeof timings.execute_action_duration_ms).toBe('number');
+
+    const traceSummaryEvent = events.find(
+      event => event.event_type === 'trace_summary'
+    );
+    if (!traceSummaryEvent) {
+      throw new Error('trace_summary event not found');
+    }
+    const summary = asRecord(
+      traceSummaryEvent.payload.summary,
+      'trace summary'
+    );
+    expect(summary.trace_id).toBe(finalTask.trace_id);
+    expect(summary.steps).toBeGreaterThanOrEqual(1);
+    const stepSummaries = traceSummaryEvent.payload.step_summaries;
+    expect(Array.isArray(stepSummaries)).toBe(true);
+    expect((stepSummaries as unknown[]).length).toBeGreaterThanOrEqual(1);
+
+    const commandResponse = await request.get(
+      `${agent_url}/test/commands/actions`
+    );
+    await assertOk(commandResponse, 'get mock device commands');
+    const commands = (await commandResponse.json()) as CommandAction[];
+    const commandActions = commands.map(command => command.action);
+    expect(commandActions).toContain('screenshot');
+    expect(commandActions).toContain('tap');
+
+    const tapCommand = commands.find(command => command.action === 'tap');
+    if (!tapCommand) {
+      throw new Error(`tap command not found: ${JSON.stringify(commands)}`);
+    }
+    expect(typeof tapCommand.x).toBe('number');
+    expect(typeof tapCommand.y).toBe('number');
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   testDir: './e2e',
   timeout: 60000,
   retries: 0,
+  workers: 1,
   globalSetup: './e2e/globalSetup.ts',
   globalTeardown: './e2e/globalTeardown.ts',
   use: {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -898,6 +898,8 @@ export interface TaskRunResponse {
   input_text: string;
   final_message: string | null;
   error_message: string | null;
+  stop_reason: string | null;
+  trace_id: string | null;
   step_count: number;
   created_at: string;
   started_at: string | null;

--- a/tests/test_history_api.py
+++ b/tests/test_history_api.py
@@ -427,6 +427,7 @@ def test_history_converts_layered_tool_events_to_messages(
         "input_text": "整理桌面",
         "final_message": "已完成",
         "error_message": None,
+        "trace_id": "trace-layered",
         "step_count": 7,
         "created_at": "2026-02-05T10:00:00",
         "started_at": "2026-02-05T10:00:01",
@@ -473,6 +474,30 @@ def test_history_converts_layered_tool_events_to_messages(
             "payload": {"message": "已完成", "steps": 7, "success": True},
             "created_at": "2026-02-05T10:00:30",
         },
+        {
+            "task_id": "layered-task",
+            "seq": 5,
+            "event_type": "trace_summary",
+            "role": "system",
+            "payload": {
+                "summary": {
+                    "trace_id": "trace-layered",
+                    "steps": 7,
+                    "total_duration_ms": 29000,
+                    "screenshot_duration_ms": 1000,
+                    "current_app_duration_ms": 500,
+                    "llm_duration_ms": 12000,
+                    "parse_action_duration_ms": 200,
+                    "execute_action_duration_ms": 6000,
+                    "update_context_duration_ms": 300,
+                    "adb_duration_ms": 1500,
+                    "sleep_duration_ms": 700,
+                    "other_duration_ms": 800,
+                },
+                "step_summaries": [],
+            },
+            "created_at": "2026-02-05T10:00:31",
+        },
     ]
 
     response = client.get("/api/history/device-1/layered-task")
@@ -489,6 +514,9 @@ def test_history_converts_layered_tool_events_to_messages(
     )
     assert any("已打开设置" in (message.get("content") or "") for message in messages)
     assert any(message.get("content") == "继续下一步" for message in messages)
+    assert data["trace_id"] == "trace-layered"
+    assert data["trace_summary"]["trace_id"] == "trace-layered"
+    assert data["trace_summary"]["llm_duration_ms"] == 12000
 
 
 def test_list_history_validates_limit_and_offset(client: TestClient) -> None:

--- a/tests/test_task_store.py
+++ b/tests/test_task_store.py
@@ -39,6 +39,35 @@ def test_task_store_creates_sessions_and_task_events(tmp_path: Path) -> None:
     assert events[1]["payload"] == {"chunk": "先看屏幕"}
 
 
+def test_task_store_persists_trace_id(tmp_path: Path) -> None:
+    store = TaskStore(tmp_path / "tasks.db")
+
+    task = store.create_task_run(
+        source="chat",
+        executor_key="classic_chat",
+        device_id="device-1",
+        device_serial="serial-1",
+        input_text="打开微信",
+        trace_id="trace-create",
+    )
+    assert task["trace_id"] == "trace-create"
+
+    updated = store.set_task_trace_id(task["id"], "trace-run")
+    assert updated is not None
+    assert updated["trace_id"] == "trace-run"
+
+    finished = store.update_task_terminal(
+        task_id=task["id"],
+        status=TaskStatus.SUCCEEDED.value,
+        final_message="完成",
+        error_message=None,
+        step_count=1,
+        trace_id="trace-finish",
+    )
+    assert finished is not None
+    assert finished["trace_id"] == "trace-finish"
+
+
 def test_task_store_can_cancel_queued_tasks_and_interrupt_running(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_trace_observability_integration.py
+++ b/tests/test_trace_observability_integration.py
@@ -1,0 +1,292 @@
+"""Integration coverage for the task trace debugging surface."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from agents.stream_events import RawResponsesStreamEvent, RunItemStreamEvent
+from prometheus_client import generate_latest
+
+import AutoGLM_GUI.api.history as history_api
+import AutoGLM_GUI.layered_agent_service as layered_service
+from AutoGLM_GUI.actions import ActionHandler
+from AutoGLM_GUI.devices.adb_device import ADBDevice
+from AutoGLM_GUI.metrics import get_metrics_registry, reset_trace_latency_metrics
+from AutoGLM_GUI.task_manager import TaskManager
+from AutoGLM_GUI.task_store import TaskStatus, TaskStore
+from AutoGLM_GUI.trace import trace_span
+
+
+pytestmark = [pytest.mark.integration]
+
+
+def _load_trace_records(trace_file: Path, trace_id: str) -> list[dict[str, Any]]:
+    assert trace_file.exists(), f"Trace file was not written: {trace_file}"
+    records: list[dict[str, Any]] = []
+    for line in trace_file.read_text(encoding="utf-8").splitlines():
+        record = json.loads(line)
+        if record.get("trace_id") == trace_id:
+            records.append(record)
+    return records
+
+
+def _fake_adb_run(*_: Any, **__: Any) -> SimpleNamespace:
+    return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+
+class _FakePlannerStreamingResult:
+    final_output = "Planner confirmed the debug scenario completed."
+
+    def __init__(self, device_id: str) -> None:
+        self.device_id = device_id
+        self.cancelled = False
+
+    def cancel(self, mode: str = "immediate") -> None:
+        self.cancelled = True
+
+    async def stream_events(self):
+        session = layered_service.TracedSQLiteSession(f"trace-test-{self.device_id}")
+        await session.add_items(
+            [
+                {
+                    "role": "user",
+                    "content": "打开微信，搜索张三，发送你好",
+                }
+            ]
+        )
+        await session.get_items()
+
+        yield RawResponsesStreamEvent(
+            data=SimpleNamespace(type="response.created"),
+        )
+        yield RunItemStreamEvent(
+            name="tool_called",
+            item=SimpleNamespace(
+                type="tool_call_item",
+                raw_item={
+                    "name": "chat",
+                    "arguments": json.dumps(
+                        {
+                            "device_id": self.device_id,
+                            "message": "打开微信，搜索张三，发送你好",
+                        },
+                        ensure_ascii=False,
+                    ),
+                },
+            ),
+        )
+
+        with trace_span(
+            "layered.tool.chat.run_agent",
+            attrs={"device_id": self.device_id, "agent_type": "TraceFakeAgent"},
+        ):
+            with trace_span(
+                "agent.step",
+                attrs={"step": 1, "agent_type": "TraceFakeAgent"},
+            ):
+                with trace_span(
+                    "step.capture_screenshot",
+                    attrs={"step": 1, "agent_type": "TraceFakeAgent"},
+                ):
+                    pass
+                with trace_span(
+                    "step.llm",
+                    attrs={
+                        "step": 1,
+                        "agent_type": "TraceFakeAgent",
+                        "model_name": "mock-glm-model",
+                        "message_count": 1,
+                    },
+                ):
+                    await asyncio.sleep(0.01)
+                with trace_span(
+                    "step.parse_action",
+                    attrs={"step": 1, "agent_type": "TraceFakeAgent"},
+                ):
+                    pass
+                with trace_span(
+                    "step.execute_action",
+                    attrs={
+                        "step": 1,
+                        "agent_type": "TraceFakeAgent",
+                        "action_name": "Tap",
+                    },
+                ):
+                    result = ActionHandler(ADBDevice(self.device_id)).execute(
+                        {"_metadata": "do", "action": "Tap", "element": [500, 500]},
+                        screen_width=1000,
+                        screen_height=1000,
+                    )
+                    assert result.success is True
+                with trace_span(
+                    "step.update_context",
+                    attrs={"step": 1, "agent_type": "TraceFakeAgent"},
+                ):
+                    with trace_span(
+                        "memory.write",
+                        attrs={"step": 1, "memory_type": "fake_agent_context"},
+                    ):
+                        pass
+
+        yield RunItemStreamEvent(
+            name="tool_output",
+            item=SimpleNamespace(
+                type="tool_call_output_item",
+                output=json.dumps(
+                    {"result": "已发送你好给张三", "steps": 1, "success": True},
+                    ensure_ascii=False,
+                ),
+            ),
+        )
+        yield RawResponsesStreamEvent(
+            data=SimpleNamespace(type="response.completed"),
+        )
+        yield RunItemStreamEvent(
+            name="message_output_created",
+            item=SimpleNamespace(
+                type="message_output_item",
+                raw_item=SimpleNamespace(
+                    content=[
+                        SimpleNamespace(
+                            text="我已经确认消息发送完成。",
+                        )
+                    ]
+                ),
+            ),
+        )
+        await session.clear_session()
+
+
+def test_layered_task_trace_observability_covers_debug_surface(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trace_file = tmp_path / "trace.jsonl"
+    monkeypatch.setenv("AUTOGLM_TRACE_ENABLED", "1")
+    monkeypatch.setenv("AUTOGLM_TRACE_FILE", str(trace_file))
+
+    import AutoGLM_GUI.adb.device as adb_device_module
+
+    monkeypatch.setattr(adb_device_module.subprocess, "run", _fake_adb_run)
+    monkeypatch.setattr(
+        adb_device_module.TIMING_CONFIG.device,
+        "default_tap_delay",
+        0.0,
+    )
+
+    reset_trace_latency_metrics()
+
+    store = TaskStore(tmp_path / "tasks.db")
+    manager = TaskManager(store)
+
+    def fake_start_run(
+        *,
+        task_id: str,
+        session_id: str,
+        message: str,
+    ) -> layered_service.LayeredTaskRun:
+        assert message == "打开微信，搜索张三，发送你好"
+        with trace_span(
+            "layered.planner.run_streamed",
+            attrs={
+                "task_id": task_id,
+                "session_id": session_id,
+                "max_turns": 100000,
+            },
+        ):
+            return layered_service.LayeredTaskRun(
+                task_id=task_id,
+                session_id=session_id,
+                result=_FakePlannerStreamingResult("adb-debug-device"),
+            )
+
+    monkeypatch.setattr(layered_service, "start_run", fake_start_run)
+    monkeypatch.setattr(history_api, "task_store", store)
+
+    async def scenario() -> dict[str, Any]:
+        await manager.start()
+        try:
+            session = await manager.create_chat_session(
+                device_id="adb-debug-device",
+                device_serial="serial-debug",
+                mode="layered",
+            )
+            task = await manager.submit_chat_task(
+                session_id=str(session["id"]),
+                device_id="adb-debug-device",
+                device_serial="serial-debug",
+                message="打开微信，搜索张三，发送你好",
+            )
+            final_task = await manager.wait_for_task(str(task["id"]), timeout=5)
+            assert final_task is not None
+            return final_task
+        finally:
+            await manager.shutdown()
+
+    try:
+        final_task = asyncio.run(scenario())
+
+        assert final_task["status"] == TaskStatus.SUCCEEDED.value
+        assert final_task["trace_id"]
+        assert final_task["step_count"] == 1
+
+        events = store.list_task_events(str(final_task["id"]))
+        event_types = [event["event_type"] for event in events]
+        assert "tool_call" in event_types
+        assert "tool_result" in event_types
+        assert "message" in event_types
+        assert "trace_summary" in event_types
+
+        trace_summary_event = next(
+            event for event in events if event["event_type"] == "trace_summary"
+        )
+        trace_summary = trace_summary_event["payload"]["summary"]
+        assert trace_summary["trace_id"] == final_task["trace_id"]
+        assert trace_summary["steps"] == 1
+
+        history_record = history_api._build_history_record_from_task(final_task)
+        assert history_record.trace_id == final_task["trace_id"]
+        assert history_record.trace_summary is not None
+        assert history_record.step_timings
+
+        trace_records = _load_trace_records(trace_file, str(final_task["trace_id"]))
+        span_names = {record["name"] for record in trace_records}
+        expected_spans = {
+            "layered.planner.run_streamed",
+            "layered.planner.stream",
+            "model.call",
+            "tool.call",
+            "tool.result",
+            "layered.tool.chat.run_agent",
+            "memory.read",
+            "memory.write",
+            "memory.clear",
+            "agent.step",
+            "step.capture_screenshot",
+            "step.llm",
+            "step.parse_action",
+            "step.execute_action",
+            "step.update_context",
+            "action.execute",
+            "device.tap",
+            "adb.tap",
+            "task_store.event.append",
+            "task_store.task.finish",
+        }
+        assert expected_spans <= span_names
+
+        metrics_output = generate_latest(get_metrics_registry()).decode("utf-8")
+        assert "autoglm_trace_task_duration_seconds_bucket" in metrics_output
+        assert 'autoglm_trace_task_duration_seconds_count{source="layered"} 1.0' in (
+            metrics_output
+        )
+        assert "autoglm_trace_step_duration_seconds_bucket" in metrics_output
+        assert "autoglm_trace_component_duration_seconds_bucket" in metrics_output
+    finally:
+        reset_trace_latency_metrics()
+        store.close()


### PR DESCRIPTION
## Summary
- persist task trace ids and expose trace summaries through task/history APIs
- add spans for planner model streams, tool calls/results, ADB/device work, memory/session writes, and task/history persistence
- document trace debugging workflow in AGENTS.md
- add backend integration coverage for layered trace observability, history replay, metrics export, and fake ADB spans
- add a Playwright integration test that drives the real frontend while asserting backend task events, trace summaries, step timings, and mock device commands

## Verification
- uv run pytest -q
- uv run pytest tests/test_trace_observability_integration.py tests/test_task_manager.py tests/test_history_api.py tests/test_task_store.py tests/test_trace.py tests/test_metrics.py -q
- uv run pytest tests/test_trace_observability_integration.py -q
- uv run python scripts/lint.py --frontend --check-only
- uv run python scripts/lint.py --backend --check-only (fails only existing DroidConfig import issue in AutoGLM_GUI/agents/droidrun/async_agent.py:73)
- cd frontend && pnpm test:e2e -- e2e/trace-events.spec.ts
- cd frontend && pnpm test:e2e
- git diff --check