### PR TITLE
chore: add conservative renovate pilot config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,7 @@
     },
     {
       "description": "Group Python uv dependencies",
-      "matchManagers": ["pep621", "uv"],
+      "matchManagers": ["pep621"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "python uv dependencies",
       "commitMessagePrefix": "chore(deps):",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "Asia/Shanghai",
+  "schedule": ["before 8am on monday"],
+  "automerge": false,
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Renovate Dependency Dashboard",
+  "labels": ["dependencies", "renovate"],
+  "prConcurrentLimit": 3,
+  "branchConcurrentLimit": 3,
+  "prHourlyLimit": 3,
+  "rangeStrategy": "bump",
+  "rebaseWhen": "conflicted",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 8am on the first day of the month"],
+    "automerge": false
+  },
+  "packageRules": [
+    {
+      "description": "Group frontend pnpm dependencies",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["frontend/package.json"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "frontend pnpm dependencies",
+      "commitMessagePrefix": "chore(deps):",
+      "additionalBranchPrefix": "frontend-"
+    },
+    {
+      "description": "Group Electron pnpm dependencies",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["electron/package.json"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "electron pnpm dependencies",
+      "commitMessagePrefix": "chore(deps):",
+      "additionalBranchPrefix": "electron-"
+    },
+    {
+      "description": "Group documentation pnpm dependencies",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["docs/package.json"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "docs pnpm dependencies",
+      "commitMessagePrefix": "chore(deps):",
+      "additionalBranchPrefix": "docs-"
+    },
+    {
+      "description": "Group Python uv dependencies",
+      "matchManagers": ["pep621", "uv"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "python uv dependencies",
+      "commitMessagePrefix": "chore(deps):",
+      "additionalBranchPrefix": "python-"
+    },
+    {
+      "description": "Group Docker base image updates",
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "docker dependencies",
+      "commitMessagePrefix": "chore(deps):",
+      "additionalBranchPrefix": "docker-"
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "github actions dependencies",
+      "commitMessagePrefix": "chore(deps):",
+      "additionalBranchPrefix": "github-actions-"
+    },
+    {
+      "description": "Keep major updates isolated for manual review",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+      "commitMessagePrefix": "chore(deps-major):",
+      "labels": ["dependencies", "renovate", "major"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds a conservative Renovate pilot configuration only. It does not change application code or dependency versions.

Pilot behavior:
- Runs on a weekly schedule using `Asia/Shanghai` timezone.
- Limits noise with `prConcurrentLimit: 3`, `branchConcurrentLimit: 3`, and `prHourlyLimit: 3`.
- Keeps `automerge` disabled globally and for lockfile maintenance.
- Groups minor/patch updates by ecosystem:
  - frontend pnpm
  - electron pnpm
  - docs pnpm
  - Python uv
  - Docker
  - GitHub Actions
- Keeps major updates isolated and requires Dependency Dashboard approval.
- Enables monthly lockfile maintenance.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('renovate.json','utf8')); console.log('renovate.json valid JSON')"`
- `python3` validation against `https://docs.renovatebot.com/renovate-schema.json` using `jsonschema` passed.

I also attempted `npm exec --yes --package=renovate renovate-config-validator renovate.json`, but the local `npx`/Node 22 toolchain failed before reading the config with a `minipass-pipeline` runtime error. The schema validation above completed successfully.

## Rollout note

Renovate will not start opening PRs until the Renovate GitHub App is installed/authorized for `suyiiyii/AutoGLM-GUI`.
