### PR TITLE
feat: support image attachments in classic chat

### DIFF
--- a/AutoGLM_GUI/agents/base/async_agent_base.py
+++ b/AutoGLM_GUI/agents/base/async_agent_base.py
@@ -2,7 +2,7 @@
 
 子类只需实现:
 - _get_default_system_prompt(lang) → 默认 system prompt
-- _prepare_initial_context(task, screenshot, current_app) → 构建首条消息
+- _prepare_initial_context(task, screenshot, current_app, reference_images) → 构建首条消息
 - _execute_step() → 单步执行（LLM 调用 + action 执行）
 """
 
@@ -77,6 +77,7 @@ class AsyncAgentBase(ABC):
 
         # State
         self._context: list[dict[str, Any]] = [self._initial_system_message]
+        self._user_image_attachments: list[dict[str, str]] = []
         self._step_count = 0
         self._is_running = False
 
@@ -89,7 +90,11 @@ class AsyncAgentBase(ABC):
 
     @abstractmethod
     def _prepare_initial_context(
-        self, task: str, screenshot_base64: str, current_app: str
+        self,
+        task: str,
+        screenshot_base64: str,
+        current_app: str,
+        reference_images: list[dict[str, str]] | None = None,
     ) -> None:
         """构建首条用户消息并添加到 self._context。"""
         ...
@@ -155,7 +160,10 @@ class AsyncAgentBase(ABC):
                     attrs={"agent_type": self.__class__.__name__},
                 ):
                     self._prepare_initial_context(
-                        task, screenshot.base64_data, current_app
+                        task,
+                        screenshot.base64_data,
+                        current_app,
+                        self._user_image_attachments,
                     )
 
                 started_at = time.monotonic()
@@ -325,7 +333,12 @@ class AsyncAgentBase(ABC):
                 raise
 
             finally:
+                self._user_image_attachments = []
                 self._is_running = False
+
+    def set_user_image_attachments(self, attachments: list[dict[str, str]]) -> None:
+        """Set user-supplied reference images for the next streamed task."""
+        self._user_image_attachments = attachments.copy()
 
     async def cancel(self) -> None:
         """取消当前执行。"""
@@ -336,6 +349,7 @@ class AsyncAgentBase(ABC):
     def reset(self) -> None:
         """重置状态。"""
         self._context = [copy.deepcopy(self._initial_system_message)]
+        self._user_image_attachments = []
         self._step_count = 0
         self._is_running = False
         self._cancel_event.clear()

--- a/AutoGLM_GUI/agents/droidrun/async_agent.py
+++ b/AutoGLM_GUI/agents/droidrun/async_agent.py
@@ -70,7 +70,7 @@ class DroidRunAgent:
             )
             from droidrun.config_manager.config_manager import (  # pyright: ignore[reportMissingImports,reportAttributeAccessIssue]
                 DeviceConfig,
-                DroidConfig,
+                DroidConfig,  # pyright: ignore[reportAttributeAccessIssue]
             )
         except ImportError as e:
             yield {

--- a/AutoGLM_GUI/agents/gemini/async_agent.py
+++ b/AutoGLM_GUI/agents/gemini/async_agent.py
@@ -28,12 +28,26 @@ class AsyncGeminiAgent(AsyncAgentBase):
         return get_system_prompt(lang)
 
     def _prepare_initial_context(
-        self, task: str, screenshot_base64: str, current_app: str
+        self,
+        task: str,
+        screenshot_base64: str,
+        current_app: str,
+        reference_images: list[dict[str, str]] | None = None,
     ) -> None:
+        reference_images = reference_images or []
+        reference_notice = MessageBuilder.build_user_reference_images_notice(
+            len(reference_images)
+        )
+        reference_section = (
+            f"\n\nUser reference images: {reference_notice}" if reference_notice else ""
+        )
         self._context.append(
-            MessageBuilder.create_user_message(
-                text=f"{task}\n\nCurrent app: {current_app}",
-                image_base64=screenshot_base64,
+            MessageBuilder.create_user_message_with_images(
+                text=f"{task}{reference_section}\n\nCurrent app: {current_app}",
+                images=[
+                    {"mime_type": "image/png", "data": screenshot_base64},
+                    *reference_images,
+                ],
             )
         )
 

--- a/AutoGLM_GUI/agents/glm/async_agent.py
+++ b/AutoGLM_GUI/agents/glm/async_agent.py
@@ -55,17 +55,23 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
         # message (together with that step's screenshot), matching the
         # official Open-AutoGLM layout.
         self._pending_task: str | None = None
+        self._pending_reference_images: list[dict[str, str]] = []
 
     def _get_default_system_prompt(self, lang: str) -> str:
         return get_system_prompt(lang)
 
     def _prepare_initial_context(
-        self, task: str, screenshot_base64: str, current_app: str
+        self,
+        task: str,
+        screenshot_base64: str,
+        current_app: str,
+        reference_images: list[dict[str, str]] | None = None,
     ) -> None:
         # Do not add a screenshot here: the first per-step screenshot is the
         # current one and it is attached in _execute_step(). This keeps the
-        # invariant that every LLM request carries exactly one image.
+        # invariant that every LLM request carries the current screen first.
         self._pending_task = task
+        self._pending_reference_images = (reference_images or []).copy()
 
     async def _execute_step(self) -> AsyncGenerator[dict[str, Any], None]:
         """执行单步：获取截图 → 流式调用 LLM → 解析文本 → 执行动作。"""
@@ -112,23 +118,39 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
 
             screen_info = MessageBuilder.build_screen_info(current_app)
             if self._step_count == 1 and self._pending_task is not None:
+                reference_notice = MessageBuilder.build_user_reference_images_notice(
+                    len(self._pending_reference_images)
+                )
+                reference_section = (
+                    f"\n\n** User Reference Images **\n\n{reference_notice}"
+                    if reference_notice
+                    else ""
+                )
                 text_content = (
-                    f"{self._pending_task}\n\n** Screen Info **\n\n{screen_info}"
+                    f"{self._pending_task}{reference_section}"
+                    f"\n\n** Screen Info **\n\n{screen_info}"
                 )
                 self._pending_task = None
+                images = [
+                    {"mime_type": "image/png", "data": screenshot.base64_data},
+                    *self._pending_reference_images,
+                ]
+                self._pending_reference_images = []
             else:
                 text_content = f"** Screen Info **\n\n{screen_info}"
+                images = [{"mime_type": "image/png", "data": screenshot.base64_data}]
             self._context.append(
-                MessageBuilder.create_user_message(
-                    text=text_content, image_base64=screenshot.base64_data
+                MessageBuilder.create_user_message_with_images(
+                    text=text_content,
+                    images=images,
                 )
             )
 
         # 3. 流式调用 OpenAI
         image_count = _count_image_parts(self._context)
-        if image_count != 1:
+        if image_count < 1:
             logger.warning(
-                "GLM request should carry exactly one screenshot, got %d (step %d)",
+                "GLM request should carry at least one screenshot, got %d (step %d)",
                 image_count,
                 self._step_count,
             )

--- a/AutoGLM_GUI/agents/mai/async_agent.py
+++ b/AutoGLM_GUI/agents/mai/async_agent.py
@@ -65,7 +65,11 @@ class AsyncMAIAgent(AsyncAgentBase):
         return MAI_MOBILE_SYSTEM_PROMPT
 
     def _prepare_initial_context(
-        self, task: str, screenshot_base64: str, current_app: str
+        self,
+        task: str,
+        screenshot_base64: str,
+        current_app: str,
+        reference_images: list[dict[str, str]] | None = None,
     ) -> None:
         """MAI 不使用基类的 _context 累积，只记录 task_goal。
 

--- a/AutoGLM_GUI/api/agents.py
+++ b/AutoGLM_GUI/api/agents.py
@@ -98,7 +98,7 @@ async def chat_stream(request: ChatRequest):
             for event in events:
                 last_seq = int(event["seq"])
                 event_type = str(event["event_type"])
-                if event_type == "status":
+                if event_type in {"status", "user_message"}:
                     continue
                 sse_event = _create_sse_event(
                     event_type,

--- a/AutoGLM_GUI/api/history.py
+++ b/AutoGLM_GUI/api/history.py
@@ -139,15 +139,30 @@ def _trace_summary_from_step_timings(
     )
 
 
-def _build_history_record_from_task(record: dict[str, Any]) -> HistoryRecordResponse:
+def _build_history_record_from_task(
+    record: dict[str, Any], *, include_attachments: bool = True
+) -> HistoryRecordResponse:
     events = task_store.list_task_events(record["id"])
+    user_message_event = next(
+        (event for event in events if event["event_type"] == "user_message"),
+        None,
+    )
+    user_message_payload = (
+        dict(user_message_event["payload"]) if user_message_event is not None else {}
+    )
+    user_attachments = user_message_payload.get("attachments", [])
+    if not isinstance(user_attachments, list):
+        user_attachments = []
+    if not include_attachments:
+        user_attachments = []
     step_timings: list[StepTimingSummaryResponse] = []
     trace_summary: TraceSummaryResponse | None = None
     messages: list[MessageRecordResponse] = [
         MessageRecordResponse(
             role="user",
-            content=record["input_text"],
+            content=str(user_message_payload.get("message", record["input_text"])),
             timestamp=record["created_at"],
+            attachments=user_attachments,
         )
     ]
     # Sequence index for layered tool-call cycles so the UI can group a tool
@@ -156,6 +171,8 @@ def _build_history_record_from_task(record: dict[str, Any]) -> HistoryRecordResp
     for event in events:
         event_type = event["event_type"]
         payload = event["payload"]
+        if event_type == "user_message":
+            continue
         if event_type == "step":
             messages.append(
                 MessageRecordResponse(
@@ -295,7 +312,7 @@ def _list_merged_history(
         ]
 
     merged = [
-        _build_history_record_from_task(record)
+        _build_history_record_from_task(record, include_attachments=False)
         for record in task_records
         if _is_terminal_task_record(record)
     ]

--- a/AutoGLM_GUI/api/layered_agent.py
+++ b/AutoGLM_GUI/api/layered_agent.py
@@ -131,7 +131,7 @@ async def _stream_layered_task(task_id: str) -> AsyncGenerator[str, None]:
         for event in events:
             last_seq = int(event["seq"])
             event_type = str(event["event_type"])
-            if event_type == "status":
+            if event_type in {"status", "user_message"}:
                 continue
 
             compat_payload = _compat_sse_payload(event_type, dict(event["payload"]))

--- a/AutoGLM_GUI/api/tasks.py
+++ b/AutoGLM_GUI/api/tasks.py
@@ -210,6 +210,7 @@ async def submit_task_session_task(
         device_id=str(session["device_id"]),
         device_serial=str(session["device_serial"]),
         message=request.message,
+        attachments=[attachment.model_dump() for attachment in request.attachments],
     )
     return _task_run_response(task)
 

--- a/AutoGLM_GUI/model/message_builder.py
+++ b/AutoGLM_GUI/model/message_builder.py
@@ -15,16 +15,34 @@ class MessageBuilder:
         if image_base64 is None:
             return {"role": "user", "content": text}
 
-        # Image first, then text — matches the official Open-AutoGLM input layout.
-        return {
-            "role": "user",
-            "content": [
+        return MessageBuilder.create_user_message_with_images(
+            text=text,
+            images=[{"mime_type": "image/png", "data": image_base64}],
+        )
+
+    @staticmethod
+    def create_user_message_with_images(
+        text: str, images: list[dict[str, str]]
+    ) -> dict[str, Any]:
+        if not images:
+            return {"role": "user", "content": text}
+
+        content_parts: list[dict[str, Any]] = []
+        for image in images:
+            content_parts.append(
                 {
                     "type": "image_url",
-                    "image_url": {"url": f"data:image/png;base64,{image_base64}"},
-                },
-                {"type": "text", "text": text},
-            ],
+                    "image_url": {
+                        "url": f"data:{image['mime_type']};base64,{image['data']}"
+                    },
+                }
+            )
+
+        # Images first, then text — matches the official Open-AutoGLM input layout.
+        content_parts.append({"type": "text", "text": text})
+        return {
+            "role": "user",
+            "content": content_parts,
         }
 
     @staticmethod
@@ -34,17 +52,25 @@ class MessageBuilder:
         if not image_base64_list:
             return {"role": "user", "content": text}
 
-        content_parts: list[dict[str, Any]] = [{"type": "text", "text": text}]
+        return MessageBuilder.create_user_message_with_images(
+            text=text,
+            images=[
+                {"mime_type": "image/png", "data": image_base64}
+                for image_base64 in image_base64_list
+            ],
+        )
 
-        for image_base64 in image_base64_list:
-            content_parts.append(
-                {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:image/png;base64,{image_base64}"},
-                }
-            )
-
-        return {"role": "user", "content": content_parts}
+    @staticmethod
+    def build_user_reference_images_notice(image_count: int) -> str:
+        if image_count <= 0:
+            return ""
+        image_word = "image" if image_count == 1 else "images"
+        return (
+            f"User attached {image_count} reference {image_word}. "
+            "Image 1 is the current Android screen and is the only image that "
+            "defines tap/swipe coordinates. Use the following attached images "
+            "only as reference material for the user's task."
+        )
 
     @staticmethod
     def create_assistant_message(content: str) -> dict[str, Any]:

--- a/AutoGLM_GUI/schemas.py
+++ b/AutoGLM_GUI/schemas.py
@@ -1,12 +1,20 @@
 """Shared Pydantic models for the AutoGLM-GUI API."""
 
+import base64
+import binascii
 import re
 from typing import Any
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from AutoGLM_GUI.device_metadata_manager import DISPLAY_NAME_MAX_LENGTH
 from AutoGLM_GUI.task_store import TaskSessionStatus, TaskStatus
+
+
+TASK_IMAGE_ATTACHMENT_MAX_COUNT = 3
+TASK_IMAGE_ATTACHMENT_MAX_BYTES = 5 * 1024 * 1024
+TASK_IMAGE_ATTACHMENT_MAX_TOTAL_BYTES = 12 * 1024 * 1024
+TASK_IMAGE_ATTACHMENT_MIME_TYPES = {"image/png", "image/jpeg", "image/webp"}
 
 
 class ChatRequest(BaseModel):
@@ -707,6 +715,7 @@ class MessageRecordResponse(BaseModel):
     thinking: str | None = None
     action: dict[str, Any] | None = None
     step: int | None = None
+    attachments: list[dict[str, Any]] = Field(default_factory=list)
 
 
 class StepTimingSummaryResponse(BaseModel):
@@ -810,17 +819,81 @@ class TaskSessionResponse(BaseModel):
     updated_at: str
 
 
+class TaskImageAttachment(BaseModel):
+    """Base64 image attachment supplied by the user with a chat task."""
+
+    mime_type: str
+    data: str
+    name: str | None = None
+
+    @field_validator("mime_type")
+    @classmethod
+    def validate_mime_type(cls, v: str) -> str:
+        mime_type = v.strip().lower()
+        if mime_type not in TASK_IMAGE_ATTACHMENT_MIME_TYPES:
+            raise ValueError(
+                "unsupported image type; expected image/png, image/jpeg, or image/webp"
+            )
+        return mime_type
+
+    @field_validator("data")
+    @classmethod
+    def validate_base64_data(cls, v: str) -> str:
+        data = v.strip()
+        if not data:
+            raise ValueError("image data cannot be empty")
+        try:
+            decoded = base64.b64decode(data, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError("image data must be valid base64") from exc
+        if not decoded:
+            raise ValueError("image data cannot be empty")
+        if len(decoded) > TASK_IMAGE_ATTACHMENT_MAX_BYTES:
+            raise ValueError("image too large (max 5 MiB)")
+        return data
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        name = v.strip()
+        if not name:
+            return None
+        return name[:255]
+
+    def byte_size(self) -> int:
+        return len(base64.b64decode(self.data, validate=True))
+
+
 class TaskSubmitRequest(BaseModel):
-    message: str
+    message: str = ""
+    attachments: list[TaskImageAttachment] = Field(default_factory=list)
 
     @field_validator("message")
     @classmethod
     def validate_message_non_empty(cls, v: str) -> str:
-        if not v or not v.strip():
-            raise ValueError("message cannot be empty")
         if len(v) > 10000:
             raise ValueError("message too long (max 10000 characters)")
         return v.strip()
+
+    @field_validator("attachments")
+    @classmethod
+    def validate_attachments_count(
+        cls, v: list[TaskImageAttachment]
+    ) -> list[TaskImageAttachment]:
+        if len(v) > TASK_IMAGE_ATTACHMENT_MAX_COUNT:
+            raise ValueError("too many images (max 3)")
+        return v
+
+    @model_validator(mode="after")
+    def validate_message_or_attachment(self) -> "TaskSubmitRequest":
+        if not self.message and not self.attachments:
+            raise ValueError("message or image attachment is required")
+        total_bytes = sum(attachment.byte_size() for attachment in self.attachments)
+        if total_bytes > TASK_IMAGE_ATTACHMENT_MAX_TOTAL_BYTES:
+            raise ValueError("images too large in total (max 12 MiB)")
+        return self
 
 
 class TaskRunResponse(BaseModel):

--- a/AutoGLM_GUI/task_manager.py
+++ b/AutoGLM_GUI/task_manager.py
@@ -6,7 +6,7 @@ import asyncio
 import inspect
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, cast
 
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.metrics import record_trace_latency_metrics
@@ -21,6 +21,7 @@ from AutoGLM_GUI.task_store import (
 import AutoGLM_GUI.trace as trace_module
 
 TaskExecutor = Callable[[TaskRecord], Awaitable[None]]
+TaskImageAttachment = dict[str, Any]
 
 
 class TaskManager:
@@ -127,6 +128,7 @@ class TaskManager:
         device_id: str,
         device_serial: str,
         message: str,
+        attachments: list[TaskImageAttachment] | None = None,
     ) -> TaskRecord:
         session = await self.get_session(session_id)
         if session is None:
@@ -149,9 +151,39 @@ class TaskManager:
             device_serial=device_serial,
             input_text=message,
         )
+        await asyncio.to_thread(
+            self.store.append_event,
+            task_id=task["id"],
+            event_type="user_message",
+            role="user",
+            payload={
+                "message": message,
+                "attachments": attachments or [],
+            },
+        )
         self._completion_events[task["id"]] = asyncio.Event()
         self._ensure_worker(device_id)
         return task
+
+    def _get_task_user_image_attachments(
+        self, task_id: str
+    ) -> list[TaskImageAttachment]:
+        events = self.store.list_task_events(task_id)
+        for event in events:
+            if event["event_type"] != "user_message":
+                continue
+            payload = event.get("payload", {})
+            attachments = payload.get("attachments")
+            if not isinstance(attachments, list):
+                return []
+            return [
+                attachment
+                for attachment in attachments
+                if isinstance(attachment, dict)
+                and isinstance(attachment.get("mime_type"), str)
+                and isinstance(attachment.get("data"), str)
+            ]
+        return []
 
     async def enqueue_scheduled_task(
         self,
@@ -404,6 +436,19 @@ class TaskManager:
                     context=context,
                     agent_type=None,
                 )
+                user_image_attachments = await asyncio.to_thread(
+                    self._get_task_user_image_attachments,
+                    task_id,
+                )
+                image_attachment_setter: (
+                    Callable[[list[TaskImageAttachment]], None] | None
+                ) = None
+                setter_candidate = getattr(agent, "set_user_image_attachments", None)
+                if callable(setter_candidate):
+                    image_attachment_setter = cast(
+                        Callable[[list[TaskImageAttachment]], None],
+                        setter_candidate,
+                    )
 
                 async def cancel_handler() -> None:
                     await agent.cancel()
@@ -423,7 +468,15 @@ class TaskManager:
                     final_message = "Task cancelled by user"
                     final_status = TaskStatus.CANCELLED.value
                     stop_reason = "user_stopped"
+                elif user_image_attachments and image_attachment_setter is None:
+                    final_message = (
+                        "Current agent does not support user image attachments"
+                    )
+                    final_status = TaskStatus.FAILED.value
+                    stop_reason = "unsupported_image_attachments"
                 else:
+                    if user_image_attachments and image_attachment_setter is not None:
+                        image_attachment_setter(user_image_attachments)
                     event_type = ""
                     event_data: dict[str, Any] = {}
                     async for event in agent.stream(task["input_text"]):

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -926,6 +926,12 @@ export interface TaskEventListResponse {
   events: TaskEventRecordResponse[];
 }
 
+export interface TaskImageAttachment {
+  mime_type: string;
+  data: string;
+  name?: string | null;
+}
+
 export interface TaskCancelResponse {
   success: boolean;
   message: string;
@@ -983,11 +989,12 @@ export async function listTaskSessionTasks(
 
 export async function submitTaskSessionTask(
   sessionId: string,
-  message: string
+  message: string,
+  attachments: TaskImageAttachment[] = []
 ): Promise<TaskRunResponse> {
   const res = await axios.post<TaskRunResponse>(
     `/api/task-sessions/${sessionId}/tasks`,
-    { message }
+    { message, attachments }
   );
   return res.data;
 }
@@ -1077,6 +1084,7 @@ export interface MessageRecordResponse {
   thinking?: string | null;
   action?: Record<string, unknown> | null;
   step?: number | null;
+  attachments?: TaskImageAttachment[];
 }
 
 export interface HistoryRecordResponse {

--- a/frontend/src/components/DevicePanel.tsx
+++ b/frontend/src/components/DevicePanel.tsx
@@ -9,16 +9,20 @@ import {
   ListChecks,
   Loader2,
   Square,
+  ImagePlus,
+  X,
 } from 'lucide-react';
 import { DeviceMonitor } from './DeviceMonitor';
 import type {
   StepTimingSummary,
+  TaskImageAttachment,
   Workflow,
   HistoryRecordResponse,
 } from '../api';
 import {
   listWorkflows,
   listHistory,
+  getHistoryRecord,
   clearHistory as clearHistoryApi,
   deleteHistoryRecord,
 } from '../api';
@@ -61,6 +65,35 @@ interface DevicePanelProps {
   isConfigured: boolean;
   isVisible?: boolean; // ✅ 新增：控制视频流行为
   unlimitedStepsEnabled?: boolean;
+}
+
+const IMAGE_ATTACHMENT_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+]);
+const MAX_IMAGE_ATTACHMENTS = 3;
+const MAX_IMAGE_ATTACHMENT_BYTES = 5 * 1024 * 1024;
+
+function readImageAttachment(file: File): Promise<TaskImageAttachment> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('读取图片失败'));
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : '';
+      const commaIndex = result.indexOf(',');
+      if (commaIndex === -1) {
+        reject(new Error('图片格式无效'));
+        return;
+      }
+      resolve({
+        mime_type: file.type,
+        data: result.slice(commaIndex + 1),
+        name: file.name || null,
+      });
+    };
+    reader.readAsDataURL(file);
+  });
 }
 
 function getStepSummary(thinking: string | undefined, action: unknown): string {
@@ -153,6 +186,10 @@ export function DevicePanel({
 }: DevicePanelProps) {
   const t = useTranslation();
   const [input, setInput] = useState('');
+  const [attachments, setAttachments] = useState<TaskImageAttachment[]>([]);
+  const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const [isDraggingAttachment, setIsDraggingAttachment] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   // ✅ 移除 initialized 状态，依赖后端自动初始化
   // const [initialized, setInitialized] = useState(false);
   const [showHistoryPopover, setShowHistoryPopover] = useState(false);
@@ -250,76 +287,88 @@ export function DevicePanel({
   }, [showHistoryPopover, deviceSerial]);
 
   const handleSelectHistory = (record: HistoryRecordResponse) => {
-    // Convert backend messages to frontend Message format
-    const newMessages: TaskConversationMessage[] = [];
+    void (async () => {
+      let selectedRecord = record;
+      try {
+        selectedRecord = await getHistoryRecord(deviceSerial, record.id);
+      } catch (error) {
+        console.error('Failed to load history record detail:', error);
+      }
 
-    // Find user message from record
-    const userMsg = record.messages.find(m => m.role === 'user');
-    if (userMsg) {
-      newMessages.push({
-        id: `${record.id}-user`,
-        role: 'user',
-        content: userMsg.content || record.task_text,
-        timestamp: new Date(userMsg.timestamp),
-      });
-    } else {
-      // Fallback to task_text if no user message
-      newMessages.push({
-        id: `${record.id}-user`,
-        role: 'user',
-        content: record.task_text,
-        timestamp: new Date(record.start_time),
-      });
-    }
+      // Convert backend messages to frontend Message format
+      const newMessages: TaskConversationMessage[] = [];
 
-    // Collect thinking and actions from assistant messages
-    const thinkingList: string[] = [];
-    const actionsList: Record<string, unknown>[] = [];
-    const screenshotsList: (string | undefined)[] = [];
-    record.messages
-      .filter(m => m.role === 'assistant')
-      .forEach(m => {
-        if (m.thinking) thinkingList.push(m.thinking);
-        if (m.action) actionsList.push(m.action);
-        // Extract screenshot directly or from loosely typed object
-        const recordData = m as unknown as { screenshot?: string };
-        screenshotsList.push(recordData.screenshot);
-      });
+      // Find user message from record
+      const userMsg = selectedRecord.messages.find(m => m.role === 'user');
+      if (userMsg) {
+        newMessages.push({
+          id: `${selectedRecord.id}-user`,
+          role: 'user',
+          content: userMsg.content || selectedRecord.task_text,
+          timestamp: new Date(userMsg.timestamp),
+          attachments: userMsg.attachments || [],
+        });
+      } else {
+        // Fallback to task_text if no user message
+        newMessages.push({
+          id: `${selectedRecord.id}-user`,
+          role: 'user',
+          content: selectedRecord.task_text,
+          timestamp: new Date(selectedRecord.start_time),
+        });
+      }
 
-    // Create agent message
-    const agentMessage: TaskConversationMessage = {
-      id: `${record.id}-agent`,
-      role: 'assistant',
-      content: record.final_message,
-      timestamp: record.end_time
-        ? new Date(record.end_time)
-        : new Date(record.start_time),
-      steps: record.steps,
-      success: record.success,
-      thinking: thinkingList,
-      actions: actionsList,
-      screenshots: screenshotsList,
-      stepTimings: record.step_timings,
-      isStreaming: false,
-    };
-    newMessages.push(agentMessage);
+      // Collect thinking and actions from assistant messages
+      const thinkingList: string[] = [];
+      const actionsList: Record<string, unknown>[] = [];
+      const screenshotsList: (string | undefined)[] = [];
+      selectedRecord.messages
+        .filter(m => m.role === 'assistant')
+        .forEach(m => {
+          if (m.thinking) thinkingList.push(m.thinking);
+          if (m.action) actionsList.push(m.action);
+          // Extract screenshot directly or from loosely typed object
+          const recordData = m as unknown as { screenshot?: string };
+          screenshotsList.push(recordData.screenshot);
+        });
 
-    setMessages(newMessages);
+      // Create agent message
+      const agentMessage: TaskConversationMessage = {
+        id: `${selectedRecord.id}-agent`,
+        role: 'assistant',
+        content: selectedRecord.final_message,
+        timestamp: selectedRecord.end_time
+          ? new Date(selectedRecord.end_time)
+          : new Date(selectedRecord.start_time),
+        steps: selectedRecord.steps,
+        success: selectedRecord.success,
+        thinking: thinkingList,
+        actions: actionsList,
+        screenshots: screenshotsList,
+        stepTimings: selectedRecord.step_timings,
+        isStreaming: false,
+      };
+      newMessages.push(agentMessage);
 
-    // Reset previous message tracking refs to match the loaded history
-    prevMessageCountRef.current = newMessages.length;
-    prevMessageSigRef.current = [
-      agentMessage.id,
-      agentMessage.content?.length ?? 0,
-      agentMessage.currentThinking?.length ?? 0,
-      agentMessage.thinking ? JSON.stringify(agentMessage.thinking).length : 0,
-      agentMessage.steps ?? '',
-      agentMessage.isStreaming ? 1 : 0,
-    ].join('|');
+      setMessages(newMessages);
 
-    setShowNewMessageNotice(false);
-    isAtBottomRef.current = true;
-    setShowHistoryPopover(false);
+      // Reset previous message tracking refs to match the loaded history
+      prevMessageCountRef.current = newMessages.length;
+      prevMessageSigRef.current = [
+        agentMessage.id,
+        agentMessage.content?.length ?? 0,
+        agentMessage.currentThinking?.length ?? 0,
+        agentMessage.thinking
+          ? JSON.stringify(agentMessage.thinking).length
+          : 0,
+        agentMessage.steps ?? '',
+        agentMessage.isStreaming ? 1 : 0,
+      ].join('|');
+
+      setShowNewMessageNotice(false);
+      isAtBottomRef.current = true;
+      setShowHistoryPopover(false);
+    })();
   };
 
   const handleClearHistory = async () => {
@@ -346,12 +395,113 @@ export function DevicePanel({
   // Note: Configuration is now managed entirely by backend ConfigManager.
   // If user updates config via Settings, they need to manually re-initialize agents.
 
+  const addImageFiles = useCallback(
+    async (files: File[]) => {
+      const imageFiles = files.filter(file =>
+        IMAGE_ATTACHMENT_TYPES.has(file.type)
+      );
+      if (imageFiles.length === 0) {
+        return;
+      }
+
+      if (attachments.length + imageFiles.length > MAX_IMAGE_ATTACHMENTS) {
+        setAttachmentError('最多只能附加 3 张图片');
+        return;
+      }
+
+      const tooLargeFile = imageFiles.find(
+        file => file.size > MAX_IMAGE_ATTACHMENT_BYTES
+      );
+      if (tooLargeFile) {
+        setAttachmentError('单张图片不能超过 5 MiB');
+        return;
+      }
+
+      try {
+        const nextAttachments = await Promise.all(
+          imageFiles.map(file => readImageAttachment(file))
+        );
+        setAttachments(current => [...current, ...nextAttachments]);
+        setAttachmentError(null);
+      } catch (readError) {
+        setAttachmentError(
+          readError instanceof Error ? readError.message : '读取图片失败'
+        );
+      }
+    },
+    [attachments.length]
+  );
+
+  const handleFileInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(event.target.files || []);
+      void addImageFiles(files);
+      event.target.value = '';
+    },
+    [addImageFiles]
+  );
+
+  const handlePaste = useCallback(
+    (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const files = Array.from(event.clipboardData.files || []);
+      const hasImages = files.some(file =>
+        IMAGE_ATTACHMENT_TYPES.has(file.type)
+      );
+      if (!hasImages) {
+        return;
+      }
+      event.preventDefault();
+      void addImageFiles(files);
+    },
+    [addImageFiles]
+  );
+
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (
+        Array.from(event.dataTransfer.items || []).some(item =>
+          IMAGE_ATTACHMENT_TYPES.has(item.type)
+        )
+      ) {
+        event.preventDefault();
+        setIsDraggingAttachment(true);
+      }
+    },
+    []
+  );
+
+  const handleDragLeave = useCallback(() => {
+    setIsDraggingAttachment(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      const files = Array.from(event.dataTransfer.files || []);
+      const hasImages = files.some(file =>
+        IMAGE_ATTACHMENT_TYPES.has(file.type)
+      );
+      if (!hasImages) {
+        return;
+      }
+      event.preventDefault();
+      setIsDraggingAttachment(false);
+      void addImageFiles(files);
+    },
+    [addImageFiles]
+  );
+
+  const removeAttachment = useCallback((index: number) => {
+    setAttachments(current => current.filter((_, idx) => idx !== index));
+  }, []);
+
   const handleSend = useCallback(async () => {
-    const didSend = await sendMessage(input);
+    const didSend = await sendMessage(input, attachments);
     if (didSend) {
       setInput('');
+      setAttachments([]);
+      setAttachmentError(null);
     }
-  }, [input, sendMessage]);
+  }, [attachments, input, sendMessage]);
 
   const handleReset = useCallback(async () => {
     await resetConversation();
@@ -359,6 +509,8 @@ export function DevicePanel({
     isAtBottomRef.current = true;
     prevMessageCountRef.current = 0;
     prevMessageSigRef.current = null;
+    setAttachments([]);
+    setAttachmentError(null);
   }, [resetConversation]);
 
   const handleAbortChat = useCallback(async () => {
@@ -584,10 +736,10 @@ export function DevicePanel({
         </div>
 
         {/* Error message */}
-        {error && (
+        {(error || attachmentError) && (
           <div className="mx-4 mt-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-sm text-red-600 dark:text-red-400 flex items-center gap-2">
             <AlertCircle className="w-4 h-4 flex-shrink-0" />
-            {error}
+            {error || attachmentError}
           </div>
         )}
 
@@ -862,10 +1014,27 @@ export function DevicePanel({
                       </div>
                     ) : (
                       <div className="max-w-[75%]">
-                        <div className="chat-bubble-user px-4 py-3">
-                          <p className="whitespace-pre-wrap">
-                            {message.content}
-                          </p>
+                        <div className="chat-bubble-user px-4 py-3 space-y-2">
+                          {message.attachments &&
+                            message.attachments.length > 0 && (
+                              <div className="grid grid-cols-2 gap-2">
+                                {message.attachments.map((attachment, idx) => (
+                                  <img
+                                    key={`${message.id}-attachment-${idx}`}
+                                    src={`data:${attachment.mime_type};base64,${attachment.data}`}
+                                    alt={
+                                      attachment.name || `Attachment ${idx + 1}`
+                                    }
+                                    className="h-24 w-full rounded-lg object-cover border border-white/20"
+                                  />
+                                ))}
+                              </div>
+                            )}
+                          {message.content && (
+                            <p className="whitespace-pre-wrap">
+                              {message.content}
+                            </p>
+                          )}
                         </div>
                         <p className="text-xs text-slate-400 dark:text-slate-500 mt-1 text-right">
                           {message.timestamp.toLocaleTimeString()}
@@ -892,12 +1061,54 @@ export function DevicePanel({
         </div>
 
         {/* Input area */}
-        <div className="p-4 border-t border-slate-200 dark:border-slate-800">
+        <div
+          className={`p-4 border-t border-slate-200 dark:border-slate-800 ${
+            isDraggingAttachment
+              ? 'bg-sky-50 dark:bg-sky-950/20'
+              : 'bg-transparent'
+          }`}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp"
+            multiple
+            className="hidden"
+            onChange={handleFileInputChange}
+          />
+          {attachments.length > 0 && (
+            <div className="mb-3 flex flex-wrap gap-2">
+              {attachments.map((attachment, idx) => (
+                <div
+                  key={`${attachment.name || 'image'}-${idx}`}
+                  className="relative h-16 w-16 overflow-hidden rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-800"
+                >
+                  <img
+                    src={`data:${attachment.mime_type};base64,${attachment.data}`}
+                    alt={attachment.name || `Attachment ${idx + 1}`}
+                    className="h-full w-full object-cover"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeAttachment(idx)}
+                    className="absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-slate-950/70 text-white hover:bg-slate-950"
+                    aria-label="移除图片"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
           <div className="flex items-end gap-3">
             <Textarea
               value={input}
               onChange={e => setInput(e.target.value)}
               onKeyDown={handleInputKeyDown}
+              onPaste={handlePaste}
               placeholder={
                 !isConfigured
                   ? t.devicePanel.configureFirst
@@ -907,6 +1118,25 @@ export function DevicePanel({
               className="flex-1 min-h-[40px] max-h-[120px] resize-none"
               rows={1}
             />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  disabled={
+                    loading || attachments.length >= MAX_IMAGE_ATTACHMENTS
+                  }
+                  className="h-10 w-10 flex-shrink-0"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <ImagePlus className="w-4 h-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={8}>
+                添加图片
+              </TooltipContent>
+            </Tooltip>
             {/* Workflow Quick Run Button */}
             <Tooltip>
               <TooltipTrigger asChild>
@@ -998,7 +1228,9 @@ export function DevicePanel({
             {!loading && (
               <Button
                 onClick={handleSend}
-                disabled={!input.trim() || !sessionReady}
+                disabled={
+                  (!input.trim() && attachments.length === 0) || !sessionReady
+                }
                 size="icon"
                 variant="twitter"
                 className="h-10 w-10 rounded-full flex-shrink-0"

--- a/frontend/src/hooks/useTaskSessionConversation.ts
+++ b/frontend/src/hooks/useTaskSessionConversation.ts
@@ -9,6 +9,7 @@ import {
 import type {
   StepTimingSummary,
   TaskEventRecordResponse,
+  TaskImageAttachment,
   TaskRunResponse,
   TaskStatus,
 } from '../api';
@@ -35,6 +36,7 @@ export interface TaskConversationMessage {
   stepTimings?: (StepTimingSummary | undefined)[];
   isStreaming?: boolean;
   currentThinking?: string;
+  attachments?: TaskImageAttachment[];
 }
 
 interface UseTaskSessionConversationOptions {
@@ -50,7 +52,10 @@ interface UseTaskSessionConversationResult {
   aborting: boolean;
   error: string | null;
   sessionReady: boolean;
-  sendMessage: (input: string) => Promise<boolean>;
+  sendMessage: (
+    input: string,
+    attachments?: TaskImageAttachment[]
+  ) => Promise<boolean>;
   resetConversation: () => Promise<void>;
   abortConversation: () => Promise<void>;
 }
@@ -229,12 +234,27 @@ function buildMessagePair(
   task: TaskRunResponse,
   events: TaskEventRecordResponse[]
 ): TaskConversationMessage[] {
+  const userEvent = events.find(event => event.event_type === 'user_message');
+  const userPayload = userEvent?.payload || {};
+  const eventAttachments = Array.isArray(userPayload.attachments)
+    ? (userPayload.attachments.filter(
+        attachment =>
+          attachment &&
+          typeof attachment === 'object' &&
+          typeof (attachment as TaskImageAttachment).mime_type === 'string' &&
+          typeof (attachment as TaskImageAttachment).data === 'string'
+      ) as TaskImageAttachment[])
+    : [];
+  const eventMessage =
+    typeof userPayload.message === 'string' ? userPayload.message : null;
+
   return [
     {
       id: `${task.id}-user`,
       role: 'user',
-      content: task.input_text,
+      content: eventMessage ?? task.input_text,
       timestamp: new Date(task.created_at),
+      attachments: eventAttachments,
     },
     buildAssistantMessage(task, events),
   ];
@@ -439,16 +459,20 @@ export function useTaskSessionConversation({
   }, [deviceId, deviceSerial, restoreSessionConversation, sessionStorageKey]);
 
   const sendMessage = useCallback(
-    async (input: string) => {
+    async (input: string, attachments: TaskImageAttachment[] = []) => {
       const inputValue = input.trim();
-      if (!inputValue || loading || !sessionId) {
+      if ((!inputValue && attachments.length === 0) || loading || !sessionId) {
         return false;
       }
 
       try {
         setError(null);
         setLoading(true);
-        const task = await submitTaskSessionTask(sessionId, inputValue);
+        const task = await submitTaskSessionTask(
+          sessionId,
+          inputValue,
+          attachments
+        );
         const initialEvents = (await listTaskEvents(task.id)).events;
         const reconciledTask = reconcileTaskRun(task, initialEvents);
 

--- a/tests/test_gemini_agent.py
+++ b/tests/test_gemini_agent.py
@@ -1,7 +1,34 @@
 """Tests for Gemini Agent components."""
 
+from typing import Any
+
 from AutoGLM_GUI.agents.gemini.action_mapper import tool_call_to_action
 from AutoGLM_GUI.agents.gemini.tools import DEVICE_TOOLS
+from AutoGLM_GUI.config import AgentConfig, ModelConfig
+from AutoGLM_GUI.device_protocol import Screenshot
+
+
+def _count_images(messages: list[dict[str, Any]]) -> int:
+    count = 0
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, list):
+            count += sum(
+                1
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "image_url"
+            )
+    return count
+
+
+class _FakeDevice:
+    device_id = "fake-001"
+
+    def get_screenshot(self, timeout: int = 10) -> Screenshot:
+        return Screenshot(base64_data="screen", width=1080, height=2400)
+
+    def get_current_app(self) -> str:
+        return "com.example.app"
 
 
 class TestDeviceTools:
@@ -131,6 +158,34 @@ class TestAgentRegistration:
         types = list_agent_types()
         assert "gemini" in types
         assert "general-vision" in types
+
+
+class TestGeminiImageAttachments:
+    def test_initial_context_includes_reference_images_after_screen(self):
+        from AutoGLM_GUI.agents.gemini.async_agent import AsyncGeminiAgent
+
+        agent = AsyncGeminiAgent(
+            model_config=ModelConfig(),
+            agent_config=AgentConfig(max_steps=10, verbose=False),
+            device=_FakeDevice(),
+        )
+
+        agent._prepare_initial_context(
+            "compare this with the attached screenshot",
+            "screen",
+            "com.example.app",
+            reference_images=[{"mime_type": "image/webp", "data": "reference"}],
+        )
+
+        assert _count_images(agent.context) == 2
+        user_message = agent.context[-1]
+        assert user_message["content"][0]["image_url"]["url"] == (
+            "data:image/png;base64,screen"
+        )
+        assert user_message["content"][1]["image_url"]["url"] == (
+            "data:image/webp;base64,reference"
+        )
+        assert "User attached 1 reference image" in user_message["content"][2]["text"]
 
 
 class TestEventTypes:

--- a/tests/test_glm_async_agent.py
+++ b/tests/test_glm_async_agent.py
@@ -4,7 +4,8 @@ Regression coverage for issue #348: a stale initial screenshot leaked into
 every LLM request (the per-step ``remove_images_from_message`` only stripped
 the *last* message), so ``autoglm-phone`` saw two screenshots per turn and
 produced wrong ``Tap`` coordinates. Each request must carry exactly one
-screenshot — the current one — and history must not retain images.
+screenshot — the current one — unless the user explicitly attached reference
+images for the first turn. History must not retain images.
 """
 
 import asyncio
@@ -91,6 +92,25 @@ def test_remove_images_passes_through_string_content():
     assert MessageBuilder.remove_images_from_message(msg) == msg
 
 
+def test_create_user_message_with_images_preserves_order_and_mime_types():
+    msg = MessageBuilder.create_user_message_with_images(
+        "hello",
+        [
+            {"mime_type": "image/png", "data": "screen"},
+            {"mime_type": "image/jpeg", "data": "reference"},
+        ],
+    )
+
+    assert [part["type"] for part in msg["content"]] == [
+        "image_url",
+        "image_url",
+        "text",
+    ]
+    assert msg["content"][0]["image_url"]["url"] == "data:image/png;base64,screen"
+    assert msg["content"][1]["image_url"]["url"] == "data:image/jpeg;base64,reference"
+    assert msg["content"][2]["text"] == "hello"
+
+
 # ---------------------------------------------------------------------------
 # AsyncGLMAgent context invariant
 # ---------------------------------------------------------------------------
@@ -165,3 +185,48 @@ def test_context_retains_no_images_after_step(monkeypatch):
     asyncio.run(run())
 
     assert _count_images(agent._context) == 0
+
+
+def test_user_reference_images_are_sent_on_first_request_only(monkeypatch):
+    agent = _make_agent()
+
+    captured: list[list[dict[str, Any]]] = []
+    raw_responses = iter(
+        [
+            "I will tap.\ndo(action=Tap(element=[500, 500]))",
+            "Done.\nfinish(message=ok)",
+        ]
+    )
+
+    async def fake_stream(messages):
+        captured.append(copy.deepcopy(messages))
+        yield {"type": "raw", "content": next(raw_responses)}
+
+    action_results = iter(
+        [
+            ActionResult(success=True, should_finish=False, message=None),
+            ActionResult(success=True, should_finish=True, message="ok"),
+        ]
+    )
+
+    monkeypatch.setattr(agent, "_stream_openai", fake_stream)
+    monkeypatch.setattr(
+        agent.action_handler, "execute", lambda *a, **k: next(action_results)
+    )
+
+    async def run() -> None:
+        agent._prepare_initial_context(
+            "use the attached image",
+            "img0",
+            "com.android.launcher",
+            reference_images=[{"mime_type": "image/jpeg", "data": "ref1"}],
+        )
+        await _drain(agent._execute_step())
+        await _drain(agent._execute_step())
+
+    asyncio.run(run())
+
+    assert len(captured) == 2
+    assert _count_images(captured[0]) == 2
+    assert _count_images(captured[1]) == 1
+    assert "User attached 1 reference image" in _text_part(captured[0][-1])

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -151,6 +151,7 @@ class FakeTaskManager:
     def __init__(self, store: FakeTaskStore) -> None:
         self.store = store
         self.waited_task_ids: list[str] = []
+        self.submitted_attachments: list[dict[str, object]] = []
         self.sessions: dict[str, dict[str, object]] = {
             "session-1": {
                 "id": "session-1",
@@ -190,7 +191,9 @@ class FakeTaskManager:
         device_id: str,
         device_serial: str,
         message: str,
+        attachments: list[dict[str, object]] | None = None,
     ) -> dict[str, object]:
+        self.submitted_attachments = attachments or []
         task = {
             "id": "task-3",
             "source": "chat",
@@ -284,6 +287,31 @@ def test_task_session_create_and_submit(client: TestClient) -> None:
     assert submit_resp.status_code == 200
     assert submit_resp.json()["id"] == "task-3"
     assert submit_resp.json()["status"] == "QUEUED"
+
+
+def test_task_session_submit_accepts_image_attachments(client: TestClient) -> None:
+    submit_resp = client.post(
+        "/api/task-sessions/session-1/tasks",
+        json={
+            "message": "",
+            "attachments": [
+                {
+                    "mime_type": "image/png",
+                    "data": "aGVsbG8=",
+                    "name": "guide.png",
+                }
+            ],
+        },
+    )
+
+    assert submit_resp.status_code == 200
+    assert client.fake_task_manager.submitted_attachments == [  # type: ignore[attr-defined]
+        {
+            "mime_type": "image/png",
+            "data": "aGVsbG8=",
+            "name": "guide.png",
+        }
+    ]
 
 
 def test_task_session_supports_layered_mode(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- Add image attachment payloads for classic chat tasks, with backend validation and task-event persistence.
- Support pasted, dragged, and selected images in the classic chat input UI with previews and history restoration.
- Pass user reference images into both GLM and General Vision agents on the first model turn while keeping the device screenshot first for coordinate grounding.

Closes #354

## Tests
- uv run pytest tests/test_glm_async_agent.py tests/test_gemini_agent.py tests/test_tasks_api.py tests/test_history_api.py -q
- uv run pytest tests/test_task_api_phase1.py tests/test_mcp_task_tools.py -q
- uv run pytest tests/test_task_manager.py -q
- uv run python scripts/lint.py --check-only