### PR TITLE
fix(frontend): fix input image zoom preview.

### DIFF
--- a/frontend/src/components/DevicePanel.tsx
+++ b/frontend/src/components/DevicePanel.tsx
@@ -1019,13 +1019,15 @@ export function DevicePanel({
                             message.attachments.length > 0 && (
                               <div className="grid grid-cols-2 gap-2">
                                 {message.attachments.map((attachment, idx) => (
-                                  <img
+                                  <ImagePreview
                                     key={`${message.id}-attachment-${idx}`}
                                     src={`data:${attachment.mime_type};base64,${attachment.data}`}
                                     alt={
                                       attachment.name || `Attachment ${idx + 1}`
                                     }
-                                    className="h-24 w-full rounded-lg object-cover border border-white/20"
+                                    className="w-full border-white/20"
+                                    thumbnailClassName="w-full object-cover"
+                                    maxHeight="96px"
                                   />
                                 ))}
                               </div>
@@ -1084,17 +1086,19 @@ export function DevicePanel({
               {attachments.map((attachment, idx) => (
                 <div
                   key={`${attachment.name || 'image'}-${idx}`}
-                  className="relative h-16 w-16 overflow-hidden rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-800"
+                  className="relative"
                 >
-                  <img
+                  <ImagePreview
                     src={`data:${attachment.mime_type};base64,${attachment.data}`}
                     alt={attachment.name || `Attachment ${idx + 1}`}
-                    className="h-full w-full object-cover"
+                    className="h-16 w-16 border-slate-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-800"
+                    thumbnailClassName="h-full w-full object-cover"
+                    maxHeight="64px"
                   />
                   <button
                     type="button"
                     onClick={() => removeAttachment(idx)}
-                    className="absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-slate-950/70 text-white hover:bg-slate-950"
+                    className="absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-slate-950/70 text-white hover:bg-slate-950 z-10"
                     aria-label="移除图片"
                   >
                     <X className="h-3 w-3" />


### PR DESCRIPTION
## 改动说明

- 经典模式最近新增了加载图片输入功能，实测发现【添加图片】加载图片后，在输入框上的预览图片，以及发送后图片无法点击放大；abd截图是可以正常放大的
- 修改了 frontend/src/components/DevicePanel.tsx 文件：
  1. 输入框缩略图（第1082-1104行）：
     - 将普通的 <img> 标签替换为 ImagePreview 组件
     - 保持了原有的样式和删除按钮功能
     - 添加了 z-10 确保删除按钮在最上层
  2. 对话窗口用户消息图片（第1016-1042行）：
     - 将普通的 <img> 标签替换为 ImagePreview 组件
     - 保持了原有的网格布局和样式
     - 设置 maxHeight="96px" 保持与原来 h-24 相同的高度
- 功能特性
  - ✅ 点击缩略图打开全屏预览
  - ✅ 鼠标悬停显示放大图标提示
  - ✅ ESC 键关闭预览
  - ✅ 点击背景关闭预览
  - ✅ 与 ADB 截图的交互体验保持一致

## 相关 Issue
fix #383

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 代码重构
- [ ] 性能优化
- [ ] 其他（请说明）

## 测试说明
- 前端简单测试

## 截图/录屏

<img width="655" height="1205" alt="image" src="https://github.com/user-attachments/assets/fb57de3d-4b1e-4037-9b32-425a3fce5b9f" />

## 其他说明
