### PR TITLE
feat: frontend parameter hot update without restarting the application.

### DIFF
--- a/AutoGLM_GUI/api/agents.py
+++ b/AutoGLM_GUI/api/agents.py
@@ -243,9 +243,10 @@ def get_config_endpoint() -> ConfigResponse:
 def save_config_endpoint(request: ConfigSaveRequest) -> dict[str, Any]:
     """保存配置到文件.
 
-    配置保存后需重启应用以立即生效。
+    配置保存后会自动热更新，所有 Agent 将被销毁并在下次使用时用新配置重新创建。
     """
     from AutoGLM_GUI.config_manager import ConfigModel, config_manager
+    from AutoGLM_GUI.phone_agent_manager import PhoneAgentManager
 
     try:
         # Validate incoming configuration
@@ -282,12 +283,20 @@ def save_config_endpoint(request: ConfigSaveRequest) -> dict[str, Any]:
         # 同步到环境变量
         config_manager.sync_to_env()
 
+        # 强制重新加载配置文件，确保立即生效
+        config_manager.load_file_config(force_reload=True)
+
+        # 销毁所有已存在的 Agent，让它们在下次使用时用新配置重新创建
+        agent_manager = PhoneAgentManager.get_instance()
+        destroyed_count = agent_manager.destroy_all_agents()
+
         # 检测冲突并返回警告
         conflicts = config_manager.detect_conflicts()
 
         response_message = (
-            f"Configuration saved to {config_manager.get_config_path()}."
-            " Restart required to apply new configuration immediately."
+            f"Configuration saved to {config_manager.get_config_path()}. "
+            f"Destroyed {destroyed_count} agent(s). "
+            "New agents will be created with updated configuration on next use."
         )
 
         if conflicts:
@@ -299,13 +308,13 @@ def save_config_endpoint(request: ConfigSaveRequest) -> dict[str, Any]:
                 "success": True,
                 "message": response_message,
                 "warnings": warnings,
-                "restart_required": True,
+                "restart_required": False,
             }
 
         return {
             "success": True,
             "message": response_message,
-            "restart_required": True,
+            "restart_required": False,
         }
 
     except ValidationError as e:

--- a/AutoGLM_GUI/phone_agent_manager.py
+++ b/AutoGLM_GUI/phone_agent_manager.py
@@ -738,3 +738,32 @@ class PhoneAgentManager:
                 ) and metadata.abort_handler is not None:
                     return True
             return False
+
+    def destroy_all_agents(self) -> int:
+        """销毁所有 Agent 实例，用于配置热更新.
+
+        Returns:
+            int: 销毁的 Agent 数量
+        """
+        with self._manager_lock:
+            agent_keys = list(self._agents.keys())
+            count = len(agent_keys)
+
+            for agent_key in agent_keys:
+                agent = self._agents.pop(agent_key, None)
+                if agent:
+                    try:
+                        agent.reset()  # Clean up agent state
+                    except Exception as e:
+                        logger.warning(
+                            f"Error resetting agent {agent_key} during destroy_all: {e}"
+                        )
+
+                # Remove config and metadata
+                self._agent_configs.pop(agent_key, None)
+                self._metadata.pop(agent_key, None)
+
+            if count > 0:
+                logger.info(f"Destroyed {count} agent(s) for config hot reload")
+
+            return count

--- a/frontend/src/routes/chat.tsx
+++ b/frontend/src/routes/chat.tsx
@@ -178,12 +178,6 @@ type ChatSearchParams = {
   mode?: 'classic' | 'chatkit';
 };
 
-type ElectronRelaunchAPI = {
-  app?: {
-    relaunch: () => Promise<{ success: boolean }>;
-  };
-};
-
 function areAgentStatesEqual(
   left: Device['agent'] | null,
   right: Device['agent'] | null
@@ -516,21 +510,13 @@ function ChatComponent() {
         decision_api_key: tempConfig.decision_api_key || undefined,
       });
 
+      // 配置已保存，后端支持热更新，无需重启
       showToast(t.toasts.configSaved, 'success');
 
-      const electronApp = (
-        window as Window & { electronAPI?: ElectronRelaunchAPI }
-      ).electronAPI?.app;
-
-      if (saveResult.restart_required && electronApp?.relaunch) {
-        showToast('配置已保存，应用将立即重启以应用新配置', 'warning');
-        await new Promise(resolve => setTimeout(resolve, 600));
-        await electronApp.relaunch();
-        return;
-      }
-
-      if (saveResult.restart_required) {
-        showToast('配置已保存，请手动重启应用以立即生效', 'warning');
+      // 如果有警告信息（配置冲突），显示警告
+      if (saveResult.warnings && saveResult.warnings.length > 0) {
+        const warningMsg = saveResult.warnings.join('; ');
+        showToast(`配置已保存，但存在冲突: ${warningMsg}`, 'warning');
       }
 
       setShowConfig(false);

--- a/tests/test_agents_chat_config_api.py
+++ b/tests/test_agents_chat_config_api.py
@@ -59,6 +59,7 @@ class FakePhoneAgentManager:
         self.unregistered_handlers: list[str] = []
         self.destroy_candidates: list[str] = []
         self.destroy_calls: list[str] = []
+        self.destroy_all_count = 0
 
     def acquire_device(self, device_id: str, **kwargs) -> bool:
         _ = kwargs
@@ -99,6 +100,13 @@ class FakePhoneAgentManager:
         if device_id.endswith("-fail"):
             raise RuntimeError("destroy failed")
 
+    def destroy_all_agents(self) -> int:
+        """销毁所有 Agent，返回销毁数量."""
+        count = len(self.destroy_candidates)
+        self.destroy_all_count = count
+        self.destroy_candidates.clear()
+        return count
+
 
 class FakeConfigManager:
     def __init__(self) -> None:
@@ -123,7 +131,8 @@ class FakeConfigManager:
         self.sync_called = False
         self.save_kwargs: dict[str, Any] | None = None
 
-    def load_file_config(self) -> None:
+    def load_file_config(self, force_reload: bool = False) -> None:
+        _ = force_reload
         return None
 
     def get_effective_config(self) -> SimpleNamespace:
@@ -487,6 +496,9 @@ def test_save_config_success_with_warnings_and_restart_required(
             override_source=SimpleNamespace(value="CLI arguments"),
         )
     ]
+    # 模拟有2个已存在的 Agent
+    env["phone_manager"].destroy_candidates = ["device1", "device2"]
+
     response = env["client"].post(
         "/api/config",
         json={
@@ -501,12 +513,14 @@ def test_save_config_success_with_warnings_and_restart_required(
     assert response.status_code == 200
     payload = response.json()
     assert payload["success"] is True
-    assert payload["restart_required"] is True
+    assert payload["restart_required"] is False  # 热更新，无需重启
     assert "warnings" in payload
     assert env["config_manager"].sync_called is True
     assert env["config_manager"].save_kwargs is not None
     assert env["config_manager"].save_kwargs["merge_mode"] is True
-    assert env["phone_manager"].destroy_calls == []
+    # 验证 destroy_all_agents 被调用
+    assert env["phone_manager"].destroy_all_count == 2
+    assert "Destroyed 2 agent(s)" in payload["message"]
 
 
 def test_save_config_returns_500_when_persist_fails(env: dict[str, Any]) -> None:


### PR DESCRIPTION
## 改动说明
- 当前实现中，每次修改设置-模型相关参数时，提示需要重启应用才能生效
- 应用部署后，用户是无法操作服务的启停的，导致参数配置的修改功能丧失意义
- 本次提交优化了此问题

## 相关 Issue
- Close #367 

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 代码重构
- [ ] 性能优化
- [ ] 其他（请说明）

## 测试说明

`uv run pytest tests/test_agents_chat_config_api.py`

## 截图/录屏

<img width="568" height="173" alt="image" src="https://github.com/user-attachments/assets/b3eb0f0b-26bc-439a-ae1e-2aff38f10280" />

---> 

<img width="514" height="137" alt="image" src="https://github.com/user-attachments/assets/4c03c827-a29c-4b95-be6e-e68120d0bb5f" />

## 其他说明
