### PR TITLE
fix: move waiting-for-device status out of chat body

### DIFF
--- a/frontend/src/components/DevicePanel.tsx
+++ b/frontend/src/components/DevicePanel.tsx
@@ -201,6 +201,7 @@ export function DevicePanel({
     setMessages,
     loading,
     aborting,
+    waitingForDevice,
     error,
     sessionReady,
     sendMessage,
@@ -1070,17 +1071,23 @@ export function DevicePanel({
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
-        >
-          <input
-            ref={fileInputRef}
-            type="file"
+          >
+            <input
+              ref={fileInputRef}
+              type="file"
             accept="image/png,image/jpeg,image/webp"
             multiple
-            className="hidden"
-            onChange={handleFileInputChange}
-          />
-          {attachments.length > 0 && (
-            <div className="mb-3 flex flex-wrap gap-2">
+              className="hidden"
+              onChange={handleFileInputChange}
+            />
+            {waitingForDevice && (
+              <div className="mb-3 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-300">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                <span>Waiting for device...</span>
+              </div>
+            )}
+            {attachments.length > 0 && (
+              <div className="mb-3 flex flex-wrap gap-2">
               {attachments.map((attachment, idx) => (
                 <div
                   key={`${attachment.name || 'image'}-${idx}`}

--- a/frontend/src/components/DevicePanel.tsx
+++ b/frontend/src/components/DevicePanel.tsx
@@ -1071,23 +1071,23 @@ export function DevicePanel({
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
-          >
-            <input
-              ref={fileInputRef}
-              type="file"
+        >
+          <input
+            ref={fileInputRef}
+            type="file"
             accept="image/png,image/jpeg,image/webp"
             multiple
-              className="hidden"
-              onChange={handleFileInputChange}
-            />
-            {waitingForDevice && (
-              <div className="mb-3 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-300">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                <span>Waiting for device...</span>
-              </div>
-            )}
-            {attachments.length > 0 && (
-              <div className="mb-3 flex flex-wrap gap-2">
+            className="hidden"
+            onChange={handleFileInputChange}
+          />
+          {waitingForDevice && (
+            <div className="mb-3 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-300">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Waiting for device...</span>
+            </div>
+          )}
+          {attachments.length > 0 && (
+            <div className="mb-3 flex flex-wrap gap-2">
               {attachments.map((attachment, idx) => (
                 <div
                   key={`${attachment.name || 'image'}-${idx}`}

--- a/frontend/src/hooks/useTaskSessionConversation.ts
+++ b/frontend/src/hooks/useTaskSessionConversation.ts
@@ -50,6 +50,7 @@ interface UseTaskSessionConversationResult {
   setMessages: Dispatch<SetStateAction<TaskConversationMessage[]>>;
   loading: boolean;
   aborting: boolean;
+  waitingForDevice: boolean;
   error: string | null;
   sessionReady: boolean;
   sendMessage: (
@@ -62,6 +63,10 @@ interface UseTaskSessionConversationResult {
 
 function isTaskActive(status: TaskStatus): boolean {
   return status === 'QUEUED' || status === 'RUNNING';
+}
+
+function isTaskWaitingForDevice(task: TaskRunResponse): boolean {
+  return task.status === 'QUEUED';
 }
 
 function applyTaskEventToTask(
@@ -196,23 +201,8 @@ function buildAssistantMessage(
         currentThinking = '';
         break;
       }
-      case 'status': {
-        if (
-          payload.status === 'QUEUED' &&
-          !currentThinking &&
-          !content &&
-          thinking.length === 0
-        ) {
-          currentThinking = 'Waiting for device...';
-        }
-        break;
-      }
     }
   });
-
-  if (task.status === 'QUEUED' && !currentThinking && !content) {
-    currentThinking = 'Waiting for device...';
-  }
 
   return {
     id: `${task.id}-agent`,
@@ -268,6 +258,7 @@ export function useTaskSessionConversation({
   const [messages, setMessages] = useState<TaskConversationMessage[]>([]);
   const [loading, setLoading] = useState(false);
   const [aborting, setAborting] = useState(false);
+  const [waitingForDevice, setWaitingForDevice] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [sessionId, setSessionId] = useState<string | null>(null);
   const chatStreamRef = useRef<{ close: () => void } | null>(null);
@@ -320,6 +311,7 @@ export function useTaskSessionConversation({
 
       const nextTask = applyTaskEventToTask(currentTask, event);
       taskRunsRef.current[taskId] = nextTask;
+      setWaitingForDevice(isTaskWaitingForDevice(nextTask));
       replaceTaskMessages(taskId);
 
       if (
@@ -328,6 +320,7 @@ export function useTaskSessionConversation({
       ) {
         setLoading(false);
         setAborting(false);
+        setWaitingForDevice(false);
         currentTaskIdRef.current = null;
       }
     },
@@ -349,6 +342,7 @@ export function useTaskSessionConversation({
           setError(message);
           setLoading(false);
           setAborting(false);
+          setWaitingForDevice(false);
           chatStreamRef.current = null;
         },
         afterSeq
@@ -390,6 +384,7 @@ export function useTaskSessionConversation({
       if (activeTask) {
         currentTaskIdRef.current = activeTask.id;
         setLoading(true);
+        setWaitingForDevice(isTaskWaitingForDevice(activeTask));
         const lastSeq =
           taskEventsRef.current[activeTask.id]?.[
             taskEventsRef.current[activeTask.id].length - 1
@@ -398,6 +393,7 @@ export function useTaskSessionConversation({
       } else {
         currentTaskIdRef.current = null;
         setLoading(false);
+        setWaitingForDevice(false);
       }
     },
     [attachTaskStream]
@@ -443,6 +439,7 @@ export function useTaskSessionConversation({
           console.error('Failed to initialize task session:', sessionError);
           setError('Failed to restore chat session');
           setLoading(false);
+          setWaitingForDevice(false);
         }
       }
     };
@@ -481,6 +478,7 @@ export function useTaskSessionConversation({
         currentTaskIdRef.current = isTaskActive(reconciledTask.status)
           ? task.id
           : null;
+        setWaitingForDevice(isTaskWaitingForDevice(reconciledTask));
         replaceTaskMessages(task.id);
 
         if (isTaskActive(reconciledTask.status)) {
@@ -489,6 +487,7 @@ export function useTaskSessionConversation({
         } else {
           setLoading(false);
           setAborting(false);
+          setWaitingForDevice(false);
         }
 
         return true;
@@ -521,6 +520,7 @@ export function useTaskSessionConversation({
       currentTaskIdRef.current = null;
       setMessages([]);
       setLoading(false);
+      setWaitingForDevice(false);
       setError(null);
       setAborting(false);
     } catch (resetError) {
@@ -544,6 +544,7 @@ export function useTaskSessionConversation({
       const response = await cancelTaskRun(taskId);
       if (response.task) {
         taskRunsRef.current[taskId] = response.task;
+        setWaitingForDevice(isTaskWaitingForDevice(response.task));
         replaceTaskMessages(taskId);
       }
     } catch (abortError) {
@@ -570,6 +571,7 @@ export function useTaskSessionConversation({
     setMessages,
     loading,
     aborting,
+    waitingForDevice,
     error,
     sessionReady: sessionId !== null,
     sendMessage,


### PR DESCRIPTION
## Summary
- remove queued waiting text from classic chat conversation message content/thinking
- surface device wait as a separate status banner in the classic device panel
- keep the fix scoped to the frontend display layer only

## Validation
- cd frontend && pnpm run type-check
- cd frontend && pnpm run build