### PR TITLE
Handle invalid Gemini tool calls as retryable

### DIFF
--- a/AutoGLM_GUI/agents/gemini/action_mapper.py
+++ b/AutoGLM_GUI/agents/gemini/action_mapper.py
@@ -2,7 +2,15 @@
 
 from typing import Any
 
-from AutoGLM_GUI.logger import logger
+
+class InvalidToolCallError(ValueError):
+    """Raised when a model tool call cannot be mapped to a device action."""
+
+    def __init__(self, tool_name: str, arguments: dict[str, Any], message: str):
+        super().__init__(message)
+        self.tool_name = tool_name
+        self.arguments = arguments
+        self.message = message
 
 
 def _require_int(args: dict[str, Any], key: str) -> int:
@@ -48,8 +56,7 @@ def tool_call_to_action(tool_name: str, arguments: dict[str, Any]) -> dict[str, 
     try:
         return _build_action(tool_name, arguments)
     except (ValueError, KeyError) as e:
-        logger.warning(f"Invalid tool arguments for {tool_name}: {e}")
-        return {"_metadata": "finish", "message": f"Invalid tool call: {e}"}
+        raise InvalidToolCallError(tool_name, arguments, str(e)) from e
 
 
 def _build_action(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
@@ -106,4 +113,4 @@ def _build_action(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
             "duration": args.get("duration", "1 seconds"),
         }
 
-    return {"_metadata": "finish", "message": f"Unknown tool: {tool_name}"}
+    raise InvalidToolCallError(tool_name, args, f"Unknown tool: {tool_name}")

--- a/AutoGLM_GUI/agents/gemini/async_agent.py
+++ b/AutoGLM_GUI/agents/gemini/async_agent.py
@@ -16,13 +16,23 @@ from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.model import MessageBuilder
 from AutoGLM_GUI.trace import summarize_text, trace_span
 
-from .action_mapper import tool_call_to_action
+from .action_mapper import InvalidToolCallError, tool_call_to_action
 from .prompts import get_system_prompt
 from .tools import DEVICE_TOOLS
 
 
 class AsyncGeminiAgent(AsyncAgentBase):
     """通用视觉模型 Agent，使用 function calling 而非自定义格式解析。"""
+
+    max_consecutive_invalid_tool_calls = 3
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._consecutive_invalid_tool_calls = 0
+
+    def reset(self) -> None:
+        super().reset()
+        self._consecutive_invalid_tool_calls = 0
 
     def _get_default_system_prompt(self, lang: str) -> str:
         return get_system_prompt(lang)
@@ -41,6 +51,7 @@ class AsyncGeminiAgent(AsyncAgentBase):
         reference_section = (
             f"\n\nUser reference images: {reference_notice}" if reference_notice else ""
         )
+        self._consecutive_invalid_tool_calls = 0
         self._context.append(
             MessageBuilder.create_user_message_with_images(
                 text=f"{task}{reference_section}\n\nCurrent app: {current_app}",
@@ -54,6 +65,7 @@ class AsyncGeminiAgent(AsyncAgentBase):
     async def _execute_step(self) -> AsyncGenerator[dict[str, Any], None]:
         """执行单步：调用 LLM → 解析 tool call → 执行动作。"""
         self._step_count += 1
+        screenshot = None
 
         # 1. 获取截图（非首步）
         if self._step_count > 1:
@@ -154,15 +166,86 @@ class AsyncGeminiAgent(AsyncAgentBase):
                     ),
                 },
             ) as span:
-                action = tool_call_to_action(tool_name, tool_args)
-                span.set_attribute("action_name", action.get("action"))
+                try:
+                    action = tool_call_to_action(tool_name, tool_args)
+                except InvalidToolCallError as exc:
+                    self._consecutive_invalid_tool_calls += 1
+                    error_message = self._invalid_tool_call_message(exc)
+                    logger.warning(
+                        f"Invalid Gemini tool call on step {self._step_count} "
+                        f"({tool_name}): {error_message}"
+                    )
+                    span.set_attributes(
+                        {
+                            "success": False,
+                            "error_kind": "invalid_arguments",
+                            "error_message": error_message,
+                            "invalid_count": self._consecutive_invalid_tool_calls,
+                        }
+                    )
+                    action = {
+                        "_metadata": "tool_error",
+                        "tool_name": tool_name,
+                        "arguments": tool_args,
+                        "message": error_message,
+                    }
+                else:
+                    self._consecutive_invalid_tool_calls = 0
+                    span.set_attributes(
+                        {"success": True, "action_name": action.get("action")}
+                    )
 
         if self.agent_config.verbose:
             logger.debug(f"🎯 Tool call: {tool_name}({tool_args})")
             logger.debug(f"   Action: {json.dumps(action, ensure_ascii=False)}")
 
+        if action.get("_metadata") == "tool_error":
+            limit_reached = (
+                self._consecutive_invalid_tool_calls
+                >= self.max_consecutive_invalid_tool_calls
+            )
+            error_message = str(action.get("message", "Invalid tool call"))
+            tool_result = {
+                "success": False,
+                "error_code": "invalid_tool_arguments",
+                "message": error_message,
+                "retryable": not limit_reached,
+            }
+            with trace_span(
+                "step.update_context",
+                attrs={"step": self._step_count, "agent_type": self.__class__.__name__},
+            ):
+                self._remove_latest_message_images()
+                self._append_tool_exchange(
+                    thinking=thinking,
+                    tool_name=tool_name,
+                    tool_args=tool_args,
+                    tool_result=tool_result,
+                )
+
+            message = error_message
+            if limit_reached:
+                message = (
+                    "Tool call validation failed "
+                    f"{self._consecutive_invalid_tool_calls} consecutive times: "
+                    f"{error_message}"
+                )
+
+            yield {
+                "type": "step",
+                "data": {
+                    "step": self._step_count,
+                    "thinking": thinking,
+                    "action": action,
+                    "success": False,
+                    "finished": limit_reached,
+                    "message": message,
+                    "screenshot": screenshot.base64_data if screenshot else None,
+                },
+            }
+            return
+
         # 4. 执行 action
-        screenshot = None
         try:
             with trace_span(
                 "step.capture_screenshot",
@@ -197,35 +280,15 @@ class AsyncGeminiAgent(AsyncAgentBase):
             "step.update_context",
             attrs={"step": self._step_count, "agent_type": self.__class__.__name__},
         ):
-            if len(self._context) > 1:
-                self._context[-1] = MessageBuilder.remove_images_from_message(
-                    self._context[-1]
-                )
-
-            self._context.append(
-                {
-                    "role": "assistant",
-                    "content": thinking or "",
-                    "tool_calls": [
-                        {
-                            "id": f"call_{self._step_count}",
-                            "type": "function",
-                            "function": {
-                                "name": tool_name,
-                                "arguments": json.dumps(tool_args),
-                            },
-                        }
-                    ],
-                }
-            )
-            self._context.append(
-                {
-                    "role": "tool",
-                    "tool_call_id": f"call_{self._step_count}",
-                    "content": json.dumps(
-                        {"success": result.success, "message": result.message or "OK"}
-                    ),
-                }
+            self._remove_latest_message_images()
+            self._append_tool_exchange(
+                thinking=thinking,
+                tool_name=tool_name,
+                tool_args=tool_args,
+                tool_result={
+                    "success": result.success,
+                    "message": result.message or "OK",
+                },
             )
 
         # 6. 检查完成
@@ -279,3 +342,49 @@ class AsyncGeminiAgent(AsyncAgentBase):
 
         logger.warning("Model did not return a tool call, treating as finish")
         return thinking, "finish", {"message": thinking or "No action returned"}
+
+    def _remove_latest_message_images(self) -> None:
+        if len(self._context) > 1:
+            self._context[-1] = MessageBuilder.remove_images_from_message(
+                self._context[-1]
+            )
+
+    def _append_tool_exchange(
+        self,
+        *,
+        thinking: str,
+        tool_name: str,
+        tool_args: dict[str, Any],
+        tool_result: dict[str, Any],
+    ) -> None:
+        tool_call_id = f"call_{self._step_count}"
+        self._context.append(
+            {
+                "role": "assistant",
+                "content": thinking or "",
+                "tool_calls": [
+                    {
+                        "id": tool_call_id,
+                        "type": "function",
+                        "function": {
+                            "name": tool_name,
+                            "arguments": json.dumps(tool_args, ensure_ascii=False),
+                        },
+                    }
+                ],
+            }
+        )
+        self._context.append(
+            {
+                "role": "tool",
+                "tool_call_id": tool_call_id,
+                "content": json.dumps(tool_result, ensure_ascii=False),
+            }
+        )
+
+    @staticmethod
+    def _invalid_tool_call_message(exc: InvalidToolCallError) -> str:
+        return (
+            f"Invalid tool call for {exc.tool_name}: {exc.message}. "
+            "Return arguments that match the declared tool schema."
+        )

--- a/tests/test_gemini_agent.py
+++ b/tests/test_gemini_agent.py
@@ -1,8 +1,16 @@
 """Tests for Gemini Agent components."""
 
+import asyncio
+import json
 from typing import Any
 
-from AutoGLM_GUI.agents.gemini.action_mapper import tool_call_to_action
+import pytest
+
+from AutoGLM_GUI.agents.gemini.action_mapper import (
+    InvalidToolCallError,
+    tool_call_to_action,
+)
+from AutoGLM_GUI.agents.gemini.async_agent import AsyncGeminiAgent
 from AutoGLM_GUI.agents.gemini.tools import DEVICE_TOOLS
 from AutoGLM_GUI.config import AgentConfig, ModelConfig
 from AutoGLM_GUI.device_protocol import Screenshot
@@ -29,6 +37,21 @@ class _FakeDevice:
 
     def get_current_app(self) -> str:
         return "com.example.app"
+
+
+class _QueuedToolCallGeminiAgent(AsyncGeminiAgent):
+    def __init__(self, tool_calls: list[tuple[str, str, dict[str, Any]]]):
+        super().__init__(
+            model_config=ModelConfig(),
+            agent_config=AgentConfig(max_steps=10, verbose=False),
+            device=_FakeDevice(),
+        )
+        self._tool_calls = tool_calls.copy()
+
+    async def _call_llm_with_tools(self) -> tuple[str, str, dict[str, Any]]:
+        if not self._tool_calls:
+            return "", "finish", {"message": "No queued tool calls"}
+        return self._tool_calls.pop(0)
 
 
 class TestDeviceTools:
@@ -123,21 +146,18 @@ class TestActionMapper:
         assert result == {"_metadata": "finish", "message": "Done"}
 
     def test_unknown_tool(self):
-        result = tool_call_to_action("unknown_tool", {})
-        assert result["_metadata"] == "finish"
-        assert "Unknown tool" in result["message"]
+        with pytest.raises(InvalidToolCallError, match="Unknown tool"):
+            tool_call_to_action("unknown_tool", {})
 
-    def test_missing_args_returns_finish(self):
-        """Missing required args should return finish, not raise KeyError."""
-        result = tool_call_to_action("tap", {})
-        assert result["_metadata"] == "finish"
-        assert "Invalid tool call" in result["message"]
+    def test_missing_args_raise_invalid_tool_call(self):
+        """Missing required args should be returned to the agent as tool errors."""
+        with pytest.raises(InvalidToolCallError, match="Missing required argument"):
+            tool_call_to_action("tap", {})
 
-    def test_invalid_arg_type_returns_finish(self):
-        """Non-numeric coordinate should return finish, not crash."""
-        result = tool_call_to_action("tap", {"x": "click_here", "y": 100})
-        assert result["_metadata"] == "finish"
-        assert "Invalid tool call" in result["message"]
+    def test_invalid_arg_type_raises_invalid_tool_call(self):
+        """Non-numeric coordinates should not be converted into finish."""
+        with pytest.raises(InvalidToolCallError, match="Expected number"):
+            tool_call_to_action("tap", {"x": "click_here", "y": 100})
 
     def test_float_coords_converted_to_int(self):
         """Float coordinates from LLM should be accepted and converted."""
@@ -186,6 +206,101 @@ class TestGeminiImageAttachments:
             "data:image/webp;base64,reference"
         )
         assert "User attached 1 reference image" in user_message["content"][2]["text"]
+
+
+class TestGeminiInvalidToolCalls:
+    def test_invalid_tool_call_is_returned_as_retryable_tool_result(self):
+        async def run():
+            agent = _QueuedToolCallGeminiAgent(
+                [("", "tap", {"x": "861, 365", "y": 100})]
+            )
+            agent._prepare_initial_context("tap the button", "screen", "app")
+            events = [event async for event in agent._execute_step()]
+            return agent, events
+
+        agent, events = asyncio.run(run())
+
+        assert len(events) == 1
+        step = events[0]["data"]
+        assert step["success"] is False
+        assert step["finished"] is False
+        assert step["action"]["_metadata"] == "tool_error"
+        assert "Expected number" in step["message"]
+
+        assistant_message = agent.context[-2]
+        assert assistant_message["role"] == "assistant"
+        assert assistant_message["tool_calls"][0]["function"]["name"] == "tap"
+        assert (
+            json.loads(assistant_message["tool_calls"][0]["function"]["arguments"])["x"]
+            == "861, 365"
+        )
+
+        tool_message = agent.context[-1]
+        assert tool_message["role"] == "tool"
+        tool_result = json.loads(tool_message["content"])
+        assert tool_result == {
+            "success": False,
+            "error_code": "invalid_tool_arguments",
+            "message": step["message"],
+            "retryable": True,
+        }
+
+    def test_invalid_tool_call_trace_marks_error(self, tmp_path, monkeypatch):
+        trace_file = tmp_path / "trace.jsonl"
+        monkeypatch.setenv("AUTOGLM_TRACE_ENABLED", "1")
+        monkeypatch.setenv("AUTOGLM_TRACE_FILE", str(trace_file))
+
+        async def run():
+            agent = _QueuedToolCallGeminiAgent(
+                [("", "tap", {"x": "861, 365", "y": 100})]
+            )
+            agent._prepare_initial_context("tap the button", "screen", "app")
+            return [event async for event in agent._execute_step()]
+
+        asyncio.run(run())
+
+        records = [
+            json.loads(line)
+            for line in trace_file.read_text(encoding="utf-8").splitlines()
+        ]
+        tool_call = next(record for record in records if record["name"] == "tool.call")
+        assert tool_call["attrs"]["success"] is False
+        assert tool_call["attrs"]["error_kind"] == "invalid_arguments"
+        assert "Expected number" in tool_call["attrs"]["error_message"]
+
+    def test_repeated_invalid_tool_calls_finish_as_failed(self):
+        async def run():
+            agent = _QueuedToolCallGeminiAgent(
+                [
+                    ("", "tap", {"x": "861, 365", "y": 100}),
+                    ("", "tap", {"x": "861, 365", "y": 100}),
+                    ("", "tap", {"x": "861, 365", "y": 100}),
+                ]
+            )
+            events = []
+            async for event in agent.stream("tap the button"):
+                events.append(event)
+            return events
+
+        events = asyncio.run(run())
+
+        step_events = [event for event in events if event["type"] == "step"]
+        assert len(step_events) == 3
+        assert step_events[0]["data"]["finished"] is False
+        assert step_events[-1]["data"]["success"] is False
+        assert step_events[-1]["data"]["finished"] is True
+        assert (
+            "Tool call validation failed 3 consecutive times"
+            in step_events[-1]["data"]["message"]
+        )
+
+        done_events = [event for event in events if event["type"] == "done"]
+        assert len(done_events) == 1
+        assert done_events[0]["data"]["success"] is False
+        assert (
+            "Tool call validation failed 3 consecutive times"
+            in done_events[0]["data"]["message"]
+        )
 
 
 class TestEventTypes:


### PR DESCRIPTION
## Summary

- Stop converting invalid Gemini tool-call arguments into successful `finish` actions.
- Return validation failures to the model as failed tool results so the agent can retry with corrected arguments.
- Add a consecutive invalid-tool-call limit that ends the run as failed after repeated schema violations.
- Mark invalid tool calls in trace spans with `success=false` and `error_kind=invalid_arguments`.

Closes #394

## Verification

- `uv run pytest tests/test_gemini_agent.py -q`
- `uv run python scripts/lint.py --backend --check-only`
