### PR TITLE
feat: add normalized harness golden check

### DIFF
--- a/scripts/run_harness.py
+++ b/scripts/run_harness.py
@@ -266,6 +266,22 @@ def _collect_replay_event_names(replay_file: Path) -> list[str]:
     )
 
 
+def _wait_for_replay_events(
+    replay_file: Path, required_event_names: list[str], timeout: float = 5.0
+) -> list[str]:
+    deadline = time.monotonic() + timeout
+    required = set(required_event_names)
+    event_names: list[str] = []
+
+    while time.monotonic() <= deadline:
+        event_names = _collect_replay_event_names(replay_file)
+        if required.issubset(event_names):
+            return event_names
+        time.sleep(0.1)
+
+    return event_names
+
+
 def _collect_step_actions(replay_file: Path) -> list[dict[str, Any]]:
     if not replay_file.exists():
         return []
@@ -515,6 +531,10 @@ def run_meituan_harness(
                     )
                     result["artifacts"]["replay_file"] = str(replay_file)
                     result["replay_file"] = str(replay_file)
+                    _wait_for_replay_events(
+                        replay_file,
+                        REQUIRED_REPLAY_EVENT_NAMES,
+                    )
                     screenshot_paths = _collect_screenshot_paths(replay_file)
                     result["artifacts"]["screenshots"] = screenshot_paths
                     result["screenshot_paths"] = screenshot_paths

--- a/scripts/run_harness.py
+++ b/scripts/run_harness.py
@@ -57,6 +57,33 @@ from tests.integration.test_trace_replay_e2e import _read_jsonl  # noqa: E402
 
 SCENARIOS_DIR = PROJECT_ROOT / "tests" / "integration" / "fixtures" / "scenarios"
 DEFAULT_REPORT = PROJECT_ROOT / "test-results" / "harness" / "report.json"
+GOLDEN_SCHEMA = "autoglm.harness.golden.v1"
+REQUIRED_TRACE_SPAN_NAMES = [
+    "agent.step",
+    "step.capture_screenshot",
+    "step.llm",
+    "step.execute_action",
+    "task_store.event.append",
+    "task_store.task.finish",
+]
+REQUIRED_REPLAY_EVENT_NAMES = [
+    "autoglm.task.start",
+    "autoglm.step",
+    "autoglm.task.done",
+    "autoglm.task.status",
+    "autoglm.trace.summary",
+]
+INTERACTIVE_DEVICE_ACTIONS = {
+    "tap",
+    "double_tap",
+    "long_press",
+    "swipe",
+    "type_text",
+    "clear_text",
+    "back",
+    "home",
+    "launch_app",
+}
 
 
 @dataclass
@@ -183,23 +210,192 @@ def _save_task_events(
     return target, payload["events"]
 
 
-def _build_reproduce_command(report_path: Path, scenario_name: str) -> str:
-    return (
-        "uv run python scripts/run_harness.py "
-        f"--scenario {scenario_name} --report-json {report_path}"
+def _build_reproduce_command(
+    report_path: Path,
+    scenario_name: str,
+    *,
+    check_golden: bool = False,
+    golden_file: Path | None = None,
+    write_golden: bool = False,
+) -> str:
+    parts = [
+        "uv run python scripts/run_harness.py",
+        f"--scenario {scenario_name}",
+        f"--report-json {report_path}",
+    ]
+    if check_golden:
+        parts.append("--check-golden")
+    if write_golden:
+        parts.append("--write-golden")
+    if golden_file is not None:
+        parts.append(f"--golden-file {golden_file}")
+    return " ".join(parts)
+
+
+def _default_golden_file(scenario_path: Path) -> Path:
+    return scenario_path.with_name("golden.normalized.json")
+
+
+def _collect_trace_span_names(trace_file: Path, trace_id: str | None) -> list[str]:
+    if not trace_file.exists() or not trace_id:
+        return []
+    return sorted(
+        {
+            record["name"]
+            for record in _read_jsonl(trace_file)
+            if record.get("trace_id") == trace_id
+            and record.get("record_type") == "span"
+        }
     )
+
+
+def _collect_replay_event_names(replay_file: Path) -> list[str]:
+    if not replay_file.exists():
+        return []
+    return sorted(
+        {
+            record["event_name"]
+            for record in _read_jsonl(replay_file)
+            if record.get("event_name")
+        }
+    )
+
+
+def _collect_step_actions(replay_file: Path) -> list[dict[str, Any]]:
+    if not replay_file.exists():
+        return []
+
+    step_actions: list[dict[str, Any]] = []
+    for record in _read_jsonl(replay_file):
+        if record.get("event_name") != "autoglm.step":
+            continue
+        step = record.get("step") or {}
+        action = step.get("action") or {}
+        normalized_action = action.get("action")
+        if normalized_action is None and "_metadata" in action:
+            normalized_action = action["_metadata"]
+        step_actions.append(
+            {
+                "index": step.get("index"),
+                "action": normalized_action,
+            }
+        )
+    return step_actions
+
+
+def _build_normalized_golden(
+    *,
+    scenario_name: str,
+    result: dict[str, Any],
+    replay_file: Path | None,
+    trace_file: Path | None,
+    task_events: list[dict[str, Any]],
+) -> dict[str, Any]:
+    done_event = next(
+        (event for event in task_events if event.get("event_type") == "done"),
+        None,
+    )
+    device_action_sequence = [
+        action["action"]
+        for action in result.get("action_history", [])
+        if action.get("action") in INTERACTIVE_DEVICE_ACTIONS
+    ]
+
+    replay_event_names = _collect_replay_event_names(replay_file) if replay_file else []
+    trace_span_names = (
+        _collect_trace_span_names(trace_file, result.get("trace_id"))
+        if trace_file
+        else []
+    )
+    step_actions = _collect_step_actions(replay_file) if replay_file else []
+
+    return {
+        "schema": GOLDEN_SCHEMA,
+        "scenario": scenario_name,
+        "task_status": result.get("task_status"),
+        "completion": {
+            "done_event_success": (
+                (done_event.get("payload") or {}).get("success") if done_event else None
+            ),
+            "step_count": len(step_actions),
+        },
+        "device_action_sequence": device_action_sequence,
+        "step_actions": step_actions,
+        "required_replay_event_names": REQUIRED_REPLAY_EVENT_NAMES,
+        "required_trace_span_names": REQUIRED_TRACE_SPAN_NAMES,
+        "actual_replay_event_names": replay_event_names,
+        "actual_trace_span_names": trace_span_names,
+    }
+
+
+def _compare_golden(
+    expected: dict[str, Any], actual: dict[str, Any]
+) -> tuple[bool, list[str]]:
+    diffs: list[str] = []
+
+    if expected.get("schema") != GOLDEN_SCHEMA:
+        diffs.append(
+            f"golden schema mismatch: expected {GOLDEN_SCHEMA}, got {expected.get('schema')}"
+        )
+
+    for key in ("scenario", "task_status"):
+        if expected.get(key) != actual.get(key):
+            diffs.append(
+                f"{key} mismatch: expected {expected.get(key)!r}, got {actual.get(key)!r}"
+            )
+
+    expected_completion = expected.get("completion") or {}
+    actual_completion = actual.get("completion") or {}
+    for key in ("done_event_success", "step_count"):
+        if expected_completion.get(key) != actual_completion.get(key):
+            diffs.append(
+                f"completion.{key} mismatch: expected {expected_completion.get(key)!r}, "
+                f"got {actual_completion.get(key)!r}"
+            )
+
+    if expected.get("device_action_sequence") != actual.get("device_action_sequence"):
+        diffs.append(
+            "device_action_sequence mismatch: "
+            f"expected {expected.get('device_action_sequence')!r}, "
+            f"got {actual.get('device_action_sequence')!r}"
+        )
+
+    if expected.get("step_actions") != actual.get("step_actions"):
+        diffs.append(
+            f"step_actions mismatch: expected {expected.get('step_actions')!r}, "
+            f"got {actual.get('step_actions')!r}"
+        )
+
+    expected_replay = set(expected.get("required_replay_event_names") or [])
+    actual_replay = set(actual.get("actual_replay_event_names") or [])
+    missing_replay = sorted(expected_replay - actual_replay)
+    if missing_replay:
+        diffs.append(f"missing replay events: {missing_replay}")
+
+    expected_trace = set(expected.get("required_trace_span_names") or [])
+    actual_trace = set(actual.get("actual_trace_span_names") or [])
+    missing_trace = sorted(expected_trace - actual_trace)
+    if missing_trace:
+        diffs.append(f"missing trace spans: {missing_trace}")
+
+    return len(diffs) == 0, diffs
 
 
 def run_meituan_harness(
     scenario_name: str,
     scenario_path: Path,
     report_path: Path,
+    *,
+    check_golden: bool = False,
+    golden_file: Path | None = None,
+    write_golden: bool = False,
 ) -> dict[str, Any]:
     report_path.parent.mkdir(parents=True, exist_ok=True)
     run_dir = report_path.parent / f"{scenario_name}-{_timestamp_slug()}"
     run_dir.mkdir(parents=True, exist_ok=True)
 
     metadata = _load_scenario_metadata(scenario_path)
+    effective_golden_file = golden_file or _default_golden_file(scenario_path)
     result: dict[str, Any] = {
         "scenario": scenario_name,
         "status": "failed",
@@ -219,12 +415,29 @@ def run_meituan_harness(
             "task_events_file": None,
             "screenshots": [],
         },
-        "reproduce_command": _build_reproduce_command(report_path, scenario_name),
+        "reproduce_command": _build_reproduce_command(
+            report_path,
+            scenario_name,
+            check_golden=check_golden,
+            golden_file=effective_golden_file,
+            write_golden=write_golden,
+        ),
+        "golden_update_command": _build_reproduce_command(
+            report_path,
+            scenario_name,
+            golden_file=effective_golden_file,
+            write_golden=True,
+        ),
         "instruction": metadata["instruction"],
         "test_name": metadata["test_name"],
         "task_status": None,
         "final_message": None,
         "llm_request_count": 0,
+        "golden_enabled": check_golden or write_golden,
+        "golden_file": str(effective_golden_file),
+        "golden_status": "skipped",
+        "golden_diff_summary": [],
+        "golden_actual_file": None,
     }
 
     try:
@@ -325,6 +538,52 @@ def run_meituan_harness(
                         if maybe_error:
                             result["failure_reason"] = maybe_error
                             result["status"] = "failed"
+
+                normalized_golden = _build_normalized_golden(
+                    scenario_name=scenario_name,
+                    result=result,
+                    replay_file=replay_file,
+                    trace_file=services.trace_file,
+                    task_events=events,
+                )
+                golden_actual_file = run_dir / "golden.normalized.actual.json"
+                golden_actual_file.write_text(
+                    json.dumps(normalized_golden, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+                result["golden_actual_file"] = str(golden_actual_file)
+
+                if write_golden:
+                    effective_golden_file.parent.mkdir(parents=True, exist_ok=True)
+                    effective_golden_file.write_text(
+                        json.dumps(normalized_golden, ensure_ascii=False, indent=2)
+                        + "\n",
+                        encoding="utf-8",
+                    )
+                    result["golden_status"] = "updated"
+
+                if check_golden:
+                    if not effective_golden_file.exists():
+                        result["golden_status"] = "failed"
+                        result["golden_diff_summary"] = [
+                            f"golden file missing: {effective_golden_file}"
+                        ]
+                        result["status"] = "failed"
+                        result["failure_reason"] = "golden check failed"
+                    else:
+                        expected_golden = json.loads(
+                            effective_golden_file.read_text(encoding="utf-8")
+                        )
+                        golden_passed, golden_diffs = _compare_golden(
+                            expected_golden, normalized_golden
+                        )
+                        result["golden_status"] = (
+                            "passed" if golden_passed else "failed"
+                        )
+                        result["golden_diff_summary"] = golden_diffs
+                        if not golden_passed:
+                            result["status"] = "failed"
+                            result["failure_reason"] = "golden check failed"
             finally:
                 test_client.close()
                 llm_client.close()
@@ -350,12 +609,21 @@ def print_summary(result: dict[str, Any], report_path: Path) -> None:
     print(f"trace_id:        {result.get('trace_id')}")
     print(f"final_message:   {result.get('final_message')}")
     print(f"failure_reason:  {result.get('failure_reason')}")
+    print(f"golden_enabled:  {result.get('golden_enabled')}")
+    print(f"golden_status:   {result.get('golden_status')}")
+    print(f"golden_file:     {result.get('golden_file')}")
+    print(f"golden_actual:   {result.get('golden_actual_file')}")
+    print(f"golden_update:   {result.get('golden_update_command')}")
     print(f"report_json:     {report_path}")
     print(f"trace_file:      {result['artifacts'].get('trace_file')}")
     print(f"replay_file:     {result['artifacts'].get('replay_file')}")
     print(f"task_events:     {result['artifacts'].get('task_events_file')}")
     print(f"screenshots:     {len(result['artifacts'].get('screenshots', []))}")
     print(f"reproduce:       {result['reproduce_command']}")
+    if result.get("golden_diff_summary"):
+        print("golden_diff_summary:")
+        for diff in result["golden_diff_summary"]:
+            print(f"  - {diff}")
     print("action_history:")
     for index, action in enumerate(result.get("action_history", []), start=1):
         print(f"  {index}. {json.dumps(action, ensure_ascii=False)}")
@@ -371,7 +639,14 @@ def cmd_list() -> int:
     return 0
 
 
-def cmd_run(scenario_name: str, report_path: Path) -> int:
+def cmd_run(
+    scenario_name: str,
+    report_path: Path,
+    *,
+    check_golden: bool = False,
+    golden_file: Path | None = None,
+    write_golden: bool = False,
+) -> int:
     scenarios = discover_scenarios()
     scenario_path = scenarios.get(scenario_name)
     if scenario_path is None:
@@ -386,7 +661,15 @@ def cmd_run(scenario_name: str, report_path: Path) -> int:
         )
         return 2
 
-    result = run_meituan_harness(scenario_name, scenario_path, report_path)
+    effective_golden_file = golden_file or _default_golden_file(scenario_path)
+    result = run_meituan_harness(
+        scenario_name,
+        scenario_path,
+        report_path,
+        check_golden=check_golden,
+        golden_file=effective_golden_file,
+        write_golden=write_golden,
+    )
     print_summary(result, report_path)
     return 0 if result["status"] == "passed" else 1
 
@@ -408,6 +691,21 @@ def parse_args() -> argparse.Namespace:
         default=DEFAULT_REPORT,
         help="Path to write the JSON report",
     )
+    parser.add_argument(
+        "--check-golden",
+        action="store_true",
+        help="Check a normalized semantic golden for meituan_message",
+    )
+    parser.add_argument(
+        "--write-golden",
+        action="store_true",
+        help="Write/update the normalized golden file from the current run",
+    )
+    parser.add_argument(
+        "--golden-file",
+        type=Path,
+        help="Optional override path for the normalized golden JSON",
+    )
     return parser.parse_args()
 
 
@@ -418,7 +716,13 @@ def main() -> int:
         return cmd_list()
 
     if args.scenario:
-        return cmd_run(args.scenario, args.report_json.resolve())
+        return cmd_run(
+            args.scenario,
+            args.report_json.resolve(),
+            check_golden=args.check_golden,
+            golden_file=args.golden_file.resolve() if args.golden_file else None,
+            write_golden=args.write_golden,
+        )
 
     print("Either --list or --scenario must be provided.", file=sys.stderr)
     return 2

--- a/scripts/run_harness.py
+++ b/scripts/run_harness.py
@@ -584,7 +584,8 @@ def run_meituan_harness(
                             f"golden file missing: {effective_golden_file}"
                         ]
                         result["status"] = "failed"
-                        result["failure_reason"] = "golden check failed"
+                        if result["failure_reason"] is None:
+                            result["failure_reason"] = "golden check failed"
                     else:
                         expected_golden = json.loads(
                             effective_golden_file.read_text(encoding="utf-8")
@@ -598,7 +599,8 @@ def run_meituan_harness(
                         result["golden_diff_summary"] = golden_diffs
                         if not golden_passed:
                             result["status"] = "failed"
-                            result["failure_reason"] = "golden check failed"
+                            if result["failure_reason"] is None:
+                                result["failure_reason"] = "golden check failed"
             finally:
                 test_client.close()
                 llm_client.close()

--- a/scripts/run_harness.py
+++ b/scripts/run_harness.py
@@ -7,11 +7,16 @@ Phase 1 scope:
   mock LLM + mock device + trace/replay path
 - write a JSON report with artifact paths and a reproduction command
 
+Phase 2 scope:
+- optionally check or update a normalized semantic golden for meituan_message
+- compare stable semantic fields instead of raw timestamps, durations, ids,
+  absolute paths, screenshots, or base64 payloads
+
 Non-goals:
 - dynamic port architecture changes
 - coverage / codecov policy
 - custom structural checks
-- full golden replay platform
+- full raw golden replay platform
 - CI gate changes
 """
 
@@ -553,7 +558,17 @@ def run_meituan_harness(
                 )
                 result["golden_actual_file"] = str(golden_actual_file)
 
-                if write_golden:
+                if write_golden and result["status"] != "passed":
+                    result["golden_status"] = "failed"
+                    result["golden_diff_summary"] = [
+                        "refusing to update golden from a failed harness run"
+                    ]
+                    if result["failure_reason"] is None:
+                        result["failure_reason"] = (
+                            "golden update requires a passed harness run"
+                        )
+
+                if write_golden and result["status"] == "passed":
                     effective_golden_file.parent.mkdir(parents=True, exist_ok=True)
                     effective_golden_file.write_text(
                         json.dumps(normalized_golden, ensure_ascii=False, indent=2)
@@ -711,6 +726,14 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+
+    if args.check_golden and args.write_golden:
+        print(
+            "--check-golden and --write-golden cannot be used together; "
+            "check the committed baseline or update it in separate runs.",
+            file=sys.stderr,
+        )
+        return 2
 
     if args.list:
         return cmd_list()

--- a/tests/integration/fixtures/scenarios/meituan_message/golden.normalized.json
+++ b/tests/integration/fixtures/scenarios/meituan_message/golden.normalized.json
@@ -1,0 +1,67 @@
+{
+  "schema": "autoglm.harness.golden.v1",
+  "scenario": "meituan_message",
+  "task_status": "SUCCEEDED",
+  "completion": {
+    "done_event_success": true,
+    "step_count": 2
+  },
+  "device_action_sequence": [
+    "tap"
+  ],
+  "step_actions": [
+    {
+      "index": 1,
+      "action": "Tap"
+    },
+    {
+      "index": 2,
+      "action": "finish"
+    }
+  ],
+  "required_replay_event_names": [
+    "autoglm.task.start",
+    "autoglm.step",
+    "autoglm.task.done",
+    "autoglm.task.status",
+    "autoglm.trace.summary"
+  ],
+  "required_trace_span_names": [
+    "agent.step",
+    "step.capture_screenshot",
+    "step.llm",
+    "step.execute_action",
+    "task_store.event.append",
+    "task_store.task.finish"
+  ],
+  "actual_replay_event_names": [
+    "autoglm.step",
+    "autoglm.task.done",
+    "autoglm.task.start",
+    "autoglm.task.status",
+    "autoglm.thinking",
+    "autoglm.trace.summary"
+  ],
+  "actual_trace_span_names": [
+    "action.execute",
+    "agent.prepare_initial_context",
+    "agent.prepare_initial_state",
+    "agent.step",
+    "agent.stream",
+    "agent_manager.create_agent",
+    "agent_manager.get_device_protocol",
+    "agent_manager.initialize_agent",
+    "remote_device.get",
+    "remote_device.post",
+    "step.build_message",
+    "step.capture_screenshot",
+    "step.execute_action",
+    "step.get_current_app",
+    "step.llm",
+    "step.parse_action",
+    "step.update_context",
+    "task_store.event.append",
+    "task_store.task.finish",
+    "task_store.task.set_trace_id"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a normalized golden replay pilot for `meituan_message`
- extend `scripts/run_harness.py` with `--check-golden`, `--write-golden`, and `--golden-file`
- write a committed semantic golden at `tests/integration/fixtures/scenarios/meituan_message/golden.normalized.json`
- surface golden status, diff summary, and update/reproduce commands in console + JSON report

## Validation
- `uv run python scripts/lint.py --backend --check-only`
- `uv run python scripts/run_harness.py --scenario meituan_message --report-json test-results/harness/report-phase2-plain.json`
- `uv run python scripts/run_harness.py --scenario meituan_message --check-golden --report-json test-results/harness/report-phase2-check.json`
- mismatch simulation: run with a temp modified golden file and confirm `golden_diff_summary` reports the semantic mismatch

## Golden update
To refresh the committed golden after an intentional semantic change:
```bash
uv run python scripts/run_harness.py \
  --scenario meituan_message \
  --write-golden \
  --report-json test-results/harness/report-phase2-write.json
```
