### PR TITLE
fix: skip empty adb keyboard broadcasts

### DIFF
--- a/AutoGLM_GUI/adb/input.py
+++ b/AutoGLM_GUI/adb/input.py
@@ -8,6 +8,10 @@ from AutoGLM_GUI.trace import trace_span
 
 
 def type_text(text: str, device_id: str | None = None) -> None:
+    # Empty --es values fail as missing args on some OEM am broadcast implementations.
+    if text == "":
+        return
+
     adb_prefix = build_adb_command(device_id)
     encoded_text = base64.b64encode(text.encode("utf-8")).decode("utf-8")
 

--- a/tests/test_adb_input.py
+++ b/tests/test_adb_input.py
@@ -1,0 +1,88 @@
+"""Unit tests for ADB text input helpers."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+import AutoGLM_GUI.adb.input as adb_input
+
+
+def test_type_text_empty_string_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(adb_input.subprocess, "run", fake_run)
+
+    adb_input.type_text("", device_id="device-1")
+
+    assert calls == []
+
+
+def test_type_text_non_empty_string_broadcasts_base64(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(adb_input.subprocess, "run", fake_run)
+
+    adb_input.type_text("123", device_id="device-1")
+
+    assert calls == [
+        (
+            [
+                "adb",
+                "-s",
+                "device-1",
+                "shell",
+                "am",
+                "broadcast",
+                "-a",
+                "ADB_INPUT_B64",
+                "--es",
+                "msg",
+                "MTIz",
+            ],
+            {"capture_output": True, "text": True, "check": True},
+        )
+    ]
+
+
+def test_detect_and_set_adb_keyboard_does_not_broadcast_empty_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[-4:] == ["settings", "get", "secure", "default_input_method"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="com.android.adbkeyboard/.AdbIME\n", stderr=""
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(adb_input.subprocess, "run", fake_run)
+
+    original_ime = adb_input.detect_and_set_adb_keyboard(device_id="device-1")
+
+    assert original_ime == "com.android.adbkeyboard/.AdbIME"
+    assert calls == [
+        [
+            "adb",
+            "-s",
+            "device-1",
+            "shell",
+            "settings",
+            "get",
+            "secure",
+            "default_input_method",
+        ]
+    ]


### PR DESCRIPTION
## Summary
- Treat empty ADB text input as a no-op before building the broadcast command
- Keep check=True for real ADB failures while avoiding OEM failures for --es msg empty values
- Add unit coverage for empty input, non-empty base64 broadcast, and keyboard detection

## Verification
- uv run pytest tests/test_adb_input.py -v
- uv run python scripts/lint.py --backend --check-only

Closes #382