### PR TITLE
Improve Python test coverage

### DIFF
--- a/tests/test_adb_manager.py
+++ b/tests/test_adb_manager.py
@@ -1,0 +1,93 @@
+"""Unit tests for ADB binary discovery and download helpers."""
+
+from __future__ import annotations
+
+import io
+import os
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import AutoGLM_GUI.adb_manager as adb_manager
+
+
+def test_platform_name_rejects_unsupported_system(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(adb_manager.platform, "system", lambda: "Plan9")
+
+    with pytest.raises(RuntimeError, match="Unsupported platform: plan9"):
+        adb_manager._platform_name()
+
+
+def test_ensure_adb_reports_extract_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    platform_tools = tmp_path / "platform-tools"
+    monkeypatch.setattr(adb_manager.shutil, "which", lambda name: None)
+    monkeypatch.setattr(adb_manager, "_PLATFORM_TOOLS_DIR", platform_tools)
+    monkeypatch.setattr(adb_manager, "_ADB_BINARY", "adb")
+    monkeypatch.setattr(adb_manager, "_platform_name", lambda: "linux")
+    monkeypatch.setattr(adb_manager, "_download_with_progress", lambda url: b"not zip")
+
+    with pytest.raises(RuntimeError, match="Failed to extract platform-tools"):
+        adb_manager.ensure_adb()
+
+
+def test_ensure_adb_reports_missing_binary_after_extract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    platform_tools = tmp_path / "platform-tools"
+    data = io.BytesIO()
+    with zipfile.ZipFile(data, "w") as zf:
+        zf.writestr("platform-tools/readme.txt", "missing adb")
+
+    monkeypatch.setattr(adb_manager.shutil, "which", lambda name: None)
+    monkeypatch.setattr(adb_manager, "_PLATFORM_TOOLS_DIR", platform_tools)
+    monkeypatch.setattr(adb_manager, "_ADB_BINARY", "adb")
+    monkeypatch.setattr(adb_manager, "_platform_name", lambda: "linux")
+    monkeypatch.setattr(
+        adb_manager, "_download_with_progress", lambda url: data.getvalue()
+    )
+
+    with pytest.raises(RuntimeError, match="ADB binary not found after extraction"):
+        adb_manager.ensure_adb()
+
+
+def test_ensure_adb_extracts_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    platform_tools = tmp_path / "platform-tools"
+    data = io.BytesIO()
+    with zipfile.ZipFile(data, "w") as zf:
+        zf.writestr("platform-tools/tools/", "")
+        zf.writestr("platform-tools/tools/adb", "adb")
+
+    monkeypatch.setattr(adb_manager.shutil, "which", lambda name: None)
+    monkeypatch.setattr(adb_manager, "_PLATFORM_TOOLS_DIR", platform_tools)
+    monkeypatch.setattr(adb_manager, "_ADB_BINARY", "tools/adb")
+    monkeypatch.setattr(adb_manager, "_platform_name", lambda: "linux")
+    monkeypatch.setattr(
+        adb_manager, "_download_with_progress", lambda url: data.getvalue()
+    )
+
+    assert adb_manager.ensure_adb() == str(platform_tools / "tools" / "adb")
+
+
+def test_download_with_progress_reads_tempfile_and_ignores_unlink_errors(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fake_urlretrieve(url: str, filename: str, reporthook) -> None:
+        Path(filename).write_bytes(b"zip-bytes")
+        reporthook(1, 4, 8)
+        reporthook(2, 4, 8)
+
+    monkeypatch.setattr(adb_manager.urllib.request, "urlretrieve", fake_urlretrieve)
+    monkeypatch.setattr(os, "unlink", lambda path: (_ for _ in ()).throw(OSError))
+
+    assert (
+        adb_manager._download_with_progress("https://example.com/tools.zip")
+        == b"zip-bytes"
+    )
+    assert "Downloading... 100%" in capsys.readouterr().out

--- a/tests/test_adb_pair_helpers.py
+++ b/tests/test_adb_pair_helpers.py
@@ -1,0 +1,126 @@
+"""Unit tests for wireless ADB pairing helpers."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+import AutoGLM_GUI.adb_plus.pair as pair
+
+
+def _completed(
+    stdout: str = "", stderr: str = "", returncode: int = 0
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["adb"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        ("failed: pairing code was wrong", (False, "Invalid pairing code")),
+        (
+            "failed: connection refused",
+            (
+                False,
+                "Connection refused - check if wireless debugging is enabled",
+            ),
+        ),
+        ("failed: protocol error", (False, "Pairing failed: failed: protocol error")),
+        ("", (False, "Unknown pairing error")),
+    ],
+)
+def test_pair_device_classifies_failure_outputs(
+    monkeypatch: pytest.MonkeyPatch, output: str, expected: tuple[bool, str]
+) -> None:
+    monkeypatch.setattr(
+        pair,
+        "run_cmd_silently_sync",
+        lambda cmd, timeout: _completed(stdout=output),
+    )
+
+    assert pair.pair_device("1.2.3.4", 1234, "123456", adb_path="adbx") == expected
+
+
+def test_pair_device_reports_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    def broken_run(cmd: list[str], timeout: int) -> subprocess.CompletedProcess[str]:
+        raise RuntimeError("adb failed")
+
+    monkeypatch.setattr(pair, "run_cmd_silently_sync", broken_run)
+
+    assert pair.pair_device("1.2.3.4", 1234, "123456") == (
+        False,
+        "Pairing error: adb failed",
+    )
+
+
+@pytest.mark.anyio
+async def test_pair_device_async_validates_and_reports_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[list[str], int]] = []
+
+    async def fake_run(
+        cmd: list[str], timeout: int
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append((cmd, timeout))
+        return _completed(stdout="success")
+
+    monkeypatch.setattr(pair, "run_cmd_silently", fake_run)
+
+    assert await pair.pair_device_async("1.2.3.4", 1234, "bad") == (
+        False,
+        "Pairing code must be 6 digits",
+    )
+    assert await pair.pair_device_async("1.2.3.4", 1234, "123456", "adbx") == (
+        True,
+        "Successfully paired to 1.2.3.4:1234",
+    )
+    assert calls == [(["adbx", "pair", "1.2.3.4:1234", "123456"], 30)]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        (
+            "failed: connection refused",
+            (
+                False,
+                "Connection refused - check if wireless debugging is enabled",
+            ),
+        ),
+        ("failed: other", (False, "Pairing failed: failed: other")),
+        ("", (False, "Unknown pairing error")),
+    ],
+)
+async def test_pair_device_async_classifies_failures(
+    monkeypatch: pytest.MonkeyPatch, output: str, expected: tuple[bool, str]
+) -> None:
+    async def fake_run(
+        cmd: list[str], timeout: int
+    ) -> subprocess.CompletedProcess[str]:
+        return _completed(stdout=output)
+
+    monkeypatch.setattr(pair, "run_cmd_silently", fake_run)
+
+    assert await pair.pair_device_async("1.2.3.4", 1234, "123456") == expected
+
+
+@pytest.mark.anyio
+async def test_pair_device_async_reports_exceptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def broken_run(
+        cmd: list[str], timeout: int
+    ) -> subprocess.CompletedProcess[str]:
+        raise RuntimeError("async adb failed")
+
+    monkeypatch.setattr(pair, "run_cmd_silently", broken_run)
+
+    assert await pair.pair_device_async("1.2.3.4", 1234, "123456") == (
+        False,
+        "Pairing error: async adb failed",
+    )

--- a/tests/test_adb_terminal_repl.py
+++ b/tests/test_adb_terminal_repl.py
@@ -1,0 +1,132 @@
+"""Unit tests for the ADB-only web terminal REPL."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+import AutoGLM_GUI.adb_terminal_repl as repl
+
+
+def test_resolve_adb_binary_uses_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AUTOGLM_ADB_PATH", raising=False)
+    assert repl._resolve_adb_binary() == "adb"
+
+    monkeypatch.setenv("AUTOGLM_ADB_PATH", "/opt/android/adb")
+    assert repl._resolve_adb_binary() == "/opt/android/adb"
+
+
+def test_handle_builtin_commands(capsys: pytest.CaptureFixture[str]) -> None:
+    assert repl._handle_builtin("help") is True
+    assert "AutoGLM Web Terminal" in capsys.readouterr().out
+
+    assert repl._handle_builtin("?") is True
+    assert "Allowed commands" in capsys.readouterr().out
+
+    assert repl._handle_builtin("clear") is True
+    assert "\033[2J\033[H" in capsys.readouterr().out
+
+    assert repl._handle_builtin("adb") is False
+
+    with pytest.raises(EOFError):
+        repl._handle_builtin("exit")
+    with pytest.raises(EOFError):
+        repl._handle_builtin("quit")
+
+
+def test_run_adb_command_parsing_and_validation(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repl._run_adb_command("adb shell 'unterminated")
+    assert "Parse error:" in capsys.readouterr().out
+
+    repl._run_adb_command("")
+    assert capsys.readouterr().out == ""
+
+    repl._run_adb_command("help")
+    assert "Built-ins:" in capsys.readouterr().out
+
+    repl._run_adb_command("ls")
+    assert "Only adb commands are allowed." in capsys.readouterr().out
+
+
+def test_run_adb_command_invokes_resolved_adb_binary(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], check: bool) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        assert check is False
+        return subprocess.CompletedProcess(args=args, returncode=0)
+
+    monkeypatch.setenv("AUTOGLM_ADB_PATH", "/custom/adb")
+    monkeypatch.setattr(repl.subprocess, "run", fake_run)
+
+    repl._run_adb_command("adb devices")
+
+    assert calls == [["/custom/adb", "devices"]]
+    assert capsys.readouterr().out == ""
+
+
+def test_run_adb_command_reports_process_failures(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        repl.subprocess,
+        "run",
+        lambda args, check: subprocess.CompletedProcess(args=args, returncode=42),
+    )
+
+    repl._run_adb_command("adb shell true")
+
+    assert "[exit code 42]" in capsys.readouterr().out
+
+
+def test_run_adb_command_handles_missing_adb_and_interrupts(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def missing_adb(args: list[str], check: bool) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError
+
+    monkeypatch.setenv("AUTOGLM_ADB_PATH", "/missing/adb")
+    monkeypatch.setattr(repl.subprocess, "run", missing_adb)
+    repl._run_adb_command("adb devices")
+    assert "ADB binary not found: /missing/adb" in capsys.readouterr().out
+
+    def interrupted(args: list[str], check: bool) -> subprocess.CompletedProcess[str]:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(repl.subprocess, "run", interrupted)
+    repl._run_adb_command("adb devices")
+    assert "^C" in capsys.readouterr().out
+
+
+def test_main_handles_input_interrupts_and_eof(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    inputs = iter([KeyboardInterrupt, "", "adb devices", EOFError])
+    commands: list[str] = []
+
+    def fake_input(prompt: str) -> str:
+        next_value = next(inputs)
+        if isinstance(next_value, type) and issubclass(next_value, BaseException):
+            raise next_value
+        return next_value
+
+    def fake_run_adb_command(line: str) -> None:
+        commands.append(line)
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    monkeypatch.setattr(repl, "_run_adb_command", fake_run_adb_command)
+
+    assert repl.main() == 0
+    assert commands == ["adb devices"]
+    assert "^C" in capsys.readouterr().out
+
+
+def test_main_returns_on_exit_builtin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("builtins.input", lambda prompt: "exit")
+
+    assert repl.main() == 0

--- a/tests/test_agent_adapter_coverage.py
+++ b/tests/test_agent_adapter_coverage.py
@@ -15,8 +15,10 @@ import pytest
 
 from AutoGLM_GUI.actions import ActionResult
 from AutoGLM_GUI.agents.droidrun.async_agent import DroidRunAgent
+from AutoGLM_GUI.agents.gemini.async_agent import AsyncGeminiAgent
 from AutoGLM_GUI.agents.mai.async_agent import AsyncMAIAgent
 from AutoGLM_GUI.agents.midscene.async_agent import AsyncMidsceneAgent
+from AutoGLM_GUI.agents.qwen.async_agent import AsyncQwenAgent
 from AutoGLM_GUI.config import AgentConfig, ModelConfig
 from AutoGLM_GUI.device_protocol import Screenshot
 
@@ -453,6 +455,26 @@ def _make_mai_agent(device: FakeDevice | None = None) -> AsyncMAIAgent:
     )
 
 
+def _make_qwen_agent(
+    device: FakeDevice | None = None, *, verbose: bool = True
+) -> AsyncQwenAgent:
+    return AsyncQwenAgent(
+        ModelConfig(model_name="qwen-model"),
+        AgentConfig(max_steps=3, verbose=verbose),
+        device or FakeDevice(),
+    )
+
+
+def _make_gemini_agent(
+    device: FakeDevice | None = None, *, verbose: bool = True
+) -> AsyncGeminiAgent:
+    return AsyncGeminiAgent(
+        ModelConfig(model_name="gemini-model"),
+        AgentConfig(max_steps=3, verbose=verbose),
+        device or FakeDevice(),
+    )
+
+
 def test_mai_agent_execute_step_success_action_failure_and_reset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -581,3 +603,248 @@ def test_mai_stream_openai_splits_thinking_and_raw(
     assert {"type": "thinking", "content": "hello "} in events
     assert events[-1]["type"] == "raw"
     assert fake_stream.closed is True
+
+
+def test_qwen_agent_execute_step_error_debug_and_action_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    agent = _make_qwen_agent()
+    monkeypatch.chdir(tmp_path)
+
+    debug_path = agent._draw_tap_debug(PNG_1X1_BASE64, 1, 1, "Tap", 1)
+    assert debug_path is not None
+    assert Path(debug_path).exists()
+    assert agent._draw_tap_debug("not-base64", 1, 1, "Tap", 2) is None
+
+    device_error_agent = _make_qwen_agent(FakeDevice(fail=True))
+    device_events = asyncio.run(_collect(device_error_agent._execute_step()))
+    assert [event["type"] for event in device_events] == ["error", "step"]
+    assert device_events[-1]["data"]["message"] == "Device error: screen failed"
+
+    model_error_agent = _make_qwen_agent()
+
+    async def broken_stream(messages):
+        raise RuntimeError("model failed")
+        yield {}
+
+    monkeypatch.setattr(model_error_agent, "_stream_openai", broken_stream)
+    model_events = asyncio.run(_collect(model_error_agent._execute_step()))
+    assert model_events[-2]["data"]["message"] == "Model error: model failed"
+    assert model_events[-1]["data"]["finished"] is True
+
+    parse_fallback_agent = _make_qwen_agent()
+
+    async def invalid_action_stream(messages):
+        yield {"type": "thinking", "content": "thinking"}
+        yield {"type": "raw", "content": "not a qwen action"}
+
+    def raise_action(*args, **kwargs):
+        raise RuntimeError("action failed")
+
+    monkeypatch.setattr(parse_fallback_agent, "_stream_openai", invalid_action_stream)
+    monkeypatch.setattr(parse_fallback_agent.action_handler, "execute", raise_action)
+    fallback_events = asyncio.run(_collect(parse_fallback_agent._execute_step()))
+    assert [event["type"] for event in fallback_events] == ["thinking", "step"]
+    assert fallback_events[-1]["data"]["action"]["_metadata"] == "finish"
+    assert fallback_events[-1]["data"]["success"] is False
+    assert fallback_events[-1]["data"]["message"] == "action failed"
+
+    tap_agent = _make_qwen_agent()
+
+    async def tap_stream(messages):
+        yield {
+            "type": "raw",
+            "content": '<answer>do(action="Tap", element=[500, 500])</answer>',
+        }
+
+    monkeypatch.setattr(tap_agent, "_stream_openai", tap_stream)
+    monkeypatch.setattr(
+        tap_agent.action_handler,
+        "execute",
+        lambda *a, **k: ActionResult(
+            success=True, should_finish=True, message="tapped"
+        ),
+    )
+    tap_events = asyncio.run(_collect(tap_agent._execute_step()))
+    assert tap_events[-1]["data"]["action"]["action"] == "Tap"
+    assert tap_events[-1]["data"]["message"] == "tapped"
+
+
+def test_qwen_stream_openai_streaming_and_cancel_paths() -> None:
+    agent = _make_qwen_agent(verbose=False)
+
+    class FakeDelta:
+        def __init__(self, content: str | None) -> None:
+            self.content = content
+
+    class FakeChoice:
+        def __init__(self, content: str | None) -> None:
+            self.delta = FakeDelta(content)
+
+    class FakeChunk:
+        def __init__(self, content: str | None = None, *, empty: bool = False) -> None:
+            self.choices = [] if empty else [FakeChoice(content)]
+
+    class FakeStream:
+        def __init__(self, chunks: list[FakeChunk]) -> None:
+            self.chunks = chunks
+            self.closed = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self.chunks:
+                raise StopAsyncIteration
+            return self.chunks.pop(0)
+
+        async def close(self) -> None:
+            self.closed = True
+
+    fake_stream = FakeStream(
+        [
+            FakeChunk("thinking "),
+            FakeChunk(empty=True),
+            FakeChunk('<answer>finish(message="done")</answer>'),
+            FakeChunk("ignored action text"),
+        ]
+    )
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            return fake_stream
+
+    agent.openai_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FakeCompletions())
+    )
+
+    events = asyncio.run(_collect(agent._stream_openai([{"role": "user"}])))
+    assert events[0] == {"type": "raw", "content": "thinking "}
+    assert {"type": "thinking", "content": "thinking "} in events
+    assert events[-1] == {"type": "raw", "content": "ignored action text"}
+    assert fake_stream.closed is True
+
+    cancelled_stream = FakeStream([FakeChunk("cancel")])
+
+    class CancelCompletions:
+        async def create(self, **kwargs):
+            return cancelled_stream
+
+    agent.openai_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=CancelCompletions())
+    )
+    agent._cancel_event.set()
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(_collect(agent._stream_openai([{"role": "user"}])))
+    assert cancelled_stream.closed is True
+
+
+def test_gemini_agent_execute_step_and_llm_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _make_gemini_agent()
+    agent._prepare_initial_context("tap", PNG_1X1_BASE64, "app")
+
+    async def tap_tool():
+        return "think", "tap", {"x": 1, "y": 2}
+
+    monkeypatch.setattr(agent, "_call_llm_with_tools", tap_tool)
+    monkeypatch.setattr(
+        agent.action_handler,
+        "execute",
+        lambda *a, **k: ActionResult(success=True, should_finish=False, message="ok"),
+    )
+    success_events = asyncio.run(_collect(agent._execute_step()))
+    assert [event["type"] for event in success_events] == ["thinking", "step"]
+    assert success_events[-1]["data"]["action"]["action"] == "Tap"
+    assert success_events[-1]["data"]["success"] is True
+
+    action_error_agent = _make_gemini_agent()
+    action_error_agent._prepare_initial_context("tap", PNG_1X1_BASE64, "app")
+
+    async def back_tool():
+        return "", "back", {}
+
+    def raise_action(*args, **kwargs):
+        raise RuntimeError("tap failed")
+
+    monkeypatch.setattr(action_error_agent, "_call_llm_with_tools", back_tool)
+    monkeypatch.setattr(action_error_agent.action_handler, "execute", raise_action)
+    action_error_events = asyncio.run(_collect(action_error_agent._execute_step()))
+    assert action_error_events[-1]["data"]["success"] is False
+    assert action_error_events[-1]["data"]["finished"] is True
+    assert action_error_events[-1]["data"]["message"] == "tap failed"
+
+    model_error_agent = _make_gemini_agent()
+
+    async def broken_tool():
+        raise RuntimeError("model failed")
+
+    monkeypatch.setattr(model_error_agent, "_call_llm_with_tools", broken_tool)
+    model_events = asyncio.run(_collect(model_error_agent._execute_step()))
+    assert [event["type"] for event in model_events] == ["error", "step"]
+    assert model_events[-1]["data"]["message"] == "Model error: model failed"
+
+    device_error_agent = _make_gemini_agent(FakeDevice(fail=True))
+    device_error_agent._step_count = 1
+    device_events = asyncio.run(_collect(device_error_agent._execute_step()))
+    assert [event["type"] for event in device_events] == ["error", "step"]
+    assert device_events[-1]["data"]["message"] == "Device error: screen failed"
+
+
+def test_gemini_call_llm_with_tools_parses_tool_no_tool_bad_json_and_cancel() -> None:
+    agent = _make_gemini_agent()
+    agent._prepare_initial_context("tap", PNG_1X1_BASE64, "app")
+
+    class FakeCompletions:
+        def __init__(self, message: Any) -> None:
+            self.message = message
+
+        async def create(self, **kwargs):
+            return SimpleNamespace(choices=[SimpleNamespace(message=self.message)])
+
+    tool_call = SimpleNamespace(
+        function=SimpleNamespace(name="tap", arguments='{"x": 1, "y": 2}')
+    )
+    agent.openai_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=FakeCompletions(
+                SimpleNamespace(content="thinking", tool_calls=[tool_call])
+            )
+        )
+    )
+    assert asyncio.run(agent._call_llm_with_tools()) == (
+        "thinking",
+        "tap",
+        {"x": 1, "y": 2},
+    )
+
+    no_tool_agent = _make_gemini_agent()
+    no_tool_agent.openai_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=FakeCompletions(SimpleNamespace(content="done", tool_calls=[]))
+        )
+    )
+    assert asyncio.run(no_tool_agent._call_llm_with_tools()) == (
+        "done",
+        "finish",
+        {"message": "done"},
+    )
+
+    bad_json_agent = _make_gemini_agent()
+    bad_tool_call = SimpleNamespace(
+        function=SimpleNamespace(name="tap", arguments="{bad")
+    )
+    bad_json_agent.openai_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=FakeCompletions(
+                SimpleNamespace(content="", tool_calls=[bad_tool_call])
+            )
+        )
+    )
+    assert asyncio.run(bad_json_agent._call_llm_with_tools()) == ("", "tap", {})
+
+    cancelled_agent = _make_gemini_agent()
+    cancelled_agent._cancel_event.set()
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(cancelled_agent._call_llm_with_tools())

--- a/tests/test_agent_adapter_coverage.py
+++ b/tests/test_agent_adapter_coverage.py
@@ -746,7 +746,7 @@ def test_gemini_agent_execute_step_and_llm_paths(
     agent._prepare_initial_context("tap", PNG_1X1_BASE64, "app")
 
     async def tap_tool():
-        return "think", "tap", {"x": 1, "y": 2}
+        return "think", None, "tap", {"x": 1, "y": 2}
 
     monkeypatch.setattr(agent, "_call_llm_with_tools", tap_tool)
     monkeypatch.setattr(
@@ -763,7 +763,7 @@ def test_gemini_agent_execute_step_and_llm_paths(
     action_error_agent._prepare_initial_context("tap", PNG_1X1_BASE64, "app")
 
     async def back_tool():
-        return "", "back", {}
+        return "", None, "back", {}
 
     def raise_action(*args, **kwargs):
         raise RuntimeError("tap failed")
@@ -815,6 +815,7 @@ def test_gemini_call_llm_with_tools_parses_tool_no_tool_bad_json_and_cancel() ->
     )
     assert asyncio.run(agent._call_llm_with_tools()) == (
         "thinking",
+        None,
         "tap",
         {"x": 1, "y": 2},
     )
@@ -827,6 +828,7 @@ def test_gemini_call_llm_with_tools_parses_tool_no_tool_bad_json_and_cancel() ->
     )
     assert asyncio.run(no_tool_agent._call_llm_with_tools()) == (
         "done",
+        None,
         "finish",
         {"message": "done"},
     )
@@ -842,7 +844,7 @@ def test_gemini_call_llm_with_tools_parses_tool_no_tool_bad_json_and_cancel() ->
             )
         )
     )
-    assert asyncio.run(bad_json_agent._call_llm_with_tools()) == ("", "tap", {})
+    assert asyncio.run(bad_json_agent._call_llm_with_tools()) == ("", None, "tap", {})
 
     cancelled_agent = _make_gemini_agent()
     cancelled_agent._cancel_event.set()

--- a/tests/test_agent_adapter_coverage.py
+++ b/tests/test_agent_adapter_coverage.py
@@ -1,0 +1,583 @@
+"""Coverage for optional agent adapters without external runtimes."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import types
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from AutoGLM_GUI.actions import ActionResult
+from AutoGLM_GUI.agents.droidrun.async_agent import DroidRunAgent
+from AutoGLM_GUI.agents.mai.async_agent import AsyncMAIAgent
+from AutoGLM_GUI.agents.midscene.async_agent import AsyncMidsceneAgent
+from AutoGLM_GUI.config import AgentConfig, ModelConfig
+from AutoGLM_GUI.device_protocol import Screenshot
+
+
+PNG_1X1_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+    "/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+
+
+async def _collect(agen: AsyncGenerator[dict[str, Any], None]) -> list[dict[str, Any]]:
+    return [event async for event in agen]
+
+
+class FakeDevice:
+    device_id = "device-1"
+
+    def __init__(self, fail: bool = False) -> None:
+        self.fail = fail
+
+    def get_screenshot(self, timeout: int = 10) -> Screenshot:
+        if self.fail:
+            raise RuntimeError("screen failed")
+        return Screenshot(base64_data=PNG_1X1_BASE64, width=100, height=200)
+
+    def get_current_app(self) -> str:
+        if self.fail:
+            raise RuntimeError("app failed")
+        return "com.example"
+
+
+def _install_fake_droidrun(monkeypatch: pytest.MonkeyPatch, events: list[Any]) -> type:
+    class CodeActResponseEvent:
+        def __init__(self, thought: str = "") -> None:
+            self.thought = thought
+
+    class CodeActResultEvent:
+        def __init__(self) -> None:
+            self.summary = "code summary"
+            self.action = "tap"
+            self.success = True
+
+    class FastAgentResultEvent:
+        def __init__(self) -> None:
+            self.reason = "fast reason"
+            self.instruction = "swipe"
+            self.outcome = False
+
+    class ExecutorResultEvent:
+        def __init__(self) -> None:
+            self.summary = "executor summary"
+            self.action = "press"
+            self.outcome = False
+            self.error = "executor failed"
+
+    class FinalizeEvent:
+        reason = "wrapping up"
+
+    class ManagerPlanEvent:
+        def __init__(self, thought: str = "manager thought") -> None:
+            self.thought = thought
+            self.current_subgoal = "subgoal"
+
+    class ResultEvent:
+        success = True
+        reason = "all done"
+        steps = 9
+
+    class DeviceConfig:
+        def __init__(self, serial: str) -> None:
+            self.serial = serial
+
+    class DroidConfig:
+        def __init__(self) -> None:
+            self.device = None
+            self.telemetry = SimpleNamespace(enabled=True)
+            self.agent = SimpleNamespace(max_steps=0, reasoning=True)
+
+    class FakeHandler:
+        cancelled = False
+
+        async def stream_events(self):
+            for event in events:
+                yield event
+
+        def cancel(self) -> None:
+            self.cancelled = True
+
+    class DroidAgent:
+        created: list[dict[str, Any]] = []
+        fail_init = False
+
+        def __init__(self, goal: str, llms: Any, config: DroidConfig) -> None:
+            if self.fail_init:
+                raise RuntimeError("init failed")
+            self.created.append({"goal": goal, "llms": llms, "config": config})
+
+        def run(self) -> FakeHandler:
+            return FakeHandler()
+
+    modules = {
+        "droidrun": types.ModuleType("droidrun"),
+        "droidrun.agent": types.ModuleType("droidrun.agent"),
+        "droidrun.agent.codeact": types.ModuleType("droidrun.agent.codeact"),
+        "droidrun.agent.codeact.events": types.ModuleType(
+            "droidrun.agent.codeact.events"
+        ),
+        "droidrun.agent.droid": types.ModuleType("droidrun.agent.droid"),
+        "droidrun.agent.droid.events": types.ModuleType("droidrun.agent.droid.events"),
+        "droidrun.agent.droid.droid_agent": types.ModuleType(
+            "droidrun.agent.droid.droid_agent"
+        ),
+        "droidrun.agent.utils": types.ModuleType("droidrun.agent.utils"),
+        "droidrun.agent.utils.llm_picker": types.ModuleType(
+            "droidrun.agent.utils.llm_picker"
+        ),
+        "droidrun.config_manager": types.ModuleType("droidrun.config_manager"),
+        "droidrun.config_manager.config_manager": types.ModuleType(
+            "droidrun.config_manager.config_manager"
+        ),
+    }
+
+    modules["droidrun.agent.codeact.events"].CodeActResponseEvent = CodeActResponseEvent
+    droid_events = modules["droidrun.agent.droid.events"]
+    droid_events.CodeActResultEvent = CodeActResultEvent
+    droid_events.FastAgentResultEvent = FastAgentResultEvent
+    droid_events.ExecutorResultEvent = ExecutorResultEvent
+    droid_events.FinalizeEvent = FinalizeEvent
+    droid_events.ManagerPlanEvent = ManagerPlanEvent
+    droid_events.ResultEvent = ResultEvent
+    modules["droidrun.agent.droid"].events = droid_events
+    modules["droidrun.agent.droid.droid_agent"].DroidAgent = DroidAgent
+    modules["droidrun.agent.utils.llm_picker"].load_llm = lambda *a, **k: "llm"
+    modules["droidrun.config_manager.config_manager"].DeviceConfig = DeviceConfig
+    modules["droidrun.config_manager.config_manager"].DroidConfig = DroidConfig
+
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    return SimpleNamespace(
+        CodeActResponseEvent=CodeActResponseEvent,
+        CodeActResultEvent=CodeActResultEvent,
+        FastAgentResultEvent=FastAgentResultEvent,
+        ExecutorResultEvent=ExecutorResultEvent,
+        FinalizeEvent=FinalizeEvent,
+        ManagerPlanEvent=ManagerPlanEvent,
+        ResultEvent=ResultEvent,
+        DroidAgent=DroidAgent,
+        llm_picker=modules["droidrun.agent.utils.llm_picker"],
+    )
+
+
+def test_droidrun_agent_converts_fake_runtime_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[Any] = []
+    fake = _install_fake_droidrun(monkeypatch, events)
+    events.extend(
+        [
+            fake.CodeActResponseEvent("code thought"),
+            fake.CodeActResponseEvent(""),
+            fake.CodeActResultEvent(),
+            fake.FastAgentResultEvent(),
+            fake.ManagerPlanEvent(),
+            fake.ManagerPlanEvent(""),
+            fake.ExecutorResultEvent(),
+            fake.FinalizeEvent(),
+            fake.ResultEvent(),
+        ]
+    )
+    agent = DroidRunAgent(ModelConfig(), AgentConfig(max_steps=None), FakeDevice())
+
+    collected = asyncio.run(_collect(agent.stream("do it")))
+
+    assert collected[0]["type"] == "thinking"
+    assert [event["type"] for event in collected[1:]] == [
+        "thinking",
+        "step",
+        "step",
+        "thinking",
+        "thinking",
+        "step",
+        "thinking",
+        "done",
+    ]
+    assert collected[2]["data"]["action"]["description"] == "tap"
+    assert collected[3]["data"]["success"] is False
+    assert collected[-1]["data"] == {"success": True, "message": "all done", "steps": 9}
+
+    assert agent.step_count == 3
+    assert agent.context == []
+    assert agent.is_running is False
+    assert asyncio.run(agent.run("do it")) == "all done"
+    asyncio.run(agent.cancel())
+    assert agent._cancel_event.is_set()
+    agent.reset()
+    assert agent.step_count == 0
+
+
+def test_droidrun_agent_reports_import_llm_init_and_runtime_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = DroidRunAgent(ModelConfig(), AgentConfig(), FakeDevice())
+    missing = asyncio.run(_collect(agent.stream("task")))
+    assert missing[-1]["type"] == "error"
+    assert "droidrun" in missing[-1]["data"]["message"]
+
+    fake = _install_fake_droidrun(monkeypatch, [])
+    fake.llm_picker.load_llm = lambda *a, **k: (_ for _ in ()).throw(
+        RuntimeError("llm failed")
+    )
+    llm_error = asyncio.run(_collect(agent.stream("task")))
+    assert llm_error[-1]["data"]["message"] == "LLM 加载失败：llm failed"
+
+    fake = _install_fake_droidrun(monkeypatch, [])
+    fake.DroidAgent.fail_init = True
+    init_error = asyncio.run(_collect(agent.stream("task")))
+    assert init_error[-1]["data"]["message"] == "DroidAgent 初始化失败：init failed"
+
+    _install_fake_droidrun(monkeypatch, [RuntimeError("not an event")])
+
+    class BadHandler:
+        async def stream_events(self):
+            raise RuntimeError("runtime failed")
+            yield None
+
+        def cancel(self) -> None:
+            pass
+
+    class BadAgent:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def run(self) -> BadHandler:
+            return BadHandler()
+
+    sys.modules["droidrun.agent.droid.droid_agent"].DroidAgent = BadAgent
+    runtime_error = asyncio.run(_collect(agent.stream("task")))
+    assert runtime_error[-1]["data"]["message"] == "执行错误：runtime failed"
+
+
+def _midscene_agent() -> AsyncMidsceneAgent:
+    return AsyncMidsceneAgent(
+        ModelConfig(
+            base_url="https://example.test/v1",
+            api_key="key",
+            model_name="vision",
+            extra_body={"model_family": "qwen"},
+        ),
+        AgentConfig(max_steps=7),
+        FakeDevice(),
+    )
+
+
+def test_midscene_env_detection_and_stream_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        AsyncMidsceneAgent, "_get_shell_path", classmethod(lambda cls: "/bin")
+    )
+    monkeypatch.setattr(AsyncMidsceneAgent, "_find_npx", classmethod(lambda cls: None))
+    monkeypatch.setattr(
+        AsyncMidsceneAgent, "_detect_android_home", staticmethod(lambda: "/sdk")
+    )
+    monkeypatch.delenv("ANDROID_HOME", raising=False)
+
+    agent = _midscene_agent()
+    env = agent._build_env()
+    no_npx = asyncio.run(_collect(agent.stream("tap")))
+
+    assert env["DEBUG"] == "midscene:*"
+    assert env["MIDSCENE_MODEL_API_KEY"] == "key"
+    assert env["MIDSCENE_MODEL_BASE_URL"] == "https://example.test/v1"
+    assert env["MIDSCENE_MODEL_NAME"] == "vision"
+    assert env["MIDSCENE_MODEL_FAMILY"] == "qwen"
+    assert env["MIDSCENE_REPLANNING_CYCLE_LIMIT"] == "7"
+    assert env["ANDROID_HOME"] == "/sdk"
+    assert no_npx[-1]["type"] == "error"
+
+    commands: list[list[str]] = []
+
+    async def fake_run_command(args, env, cwd, timeout=60):
+        commands.append(args)
+        return ("connect" not in args, "connect failed")
+
+    monkeypatch.setattr(AsyncMidsceneAgent, "_find_npx", classmethod(lambda cls: "npx"))
+    monkeypatch.setattr(agent, "_run_command", fake_run_command)
+    connect_fail = asyncio.run(_collect(agent.stream("tap")))
+    assert connect_fail[-1]["data"]["message"].startswith("Midscene 连接设备失败")
+    assert commands[-1][-1] == "disconnect"
+
+    async def fake_run_command_ok(args, env, cwd, timeout=60):
+        commands.append(args)
+        return True, "ok"
+
+    async def fake_act(args, env, cwd):
+        yield {"type": "done", "data": {"message": "done", "steps": 1, "success": True}}
+
+    monkeypatch.setattr(agent, "_run_command", fake_run_command_ok)
+    monkeypatch.setattr(agent, "_run_act_streaming", fake_act)
+    monkeypatch.setattr("tempfile.mkdtemp", lambda prefix: str(tmp_path / prefix))
+    monkeypatch.setattr(os, "rmdir", lambda path: None)
+
+    success = asyncio.run(_collect(agent.stream("tap")))
+    assert success[-1]["data"]["message"] == "done"
+
+
+def test_midscene_run_command_success_timeout_and_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _midscene_agent()
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"ok", None
+
+    async def fake_create(*args, **kwargs):
+        return FakeProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create)
+    ok, output = asyncio.run(agent._run_command(["npx"], {}, "/tmp"))
+    assert (ok, output) == (True, "ok")
+
+    async def timeout_wait_for(awaitable, timeout):
+        awaitable.close()
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(asyncio, "wait_for", timeout_wait_for)
+    ok, output = asyncio.run(agent._run_command(["npx"], {}, "/tmp"))
+    assert (ok, output) == (False, "命令执行超时")
+
+    async def exploding_create(*args, **kwargs):
+        raise RuntimeError("spawn failed")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", exploding_create)
+    ok, output = asyncio.run(agent._run_command(["npx"], {}, "/tmp"))
+    assert (ok, output) == (False, "spawn failed")
+
+
+class FakeStdout:
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = [line.encode() for line in lines] + [b""]
+
+    async def readline(self) -> bytes:
+        return self._lines.pop(0)
+
+
+class FakeMidsceneProcess:
+    def __init__(self, lines: list[str], returncode: int = 0) -> None:
+        self.stdout = FakeStdout(lines)
+        self.returncode = returncode
+        self.terminated = False
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    async def wait(self) -> None:
+        return None
+
+
+def test_midscene_run_act_streaming_success_error_and_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _midscene_agent()
+    plan = (
+        '{"thought": "inspect", "log": "tap", '
+        '"action": {"type": "Tap", "param": {"x": 1}}, '
+        '"shouldContinuePlanning": false}'
+    )
+    lines = [
+        "2026-05-19T01:02:03.456Z midscene:ai:call response reasoning content: think\n",
+        "2026-05-19T01:02:03.456Z midscene:agent:task-builder calling action Tap\n",
+        "2026-05-19T01:02:03.456Z midscene:device-task-executor planResult "
+        + plan
+        + "\n",
+        "Task finished, message: done\n",
+    ]
+
+    async def fake_create(*args, **kwargs):
+        return FakeMidsceneProcess(lines)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create)
+    events = asyncio.run(_collect(agent._run_act_streaming(["npx"], {}, "/tmp")))
+    assert [event["type"] for event in events] == [
+        "thinking",
+        "thinking",
+        "step",
+        "done",
+    ]
+    assert events[2]["data"]["action"]["param"] == {"x": 1}
+
+    async def fake_error_create(*args, **kwargs):
+        return FakeMidsceneProcess(["Error: unable to click\n"], returncode=2)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_error_create)
+    error_events = asyncio.run(_collect(agent._run_act_streaming(["npx"], {}, "/tmp")))
+    assert error_events[-1]["type"] == "error"
+    assert "unable to click" in error_events[-1]["data"]["message"]
+
+    async def fake_cancel_create(*args, **kwargs):
+        return FakeMidsceneProcess([])
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_cancel_create)
+    agent._cancel_event.set()
+    cancel_events = asyncio.run(_collect(agent._run_act_streaming(["npx"], {}, "/tmp")))
+    assert cancel_events == [{"type": "cancelled", "data": {"message": "任务已取消"}}]
+
+    async def fake_start_error(*args, **kwargs):
+        raise RuntimeError("no process")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_start_error)
+    start_error = asyncio.run(_collect(agent._run_act_streaming(["npx"], {}, "/tmp")))
+    assert start_error[-1]["data"]["message"] == "启动 Midscene 失败：no process"
+
+
+def _tool_response(action: dict[str, Any]) -> str:
+    import json
+
+    return (
+        "<thinking>tap it</thinking><tool_call>"
+        + json.dumps({"name": "mobile_use", "arguments": action})
+        + "</tool_call>"
+    )
+
+
+def _make_mai_agent(device: FakeDevice | None = None) -> AsyncMAIAgent:
+    return AsyncMAIAgent(
+        ModelConfig(model_name="mai-model"),
+        AgentConfig(max_steps=3, verbose=True),
+        device or FakeDevice(),
+        history_n=2,
+    )
+
+
+def test_mai_agent_execute_step_success_action_failure_and_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _make_mai_agent()
+    agent._prepare_initial_context("task", PNG_1X1_BASE64, "app")
+
+    async def fake_stream(messages):
+        yield {"type": "thinking", "content": "partial"}
+        yield {
+            "type": "raw",
+            "content": _tool_response({"action": "click", "coordinate": [500, 500]}),
+        }
+
+    monkeypatch.setattr(agent, "_stream_openai", fake_stream)
+    monkeypatch.setattr(
+        agent.action_handler,
+        "execute",
+        lambda action, width, height: ActionResult(
+            success=True, should_finish=False, message="ok"
+        ),
+    )
+
+    events = asyncio.run(_collect(agent._execute_step()))
+    assert [event["type"] for event in events] == ["thinking", "step"]
+    assert events[-1]["data"]["action"]["element"] == [500, 500]
+    assert events[-1]["data"]["success"] is True
+    assert len(agent.traj_memory) == 1
+
+    async def finish_stream(messages):
+        yield {"type": "raw", "content": _tool_response({"action": "terminate"})}
+
+    def raise_action(*args, **kwargs):
+        raise RuntimeError("action failed")
+
+    monkeypatch.setattr(agent, "_stream_openai", finish_stream)
+    monkeypatch.setattr(agent.action_handler, "execute", raise_action)
+    failed_action = asyncio.run(_collect(agent._execute_step()))
+    assert failed_action[-1]["data"]["finished"] is True
+    assert failed_action[-1]["data"]["success"] is False
+
+    messages = agent._build_messages("task", "screen", PNG_1X1_BASE64)
+    assert len(messages) == 5
+    agent.reset()
+    assert len(agent.traj_memory) == 0
+
+
+def test_mai_agent_execute_step_error_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    device_error_agent = _make_mai_agent(FakeDevice(fail=True))
+    device_events = asyncio.run(_collect(device_error_agent._execute_step()))
+    assert [event["type"] for event in device_events] == ["error", "step"]
+    assert device_events[-1]["data"]["finished"] is True
+
+    parse_agent = _make_mai_agent()
+
+    async def bad_parse_stream(messages):
+        yield {"type": "raw", "content": "not xml"}
+
+    monkeypatch.setattr(parse_agent, "_stream_openai", bad_parse_stream)
+    parse_events = asyncio.run(_collect(parse_agent._execute_step()))
+    assert parse_events[-2]["data"]["message"].startswith("Parse error:")
+    assert "after 3 retries" in parse_events[-1]["data"]["message"]
+
+    model_agent = _make_mai_agent()
+
+    async def broken_stream(messages):
+        raise RuntimeError("model failed")
+        yield {}
+
+    monkeypatch.setattr(model_agent, "_stream_openai", broken_stream)
+    model_events = asyncio.run(_collect(model_agent._execute_step()))
+    assert model_events[-2]["data"]["message"] == "Model error: model failed"
+    assert "after 3 retries" in model_events[-1]["data"]["message"]
+
+
+def test_mai_stream_openai_splits_thinking_and_raw(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _make_mai_agent()
+
+    class FakeDelta:
+        def __init__(self, content: str | None) -> None:
+            self.content = content
+
+    class FakeChoice:
+        def __init__(self, content: str | None) -> None:
+            self.delta = FakeDelta(content)
+
+    class FakeChunk:
+        def __init__(self, content: str | None = None, empty: bool = False) -> None:
+            self.choices = [] if empty else [FakeChoice(content)]
+
+    class FakeStream:
+        def __init__(self) -> None:
+            self.closed = False
+            self.chunks = [
+                FakeChunk("hello "),
+                FakeChunk("<think", empty=True),
+                FakeChunk("<tool_call>{}</tool_call>"),
+            ]
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self.chunks:
+                raise StopAsyncIteration
+            return self.chunks.pop(0)
+
+        async def close(self) -> None:
+            self.closed = True
+
+    fake_stream = FakeStream()
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            return fake_stream
+
+    agent.openai_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FakeCompletions())
+    )
+
+    events = asyncio.run(
+        _collect(agent._stream_openai([{"role": "user", "content": "x"}]))
+    )
+    assert events[0] == {"type": "raw", "content": "hello "}
+    assert {"type": "thinking", "content": "hello "} in events
+    assert events[-1]["type"] == "raw"
+    assert fake_stream.closed is True

--- a/tests/test_coverage_phase1.py
+++ b/tests/test_coverage_phase1.py
@@ -1,0 +1,455 @@
+"""Additional unit coverage for pure parsing and file-backed managers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from AutoGLM_GUI.agents.mai.parser import MAIParseError, MAIParser
+from AutoGLM_GUI.agents.midscene.log_parser import (
+    MidsceneLogParser,
+    _is_new_log_entry,
+    _strip_timestamp,
+)
+from AutoGLM_GUI.device_group_manager import DeviceGroupManager
+from AutoGLM_GUI.history_manager import HistoryManager
+from AutoGLM_GUI.models.device_group import DEFAULT_GROUP_ID, DeviceGroup
+from AutoGLM_GUI.models.history import (
+    ConversationRecord,
+    DeviceHistory,
+    MessageRecord,
+    StepTimingRecord,
+    TraceSummaryRecord,
+)
+from AutoGLM_GUI.workflow_manager import WorkflowManager
+
+
+def _make_midscene_plan(action_type: str = "Tap") -> str:
+    return json.dumps(
+        {
+            "thought": "tap the button",
+            "log": "tap login",
+            "action": {"type": action_type, "param": {"x": 1}},
+            "shouldContinuePlanning": False,
+        }
+    )
+
+
+def test_midscene_log_parser_extracts_debug_events() -> None:
+    parser = MidsceneLogParser()
+
+    reasoning = parser.feed(
+        "2026-05-19T01:02:03.456Z midscene:ai:call response reasoning content: think"
+    )
+    action = parser.feed(
+        "2026-05-19T01:02:03.456Z midscene:agent:task-builder calling action Tap"
+    )
+    plan = parser.feed(
+        "2026-05-19T01:02:03.456Z midscene:device-task-executor planResult "
+        + _make_midscene_plan()
+    )
+
+    assert reasoning == [{"event": "reasoning", "data": "think"}]
+    assert action == [{"event": "action_executing", "data": "Tap"}]
+    assert plan[0]["event"] == "plan_result"
+    assert plan[0]["data"]["action"]["type"] == "Tap"
+
+
+def test_midscene_log_parser_flushes_multiline_json_and_task_messages() -> None:
+    parser = MidsceneLogParser()
+
+    assert parser.feed("dbug midscene:device-task-executor planResult {") == []
+    assert parser.feed('"thought": "inspect",') == []
+    assert parser.feed('"log": "look",') == []
+    assert parser.feed('"action": {"type": "Insight"},') == []
+    assert parser.feed('"shouldContinuePlanning": true') == []
+    plan_events = parser.feed("}")
+
+    assert plan_events[0]["event"] == "plan_result"
+    assert plan_events[0]["data"]["thought"] == "inspect"
+
+    assert parser.feed("Task finished, message: first line") == []
+    assert parser.feed("second line") == []
+    finished = parser.feed("info another log entry")
+
+    assert finished == [{"event": "task_finished", "data": "first line\nsecond line"}]
+
+    parser.feed("Task finished, message: trailing")
+    assert parser.flush() == [{"event": "task_finished", "data": "trailing"}]
+
+
+def test_midscene_log_parser_helpers_and_oversized_json(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    timestamped = "2026-05-19T01:02:03.456Z content"
+
+    assert _is_new_log_entry(timestamped)
+    assert _is_new_log_entry("Action tap")
+    assert not _is_new_log_entry("continuation")
+    assert _strip_timestamp(timestamped) == "content"
+    assert _strip_timestamp("plain") == "plain"
+
+    parser = MidsceneLogParser()
+    parser.feed("dbug midscene:device-task-executor planResult {")
+    for index in range(201):
+        parser.feed(f'"line{index}": "value",')
+
+    assert "JSON block too long" in caplog.text
+    assert parser.flush() == []
+
+
+def _tool_call(arguments: dict[str, object]) -> str:
+    return (
+        "<thinking>ready</thinking><tool_call>"
+        + json.dumps({"name": "mobile_use", "arguments": arguments})
+        + "</tool_call>"
+    )
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected"),
+    [
+        (
+            {"action": "click", "coordinate": [0.25, 0.75]},
+            {"_metadata": "do", "action": "Tap", "element": [250, 750]},
+        ),
+        (
+            {"action": "long_press", "coordinate": [0.1, 0.2]},
+            {"_metadata": "do", "action": "Long Press", "element": [100, 200]},
+        ),
+        (
+            {"action": "double_click", "coordinate": [0.9, 0.8]},
+            {"_metadata": "do", "action": "Double Tap", "element": [900, 800]},
+        ),
+        (
+            {"action": "wait"},
+            {"_metadata": "do", "action": "Wait", "duration": "1 seconds"},
+        ),
+        (
+            {"action": "system_button", "button": "home"},
+            {"_metadata": "do", "action": "Home"},
+        ),
+        (
+            {"action": "system_button", "button": "menu"},
+            {"_metadata": "do", "action": "Back"},
+        ),
+        (
+            {"action": "type", "text": "hello"},
+            {"_metadata": "do", "action": "Type", "text": "hello"},
+        ),
+        (
+            {"action": "open", "app": "Settings"},
+            {"_metadata": "do", "action": "Launch", "app": "Settings"},
+        ),
+        (
+            {"action": "answer", "text": "done"},
+            {"_metadata": "finish", "message": "done"},
+        ),
+        (
+            {"action": "terminate", "status": "success"},
+            {"_metadata": "finish", "message": "Task completed"},
+        ),
+        (
+            {"action": "terminate", "status": "failed"},
+            {"_metadata": "finish", "message": "Task failed"},
+        ),
+    ],
+)
+def test_mai_parser_converts_actions(
+    arguments: dict[str, object], expected: dict[str, object]
+) -> None:
+    assert MAIParser().parse(_tool_call(arguments)) == expected
+
+
+@pytest.mark.parametrize(
+    ("direction", "start", "end"),
+    [
+        ("up", [500, 800], [500, 200]),
+        ("down", [500, 200], [500, 800]),
+        ("left", [800, 500], [200, 500]),
+        ("right", [200, 500], [800, 500]),
+        ("diagonal", [500, 500], [500, 500]),
+    ],
+)
+def test_mai_parser_swipe_directions(
+    direction: str, start: list[int], end: list[int]
+) -> None:
+    assert MAIParser().parse(
+        _tool_call(
+            {"action": "swipe", "direction": direction, "coordinate": [0.5, 0.5]}
+        )
+    ) == {"_metadata": "do", "action": "Swipe", "start": start, "end": end}
+
+
+def test_mai_parser_handles_think_alias_drag_and_scaled_coordinates() -> None:
+    parser = MAIParser()
+    raw = (
+        "step one</think><tool_call>"
+        + json.dumps(
+            {
+                "name": "mobile_use",
+                "arguments": {"action": "click", "coordinate": [0, 0, 999, 999]},
+            }
+        )
+        + "</tool_call>"
+    )
+
+    parsed = parser.parse_with_thinking(raw)
+    dragged = parser.parse(
+        _tool_call(
+            {
+                "action": "drag",
+                "start_coordinate": [0, 999],
+                "end_coordinate": [999, 0],
+            }
+        )
+    )
+
+    assert parsed["thinking"] == "step one"
+    assert parsed["raw_action"]["coordinate"] == [0.5, 0.5]
+    assert parsed["converted_action"] == {
+        "_metadata": "do",
+        "action": "Tap",
+        "element": [500, 500],
+    }
+    assert dragged == {
+        "_metadata": "do",
+        "action": "Swipe",
+        "start": [0, 1000],
+        "end": [1000, 0],
+    }
+    assert parser.coordinate_scale == 999
+
+
+def test_mai_parser_rejects_invalid_content() -> None:
+    parser = MAIParser()
+
+    with pytest.raises(ValueError, match="Failed to find"):
+        parser.parse("plain text")
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        parser.parse("<thinking>x</thinking><tool_call>{bad</tool_call>")
+    with pytest.raises(ValueError, match="Unknown MAI action type"):
+        parser.parse(_tool_call({"action": "unknown"}))
+    with pytest.raises(MAIParseError, match="Invalid coordinate format"):
+        parser.parse_with_thinking(_tool_call({"action": "click", "coordinate": [1]}))
+
+
+@pytest.fixture
+def workflow_manager(tmp_path: Path) -> WorkflowManager:
+    WorkflowManager._instance = None
+    manager = WorkflowManager()
+    manager._workflows_path = tmp_path / "workflows.json"
+    manager._file_cache = None
+    manager._file_mtime = None
+    yield manager
+    WorkflowManager._instance = None
+
+
+def test_workflow_manager_crud_cache_and_bad_json(
+    workflow_manager: WorkflowManager,
+) -> None:
+    assert workflow_manager.list_workflows() == []
+
+    created = workflow_manager.create_workflow("Morning", "sign in")
+    cached = workflow_manager.list_workflows()
+    updated = workflow_manager.update_workflow(created["uuid"], "Evening", "sign out")
+
+    assert cached == [created]
+    assert updated == {
+        "uuid": created["uuid"],
+        "name": "Evening",
+        "text": "sign out",
+    }
+    assert workflow_manager.get_workflow(created["uuid"]) == updated
+    assert workflow_manager.get_workflow("missing") is None
+    assert workflow_manager.update_workflow("missing", "x", "y") is None
+    assert workflow_manager.delete_workflow("missing") is False
+    assert workflow_manager.delete_workflow(created["uuid"]) is True
+    assert workflow_manager.list_workflows() == []
+
+    workflow_manager._workflows_path.write_text("{bad", encoding="utf-8")
+    workflow_manager._file_cache = None
+    workflow_manager._file_mtime = None
+    assert workflow_manager.list_workflows() == []
+
+
+@pytest.fixture
+def device_group_manager(tmp_path: Path) -> DeviceGroupManager:
+    DeviceGroupManager._instance = None
+    manager = DeviceGroupManager()
+    manager._groups_path = tmp_path / "device_groups.json"
+    manager._groups_cache = None
+    manager._assignments_cache = None
+    manager._file_mtime = None
+    yield manager
+    DeviceGroupManager._instance = None
+
+
+def test_device_group_manager_crud_assignments_and_cache(
+    device_group_manager: DeviceGroupManager,
+) -> None:
+    groups = device_group_manager.list_groups()
+    assert [group.id for group in groups] == [DEFAULT_GROUP_ID]
+    assert device_group_manager.delete_group(DEFAULT_GROUP_ID) is False
+
+    work = device_group_manager.create_group("Work")
+    personal = device_group_manager.create_group("Personal")
+    assert device_group_manager.get_group(work.id).name == "Work"
+    assert device_group_manager.update_group(work.id, "Office").name == "Office"
+    assert device_group_manager.update_group("missing", "x") is None
+
+    assert device_group_manager.assign_device("serial-1", work.id) is True
+    assert device_group_manager.assign_device("serial-2", "missing") is False
+    assert device_group_manager.get_device_group("serial-1") == work.id
+    assert device_group_manager.get_device_group("unknown") == DEFAULT_GROUP_ID
+    assert device_group_manager.get_devices_in_group(work.id) == ["serial-1"]
+    assert device_group_manager.get_all_assignments() == {"serial-1": work.id}
+
+    assert device_group_manager.reorder_groups([DEFAULT_GROUP_ID, personal.id, work.id])
+    assert device_group_manager.reorder_groups(["missing"]) is False
+    assert [group.id for group in device_group_manager.list_groups()] == [
+        DEFAULT_GROUP_ID,
+        personal.id,
+        work.id,
+    ]
+
+    assert device_group_manager.delete_group(work.id) is True
+    assert device_group_manager.get_device_group("serial-1") == DEFAULT_GROUP_ID
+    assert device_group_manager.get_devices_in_group(DEFAULT_GROUP_ID) == ["serial-1"]
+    assert device_group_manager.delete_group("missing") is False
+
+
+def test_device_group_manager_recovers_default_and_bad_json(
+    device_group_manager: DeviceGroupManager,
+) -> None:
+    custom = DeviceGroup(id="custom", name="Custom", order=2)
+    device_group_manager._groups_path.parent.mkdir(parents=True, exist_ok=True)
+    device_group_manager._groups_path.write_text(
+        json.dumps(
+            {
+                "groups": [custom.to_dict()],
+                "device_assignments": {"serial": "custom"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    device_group_manager._groups_cache = None
+    device_group_manager._assignments_cache = None
+    device_group_manager._file_mtime = None
+
+    assert [group.id for group in device_group_manager.list_groups()] == [
+        DEFAULT_GROUP_ID,
+        "custom",
+    ]
+
+    device_group_manager._groups_path.write_text("{bad", encoding="utf-8")
+    device_group_manager._groups_cache = None
+    device_group_manager._assignments_cache = None
+    device_group_manager._file_mtime = None
+    assert [group.id for group in device_group_manager.list_groups()] == [
+        DEFAULT_GROUP_ID
+    ]
+
+
+@pytest.fixture
+def history_manager(tmp_path: Path) -> HistoryManager:
+    HistoryManager._instance = None
+    manager = HistoryManager()
+    manager._history_dir = tmp_path / "history"
+    manager._file_cache = {}
+    manager._file_mtime = {}
+    yield manager
+    HistoryManager._instance = None
+
+
+def _conversation(record_id: str = "record-1") -> ConversationRecord:
+    return ConversationRecord(
+        id=record_id,
+        task_text="task",
+        final_message="done",
+        success=True,
+        steps=1,
+        source="chat",
+        trace_id="trace-1",
+        step_timings=[
+            StepTimingRecord(step=1, trace_id="trace-1", llm_duration_ms=2.5)
+        ],
+        trace_summary=TraceSummaryRecord(trace_id="trace-1", steps=1),
+        messages=[
+            MessageRecord(
+                role="assistant",
+                content="done",
+                thinking="think",
+                action={"action": "Tap"},
+                step=1,
+            )
+        ],
+    )
+
+
+def test_history_manager_crud_cache_and_serial_safety(
+    history_manager: HistoryManager,
+) -> None:
+    record = _conversation()
+
+    assert (
+        history_manager._sanitize_serialno("")
+        == "ad87109bfff0765f4dd8cf4943b04d16a4070fea"
+    )
+    assert history_manager._sanitize_serialno("../bad") != "../bad"
+    assert history_manager._sanitize_serialno("adb-1._tcp:5555") == "adb-1._tcp:5555"
+
+    history_manager.add_record("serial-1", record)
+    assert history_manager.get_total_count("serial-1") == 1
+    assert history_manager.list_records("serial-1")[0].id == "record-1"
+    assert history_manager.list_records("serial-1", limit=1, offset=1) == []
+    assert history_manager.get_record("serial-1", "record-1").trace_id == "trace-1"
+    assert history_manager.get_record("serial-1", "missing") is None
+
+    loaded_once = history_manager._load_history("serial-1")
+    loaded_twice = history_manager._load_history("serial-1")
+    assert loaded_once is loaded_twice
+
+    assert history_manager.delete_record("serial-1", "missing") is False
+    assert history_manager.delete_record("serial-1", "record-1") is True
+    assert history_manager.get_total_count("serial-1") == 0
+    assert history_manager.clear_device_history("serial-1") is True
+    assert history_manager.clear_device_history("serial-1") is False
+
+
+def test_history_manager_models_and_corrupt_file(
+    history_manager: HistoryManager,
+) -> None:
+    record = _conversation()
+    history = DeviceHistory(serialno="serial-1", records=[record])
+    round_tripped = DeviceHistory.from_dict(history.to_dict())
+
+    assert round_tripped.records[0].messages[0].action == {"action": "Tap"}
+    assert round_tripped.records[0].step_timings[0].llm_duration_ms == 2.5
+    assert round_tripped.records[0].trace_summary.trace_id == "trace-1"
+
+    path = history_manager._get_history_path("serial-2")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{bad", encoding="utf-8")
+    assert history_manager._load_history("serial-2").records == []
+
+
+def test_history_manager_save_failure_cleans_temp_file(
+    history_manager: HistoryManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    history = DeviceHistory(serialno="serial-1", records=[_conversation()])
+    real_open = open
+
+    def failing_open(path, *args, **kwargs):
+        if str(path).endswith(".tmp"):
+            raise OSError("write failed")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", failing_open)
+
+    assert history_manager._save_history(history) is False
+    assert (
+        not history_manager._get_history_path("serial-1").with_suffix(".tmp").exists()
+    )

--- a/tests/test_hardware_boundary_coverage.py
+++ b/tests/test_hardware_boundary_coverage.py
@@ -1,0 +1,548 @@
+"""Coverage for ADB/scrcpy boundary code using fakes only."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import socket
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+import AutoGLM_GUI.adb_plus.device as adb_device
+import AutoGLM_GUI.adb_plus.ip as adb_ip
+import AutoGLM_GUI.adb_plus.keyboard_installer as keyboard
+import AutoGLM_GUI.adb_plus.mdns as mdns
+import AutoGLM_GUI.adb_plus.pair as pair
+import AutoGLM_GUI.adb_plus.qr_pair as qr_pair
+import AutoGLM_GUI.adb_plus.screenshot as screenshot
+import AutoGLM_GUI.adb_plus.touch as touch
+import AutoGLM_GUI.adb_plus.version as adb_version
+import AutoGLM_GUI.scrcpy_stream as scrcpy_stream
+from AutoGLM_GUI.exceptions import DeviceNotAvailableError
+from AutoGLM_GUI.scrcpy_protocol import (
+    PTS_CONFIG,
+    PTS_KEYFRAME,
+    SCRCPY_CODEC_H264,
+    ScrcpyVideoStreamOptions,
+)
+from AutoGLM_GUI.scrcpy_stream import ScrcpyStreamer
+
+
+PNG_1X1_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+    "/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+
+
+async def _noop_sleep(delay: float) -> None:
+    return None
+
+
+def _completed(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def _streamer(**kwargs) -> ScrcpyStreamer:
+    return ScrcpyStreamer(device_id="serial-1", **kwargs)
+
+
+@pytest.fixture(autouse=True)
+def fake_scrcpy_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ScrcpyStreamer, "_find_scrcpy_server", lambda self: "/server")
+
+
+def test_scrcpy_port_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.listen(1)
+    try:
+        assert asyncio.run(scrcpy_stream.is_port_available(port)) is False
+    finally:
+        sock.close()
+
+    values = iter([False, False, True])
+
+    async def fake_available(port: int, host: str = "127.0.0.1") -> bool:
+        return next(values)
+
+    monkeypatch.setattr(scrcpy_stream, "is_port_available", fake_available)
+    monkeypatch.setattr(asyncio, "sleep", _noop_sleep)
+    assert asyncio.run(
+        scrcpy_stream.wait_for_port_release(1234, timeout=1.0, poll_interval=0.0)
+    )
+
+
+def test_scrcpy_start_cleanup_and_server_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    streamer = _streamer()
+    calls: list[list[str]] = []
+
+    async def fake_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        return _completed()
+
+    async def fake_check(device_id: str | None) -> None:
+        calls.append(["check", str(device_id)])
+
+    async def fake_wait(port: int, timeout: float, poll_interval: float):
+        return True
+
+    class FakeProcess:
+        returncode = None
+
+        def terminate(self) -> None:
+            pass
+
+    async def fake_spawn(cmd, capture_output=False):
+        calls.append(cmd)
+        return FakeProcess()
+
+    monkeypatch.setattr(scrcpy_stream, "run_cmd_silently", fake_run)
+    monkeypatch.setattr(scrcpy_stream, "check_device_available", fake_check)
+    monkeypatch.setattr(scrcpy_stream, "wait_for_port_release", fake_wait)
+    monkeypatch.setattr(scrcpy_stream, "spawn_process", fake_spawn)
+    monkeypatch.setattr(scrcpy_stream, "is_windows", lambda: False)
+    monkeypatch.setattr(asyncio, "sleep", _noop_sleep)
+
+    async def fake_connect(self):
+        self.tcp_socket = FakeSocket()
+
+    monkeypatch.setattr(ScrcpyStreamer, "_connect_socket", fake_connect)
+
+    asyncio.run(streamer.start())
+
+    assert calls[0] == ["check", "serial-1"]
+    assert [
+        "adb",
+        "-s",
+        "serial-1",
+        "push",
+        "/server",
+        "/data/local/tmp/scrcpy-server",
+    ] in calls
+    assert streamer.forward_cleanup_needed is True
+    assert any("app_process" in cmd for cmd in calls)
+
+
+def test_scrcpy_start_failure_and_server_port_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    streamer = _streamer()
+
+    async def fail_check(device_id: str | None) -> None:
+        raise RuntimeError("device gone")
+
+    stopped = False
+
+    def fake_stop() -> None:
+        nonlocal stopped
+        stopped = True
+
+    monkeypatch.setattr(scrcpy_stream, "check_device_available", fail_check)
+    monkeypatch.setattr(streamer, "stop", fake_stop)
+    with pytest.raises(RuntimeError, match="Failed to start scrcpy server"):
+        asyncio.run(streamer.start())
+    assert stopped
+
+    conflict = _streamer()
+
+    class FailedProc:
+        returncode = 1
+
+        async def communicate(self):
+            return b"", b"Address already in use"
+
+    async def fake_spawn(cmd, capture_output=False):
+        return FailedProc()
+
+    monkeypatch.setattr(scrcpy_stream, "spawn_process", fake_spawn)
+    monkeypatch.setattr(scrcpy_stream, "is_windows", lambda: False)
+
+    async def cleanup_noop() -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _noop_sleep)
+    monkeypatch.setattr(conflict, "_cleanup_existing_server", cleanup_noop)
+    with pytest.raises(RuntimeError, match="persistently occupied"):
+        asyncio.run(conflict._start_server())
+    conflict.scrcpy_process = None
+
+
+class FakeSocket:
+    def __init__(self, data: bytes = b"", fail_connects: int = 0) -> None:
+        self.data = bytearray(data)
+        self.fail_connects = fail_connects
+        self.closed = False
+        self.options: list[tuple[int, int, int]] = []
+
+    def setsockopt(self, level: int, option: int, value: int) -> None:
+        self.options.append((level, option, value))
+
+    def settimeout(self, value: float | None) -> None:
+        self.timeout = value
+
+    def connect(self, address) -> None:
+        if self.fail_connects > 0:
+            self.fail_connects -= 1
+            raise ConnectionRefusedError("not yet")
+
+    def recv(self, size: int) -> bytes:
+        if not self.data:
+            return b""
+        chunk = bytes(self.data[:size])
+        del self.data[:size]
+        return chunk
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_scrcpy_socket_connect_metadata_packets_and_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[FakeSocket] = []
+
+    def fake_socket(*args, **kwargs):
+        sock = FakeSocket(fail_connects=1 if not created else 0)
+        created.append(sock)
+        return sock
+
+    streamer = _streamer()
+    real_socket = socket.socket
+
+    async def run_connect() -> None:
+        monkeypatch.setattr(scrcpy_stream.socket, "socket", fake_socket)
+        monkeypatch.setattr(asyncio, "sleep", _noop_sleep)
+        try:
+            await streamer._connect_socket()
+        finally:
+            monkeypatch.setattr(scrcpy_stream.socket, "socket", real_socket)
+
+    asyncio.run(run_connect())
+    assert len(created) == 2
+    assert created[0].closed is True
+    assert streamer.tcp_socket is created[1]
+
+    name = b"Pixel 8" + b"\x00" * (64 - len("Pixel 8"))
+    raw = (
+        b"\x00"
+        + name
+        + SCRCPY_CODEC_H264.to_bytes(4, "big")
+        + (1080).to_bytes(4, "big")
+        + (2400).to_bytes(4, "big")
+        + PTS_CONFIG.to_bytes(8, "big")
+        + (3).to_bytes(4, "big")
+        + b"cfg"
+        + (PTS_KEYFRAME | 12).to_bytes(8, "big")
+        + (4).to_bytes(4, "big")
+        + b"data"
+    )
+    packet_streamer = _streamer(
+        stream_options=ScrcpyVideoStreamOptions(send_dummy_byte=True)
+    )
+    packet_streamer.tcp_socket = FakeSocket(raw)
+
+    metadata = asyncio.run(packet_streamer.read_video_metadata())
+    config_packet = asyncio.run(packet_streamer.read_media_packet())
+    data_packet = asyncio.run(packet_streamer.read_media_packet())
+
+    assert metadata.device_name == "Pixel 8"
+    assert metadata.width == 1080
+    assert metadata.height == 2400
+    assert config_packet.type == "configuration"
+    assert data_packet.keyframe is True
+    assert data_packet.pts == 12
+
+    no_frame = _streamer(stream_options=ScrcpyVideoStreamOptions(send_frame_meta=False))
+    with pytest.raises(RuntimeError, match="send_frame_meta"):
+        asyncio.run(no_frame.read_media_packet())
+
+    run_calls: list[list[str]] = []
+    packet_streamer.forward_cleanup_needed = True
+    monkeypatch.setattr(
+        scrcpy_stream.subprocess,
+        "run",
+        lambda cmd, **kwargs: run_calls.append(cmd),
+    )
+    packet_streamer.stop()
+    assert run_calls[-1][-1] == "tcp:27183"
+
+
+def test_adb_device_availability(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def ok(cmd, *args, **kwargs):
+        return _completed(stdout="device\n")
+
+    monkeypatch.setattr(adb_device, "run_cmd_silently", ok)
+    asyncio.run(adb_device.check_device_available("serial"))
+
+    async def offline(cmd, *args, **kwargs):
+        return _completed(stderr="device offline")
+
+    monkeypatch.setattr(adb_device, "run_cmd_silently", offline)
+    with pytest.raises(DeviceNotAvailableError, match="not available"):
+        asyncio.run(adb_device.check_device_available("serial"))
+
+    async def timeout(cmd, *args, **kwargs):
+        raise TimeoutError
+
+    monkeypatch.setattr(adb_device, "run_cmd_silently", timeout)
+    with pytest.raises(DeviceNotAvailableError, match="timed out"):
+        asyncio.run(adb_device.check_device_available("serial"))
+
+    async def missing(cmd, *args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(adb_device, "run_cmd_silently", missing)
+    with pytest.raises(DeviceNotAvailableError, match="ADB executable"):
+        asyncio.run(adb_device.check_device_available("serial"))
+
+
+def test_adb_ip_sync_and_async(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert adb_ip._extract_ip("inet 192.168.1.5/24") == "192.168.1.5"
+    assert adb_ip._extract_ip("inet 0.0.0.0") is None
+    assert adb_ip._build_shell_cmd("adb", "s", ["ip"]) == [
+        "adb",
+        "-s",
+        "s",
+        "shell",
+        "ip",
+    ]
+
+    outputs = iter(
+        [
+            "8.8.8.8 dev rmnet_data0 src 10.0.0.2\n8.8.8.8 dev wlan0 src 192.168.1.8",
+            "inet 192.168.1.9/24",
+        ]
+    )
+    monkeypatch.setattr(adb_ip, "_run", lambda *a, **k: next(outputs))
+    assert adb_ip.get_wifi_ip("adb", "serial") == "192.168.1.8"
+
+    monkeypatch.setattr(
+        adb_ip, "_run", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("x"))
+    )
+    assert adb_ip.get_wifi_ip("adb", "serial") is None
+
+    async_outputs = iter(
+        [
+            _completed(stdout="8.8.8.8 dev rmnet0 src 10.0.0.1"),
+            _completed(stdout="inet 192.168.1.10/24"),
+        ]
+    )
+
+    async def fake_run(cmd, timeout=5):
+        return next(async_outputs)
+
+    monkeypatch.setattr(adb_ip, "run_cmd_silently", fake_run)
+    assert asyncio.run(adb_ip.get_wifi_ip_async("adb", "serial")) == "192.168.1.10"
+
+
+def test_screenshot_sync_async_and_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert screenshot._is_valid_png(PNG_1X1_BYTES)
+    assert not screenshot._is_valid_png(b"nope")
+
+    monkeypatch.setattr(
+        screenshot.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 0, PNG_1X1_BYTES, b""),
+    )
+    captured = screenshot.capture_screenshot("serial", retries=0)
+    assert captured.width == 1
+    assert captured.height == 1
+
+    monkeypatch.setattr(
+        screenshot.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 1, b"", b"device offline"),
+    )
+    with pytest.raises(DeviceNotAvailableError):
+        screenshot._try_capture("serial", "adb", 1)
+
+    monkeypatch.setattr(
+        screenshot.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 1, b"", b"bad png"),
+    )
+    fallback = screenshot.capture_screenshot("serial", retries=0)
+    assert fallback.width == 1080
+    assert fallback.is_sensitive is False
+
+    class AsyncProc:
+        returncode = 0
+
+        async def communicate(self):
+            return PNG_1X1_BYTES, b""
+
+        def kill(self) -> None:
+            pass
+
+    async def fake_create(*args, **kwargs):
+        return AsyncProc()
+
+    monkeypatch.setattr(screenshot, "is_windows", lambda: False)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create)
+    async_captured = asyncio.run(
+        screenshot.capture_screenshot_async("serial", retries=0)
+    )
+    assert async_captured.width == 1
+
+
+def test_mdns_pair_touch_version_and_keyboard(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert mdns._parse_mdns_line("name\t_adb-tls-connect._tcp\t1.2.3.4:5555") == (
+        "name",
+        "_adb-tls-connect._tcp",
+        "1.2.3.4:5555",
+    )
+    assert mdns._parse_mdns_line("bad") is None
+    assert mdns._parse_address("1.2.3.4:5555") == ("1.2.3.4", 5555)
+    assert mdns._parse_address("999.2.3.4:5555") is None
+
+    mdns_output = (
+        "List of discovered mdns services\n"
+        "adb-dev\t_adb-tls-pairing._tcp\t0.0.0.0:12345\n"
+        "adb-dev\t_adb-tls-connect._tcp\t192.168.1.50:34567\n"
+    )
+    monkeypatch.setattr(
+        mdns, "run_cmd_silently_sync", lambda *a, **k: _completed(stdout=mdns_output)
+    )
+    devices = mdns.discover_mdns_devices()
+    assert devices[0].has_pairing is True
+    assert devices[0].pairing_port == 12345
+
+    monkeypatch.setattr(
+        pair,
+        "run_cmd_silently_sync",
+        lambda *a, **k: _completed(stdout="Successfully paired"),
+    )
+    assert pair.pair_device("1.2.3.4", 1234, "123456")[0] is True
+    assert pair.pair_device("1.2.3.4", 1234, "bad") == (
+        False,
+        "Pairing code must be 6 digits",
+    )
+
+    async def fake_pair_run(cmd, timeout=30):
+        return _completed(stdout="failed: pairing code")
+
+    monkeypatch.setattr(pair, "run_cmd_silently", fake_pair_run)
+    assert asyncio.run(pair.pair_device_async("1.2.3.4", 1234, "123456")) == (
+        False,
+        "Invalid pairing code",
+    )
+
+    run_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        touch.subprocess, "run", lambda cmd, **kwargs: run_calls.append(cmd)
+    )
+    monkeypatch.setattr(touch.time, "sleep", lambda delay: None)
+    touch.touch_down(1, 2, "serial", delay=0.1)
+    touch.touch_move(3, 4, "serial")
+    touch.touch_up(5, 6, "serial")
+    assert [call[-3] for call in run_calls] == ["DOWN", "MOVE", "UP"]
+
+    async_calls: list[list[str]] = []
+
+    async def fake_touch_run(cmd, timeout=5):
+        async_calls.append(cmd)
+        return _completed()
+
+    monkeypatch.setattr(touch, "run_cmd_silently", fake_touch_run)
+    monkeypatch.setattr(asyncio, "sleep", _noop_sleep)
+    asyncio.run(touch.touch_down_async(1, 2, "serial", delay=0))
+    asyncio.run(touch.touch_move_async(3, 4, "serial", delay=0))
+    asyncio.run(touch.touch_up_async(5, 6, "serial", delay=0))
+    assert [call[-3] for call in async_calls] == ["DOWN", "MOVE", "UP"]
+
+    monkeypatch.setattr(
+        adb_version,
+        "run_cmd_silently_sync",
+        lambda *a, **k: _completed(stdout="Android Debug Bridge version 1.0.41"),
+    )
+    assert adb_version.get_adb_version() == (1, 0, 41)
+    monkeypatch.setattr(
+        adb_version,
+        "run_cmd_silently_sync",
+        lambda *a, **k: _completed(stdout="Version 34.0.5-11580240"),
+    )
+    assert adb_version.get_adb_version() == (34, 0, 5)
+    monkeypatch.setattr(
+        adb_version,
+        "run_cmd_silently_sync",
+        lambda *a, **k: _completed(stdout="mdns services"),
+    )
+    assert adb_version.supports_mdns_services()
+
+    installer = keyboard.ADBKeyboardInstaller("serial")
+    monkeypatch.setattr(
+        installer, "get_apk_path", lambda: SimpleNamespace(exists=lambda: True)
+    )
+    monkeypatch.setattr(installer, "is_installed", lambda: True)
+    monkeypatch.setattr(installer, "is_enabled", lambda: False)
+    monkeypatch.setattr(installer, "enable", lambda: (True, "enabled"))
+    assert installer.auto_setup() == (True, "enabled")
+    status = installer.get_status()
+    assert status["status"] == "installed_but_disabled"
+
+
+def test_qr_pair_listener_and_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeInfo:
+        port = 1234
+        server = "host.local."
+
+        def __init__(self, addrs: list[str]) -> None:
+            self._addrs = addrs
+
+        def parsed_addresses(self) -> list[str]:
+            return self._addrs
+
+    assert (
+        qr_pair._pick_host_from_info(FakeInfo(["fe80::1", "192.168.1.2"]))
+        == "192.168.1.2"
+    )
+    assert qr_pair._pick_host_from_info(FakeInfo([])) == "host.local"
+
+    monkeypatch.setattr(
+        qr_pair,
+        "run_cmd_silently_sync",
+        lambda cmd, timeout=20: _completed(
+            stdout="Successfully paired" if "pair" in cmd else "connected to device"
+        ),
+    )
+    assert qr_pair._adb_pair("1.2.3.4", 1234, "pass")
+    assert qr_pair._adb_connect("1.2.3.4", 5555)
+
+    session = qr_pair.PairingSession(
+        session_id="sid",
+        name="name",
+        password="pass",
+        qr_payload="payload",
+        status="listening",
+    )
+    listener = qr_pair.QRPairingListener(session, "adb")
+
+    class FakeZeroconf:
+        def __init__(self, info: FakeInfo) -> None:
+            self.info = info
+
+        def get_service_info(self, type_, name, timeout=3000):
+            return self.info
+
+    zc = FakeZeroconf(FakeInfo(["192.168.1.2"]))
+    listener.add_service(zc, qr_pair.PAIR_SERVICE_TYPE, "pair")
+    listener.add_service(zc, qr_pair.PAIR_SERVICE_TYPE, "pair")
+    listener.add_service(zc, qr_pair.CONNECT_SERVICE_TYPE, "connect")
+    listener.update_service(zc, qr_pair.CONNECT_SERVICE_TYPE, "connect")
+    listener.remove_service(zc, qr_pair.CONNECT_SERVICE_TYPE, "connect")
+
+    assert session.status == "connected"
+    assert session.device_id == "192.168.1.2:1234"
+
+    manager = qr_pair.QRPairingManager()
+    session.zeroconf = SimpleNamespace(close=lambda: None)
+    session.thread = SimpleNamespace(is_alive=lambda: False, join=lambda timeout: None)
+    manager._sessions["sid"] = session
+    assert manager.get_session("sid") is session
+    assert manager.cancel_session("sid") is True
+    assert manager.cancel_session("missing") is False

--- a/tests/test_hardware_boundary_coverage.py
+++ b/tests/test_hardware_boundary_coverage.py
@@ -7,9 +7,14 @@ import base64
 import socket
 import subprocess
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
+import AutoGLM_GUI.adb.apps as adb_apps
+import AutoGLM_GUI.adb.connection as adb_connection
+import AutoGLM_GUI.adb.device as adb_core_device
+import AutoGLM_GUI.adb.input as adb_input
 import AutoGLM_GUI.adb_plus.device as adb_device
 import AutoGLM_GUI.adb_plus.ip as adb_ip
 import AutoGLM_GUI.adb_plus.keyboard_installer as keyboard
@@ -19,6 +24,8 @@ import AutoGLM_GUI.adb_plus.qr_pair as qr_pair
 import AutoGLM_GUI.adb_plus.screenshot as screenshot
 import AutoGLM_GUI.adb_plus.touch as touch
 import AutoGLM_GUI.adb_plus.version as adb_version
+import AutoGLM_GUI.devices.adb_device as adb_device_impl
+import AutoGLM_GUI.platform_utils as platform_utils
 import AutoGLM_GUI.scrcpy_stream as scrcpy_stream
 from AutoGLM_GUI.exceptions import DeviceNotAvailableError
 from AutoGLM_GUI.scrcpy_protocol import (
@@ -301,6 +308,410 @@ def test_adb_device_availability(monkeypatch: pytest.MonkeyPatch) -> None:
         asyncio.run(adb_device.check_device_available("serial"))
 
 
+def test_adb_connection_command_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert adb_connection.is_adb_tcpip_device_id("192.168.1.2:5555")
+    assert not adb_connection.is_adb_tcpip_device_id("usb-1")
+    assert (
+        adb_connection.infer_connection_type_from_device_id("192.168.1.2:5555")
+        == adb_connection.ConnectionType.REMOTE
+    )
+    assert (
+        adb_connection.infer_connection_type_from_device_id("usb-1")
+        == adb_connection.ConnectionType.USB
+    )
+
+    conn = adb_connection.ADBConnection("adbx")
+    run_calls: list[list[str]] = []
+
+    def fake_connect_run(cmd, **kwargs):
+        run_calls.append(cmd)
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="connected to device", stderr=""
+        )
+
+    monkeypatch.setattr(adb_connection.subprocess, "run", fake_connect_run)
+    assert conn.connect("1.2.3.4") == (True, "Connected to 1.2.3.4:5555")
+    assert run_calls[-1] == ["adbx", "connect", "1.2.3.4:5555"]
+
+    def fake_already_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="already connected", stderr=""
+        )
+
+    monkeypatch.setattr(adb_connection.subprocess, "run", fake_already_run)
+    assert conn.connect("1.2.3.4:7777") == (True, "Connected to 1.2.3.4:7777")
+
+    def fake_failed_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="refused")
+
+    monkeypatch.setattr(adb_connection.subprocess, "run", fake_failed_run)
+    assert conn.connect("1.2.3.4:7777") == (False, "refused")
+    assert conn.disconnect("1.2.3.4:7777") == (True, "refused")
+
+    def fake_timeout_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 1))
+
+    monkeypatch.setattr(adb_connection.subprocess, "run", fake_timeout_run)
+    assert conn.connect("1.2.3.4:7777", timeout=2) == (
+        False,
+        "Connection timeout after 2s",
+    )
+
+    def fake_broken_run(cmd, **kwargs):
+        raise RuntimeError("subprocess failed")
+
+    monkeypatch.setattr(adb_connection.subprocess, "run", fake_broken_run)
+    assert conn.connect("1.2.3.4:7777") == (
+        False,
+        "Connection error: subprocess failed",
+    )
+    assert conn.disconnect() == (False, "Disconnect error: subprocess failed")
+
+    devices_output = (
+        "List of devices attached\n"
+        "usb-1 device product:p model:Pixel device:d\n"
+        "192.168.1.2:5555 offline product:p model:Remote device:d\n"
+    )
+
+    def fake_devices_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, stdout=devices_output, stderr="")
+
+    monkeypatch.setattr(adb_connection.subprocess, "run", fake_devices_run)
+    listed = conn.list_devices()
+    assert [device.device_id for device in listed] == ["usb-1", "192.168.1.2:5555"]
+    assert listed[0].model == "Pixel"
+    assert listed[1].connection_type == adb_connection.ConnectionType.REMOTE
+    assert conn.get_device_info("usb-1") == listed[0]
+    assert conn.get_device_info("missing") is None
+    assert conn.is_connected("usb-1") is True
+    assert conn.is_connected("192.168.1.2:5555") is False
+    assert conn.is_connected() is True
+
+    monkeypatch.setattr(
+        conn,
+        "list_devices",
+        lambda: [],
+    )
+    assert conn.get_device_info() is None
+    assert conn.is_connected() is False
+
+    monkeypatch.setattr(adb_connection.time, "sleep", lambda delay: None)
+
+    def fake_tcpip_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="restarting in TCP mode", stderr=""
+        )
+
+    monkeypatch.setattr(adb_connection.subprocess, "run", fake_tcpip_run)
+    assert conn.enable_tcpip(5556, "usb-1") == (
+        True,
+        "TCP/IP mode enabled on port 5556",
+    )
+
+    monkeypatch.setattr(adb_connection.subprocess, "run", fake_failed_run)
+    assert conn.enable_tcpip()[0] is False
+
+    monkeypatch.setattr(adb_connection.subprocess, "run", fake_broken_run)
+    assert conn.enable_tcpip() == (False, "Error enabling TCP/IP: subprocess failed")
+
+    monkeypatch.setattr(adb_connection, "get_wifi_ip", lambda **kwargs: "192.168.1.9")
+    assert conn.get_device_ip("usb-1") == "192.168.1.9"
+
+    def fake_restart_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(adb_connection.subprocess, "run", fake_restart_run)
+    assert conn.restart_server() == (True, "ADB server restarted")
+    monkeypatch.setattr(adb_connection.subprocess, "run", fake_broken_run)
+    assert conn.restart_server() == (
+        False,
+        "Error restarting server: subprocess failed",
+    )
+
+
+def test_adb_core_device_command_wrappers(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+    sleeps: list[tuple[str, float]] = []
+    current_stdout = {"value": "mCurrentFocus Window{u0 com.tencent.mm/.Main}"}
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if "dumpsys" in cmd:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=current_stdout["value"], stderr=""
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(adb_core_device.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        adb_core_device,
+        "trace_sleep",
+        lambda delay, name, attrs: sleeps.append((name, delay)),
+    )
+
+    assert adb_core_device.get_current_app("serial") == "微信"
+    current_stdout["value"] = "mFocusedApp ActivityRecord{u0 unknown.package/.Main}"
+    assert adb_core_device.get_current_app("serial") == "System Home"
+    current_stdout["value"] = ""
+    with pytest.raises(ValueError, match="No output"):
+        adb_core_device.get_current_app("serial")
+
+    adb_core_device.tap(1, 2, "serial", delay=0.01)
+    adb_core_device.double_tap(3, 4, "serial", delay=0.02)
+    adb_core_device.long_press(5, 6, 700, "serial", delay=0.03)
+    adb_core_device.swipe(1, 2, 3, 4, device_id="serial", delay=0.04)
+    adb_core_device.swipe(1, 2, 3, 4, duration_ms=250, device_id="serial", delay=0.05)
+    adb_core_device.back("serial", delay=0.06)
+    adb_core_device.home("serial", delay=0.07)
+    assert adb_core_device.launch_app("Settings", "serial", delay=0.08) is True
+    assert adb_core_device.launch_app("missing", "serial") is False
+
+    flattened = [" ".join(call) for call in calls]
+    assert any("input tap 1 2" in call for call in flattened)
+    assert any("input swipe 5 6 5 6 700" in call for call in flattened)
+    assert any("input keyevent 4" in call for call in flattened)
+    assert any("input keyevent KEYCODE_HOME" in call for call in flattened)
+    assert any("monkey -p com.android.settings" in call for call in flattened)
+    assert [name for name, _ in sleeps] == [
+        "sleep.device_tap_delay",
+        "sleep.device_double_tap_interval",
+        "sleep.device_double_tap_delay",
+        "sleep.device_long_press_delay",
+        "sleep.device_swipe_delay",
+        "sleep.device_swipe_delay",
+        "sleep.device_back_delay",
+        "sleep.device_home_delay",
+        "sleep.device_launch_delay",
+    ]
+
+
+def test_platform_utils_adb_input_apps_and_version_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert platform_utils.build_adb_command() == ["adb"]
+    assert platform_utils.build_adb_command("serial", adb_path="adbx") == [
+        "adbx",
+        "-s",
+        "serial",
+    ]
+    monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+    assert platform_utils.is_windows() is True
+    monkeypatch.setattr(platform_utils.platform, "system", lambda: "Darwin")
+    assert platform_utils.is_windows() is False
+
+    run_calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        run_calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="out", stderr="err")
+
+    monkeypatch.setattr(platform_utils.subprocess, "run", fake_run)
+    assert platform_utils.run_cmd_silently_sync(["cmd"]).stdout == "out"
+
+    monkeypatch.setattr(platform_utils, "is_windows", lambda: True)
+    assert asyncio.run(platform_utils.run_cmd_silently(["cmd"])).stderr == "err"
+
+    class FakeAsyncProcess:
+        returncode = 7
+
+        async def communicate(self):
+            return b"async-out", b"async-err"
+
+        def kill(self) -> None:
+            self.killed = True
+
+    async def fake_create(*cmd, stdout=None, stderr=None):
+        run_calls.append(list(cmd))
+        return FakeAsyncProcess()
+
+    monkeypatch.setattr(platform_utils, "is_windows", lambda: False)
+    monkeypatch.setattr(platform_utils.asyncio, "create_subprocess_exec", fake_create)
+    async_result = asyncio.run(platform_utils.run_cmd_silently(["async-cmd"]))
+    assert async_result.returncode == 7
+    assert async_result.stdout == "async-out"
+    assert (
+        asyncio.run(
+            platform_utils.spawn_process(["spawn"], capture_output=True)
+        ).returncode
+        == 7
+    )
+
+    monkeypatch.setattr(platform_utils, "is_windows", lambda: True)
+    monkeypatch.setattr(
+        platform_utils.subprocess,
+        "Popen",
+        lambda cmd, stdout=None, stderr=None: SimpleNamespace(cmd=cmd),
+    )
+    assert platform_utils.spawn_process
+    assert asyncio.run(platform_utils.spawn_process(["spawn-win"])).cmd == ["spawn-win"]
+
+    input_calls: list[list[str]] = []
+
+    def fake_input_run(cmd, **kwargs):
+        input_calls.append(cmd)
+        if "default_input_method" in cmd:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="ime.old/.Keyboard", stderr=""
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(adb_input.subprocess, "run", fake_input_run)
+    adb_input.type_text("")
+    adb_input.type_text("hi", "serial")
+    adb_input.clear_text("serial")
+    assert adb_input.detect_and_set_adb_keyboard("serial") == "ime.old/.Keyboard"
+    adb_input.restore_keyboard("ime.old/.Keyboard", "serial")
+    flattened = [" ".join(call) for call in input_calls]
+    assert any("ADB_INPUT_B64" in call for call in flattened)
+    assert any("ADB_CLEAR_TEXT" in call for call in flattened)
+    assert any("ime set com.android.adbkeyboard/.AdbIME" in call for call in flattened)
+    assert any("ime set ime.old/.Keyboard" in call for call in flattened)
+
+    assert adb_apps.get_package_name("Settings") == "com.android.settings"
+    assert adb_apps.get_package_name("missing") is None
+    assert adb_apps.get_app_name("com.android.settings") is not None
+    assert adb_apps.get_app_name("missing.package") is None
+    assert "Settings" in adb_apps.list_supported_apps()
+
+    monkeypatch.setattr(
+        adb_version,
+        "run_cmd_silently_sync",
+        lambda *a, **k: _completed(stdout="bad", returncode=1),
+    )
+    assert adb_version.get_adb_version() is None
+    monkeypatch.setattr(
+        adb_version,
+        "run_cmd_silently_sync",
+        lambda *a, **k: _completed(stdout="no version"),
+    )
+    assert adb_version.get_adb_version() is None
+    monkeypatch.setattr(
+        adb_version,
+        "run_cmd_silently_sync",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("adb missing")),
+    )
+    assert adb_version.get_adb_version() is None
+    assert adb_version.supports_mdns_services() is False
+
+    monkeypatch.setattr(
+        adb_version,
+        "run_cmd_silently_sync",
+        lambda *a, **k: _completed(stderr="unknown command", returncode=1),
+    )
+    assert adb_version.supports_mdns_services() is False
+
+
+def test_adb_device_and_manager_wrappers(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    class FakeScreenshot:
+        base64_data = "img"
+        width = 100
+        height = 200
+        is_sensitive = True
+
+    monkeypatch.setattr(
+        adb_device_impl.adb,
+        "get_screenshot",
+        lambda device_id, timeout: FakeScreenshot(),
+    )
+    for name in [
+        "tap",
+        "double_tap",
+        "long_press",
+        "swipe",
+        "type_text",
+        "clear_text",
+        "back",
+        "home",
+        "restore_keyboard",
+    ]:
+        monkeypatch.setattr(
+            adb_device_impl.adb,
+            name,
+            lambda *args, _name=name, **kwargs: calls.append((_name, args)),
+        )
+    monkeypatch.setattr(adb_device_impl.adb, "launch_app", lambda *args: True)
+    monkeypatch.setattr(
+        adb_device_impl.adb, "get_current_app", lambda device_id: "com.example"
+    )
+    monkeypatch.setattr(
+        adb_device_impl.adb,
+        "detect_and_set_adb_keyboard",
+        lambda device_id: "ime",
+    )
+
+    device = adb_device_impl.ADBDevice("serial")
+    assert device.device_id == "serial"
+    assert device.get_screenshot(timeout=3).is_sensitive is True
+    device.tap(1, 2, delay=0)
+    device.double_tap(3, 4)
+    device.long_press(5, 6, duration_ms=700)
+    device.swipe(1, 2, 3, 4, duration_ms=500)
+    device.type_text("hello")
+    device.clear_text()
+    device.back()
+    device.home()
+    assert device.launch_app("Settings") is True
+    assert device.get_current_app() == "com.example"
+    assert device.detect_and_set_adb_keyboard() == "ime"
+    device.restore_keyboard("ime")
+    assert [call[0] for call in calls] == [
+        "tap",
+        "double_tap",
+        "long_press",
+        "swipe",
+        "type_text",
+        "clear_text",
+        "back",
+        "home",
+        "restore_keyboard",
+    ]
+
+    class FakeConnection:
+        def __init__(self, adb_path: str = "adb") -> None:
+            self.adb_path = adb_path
+            self.disconnects: list[str] = []
+
+        def list_devices(self):
+            return [
+                adb_connection.DeviceInfo(
+                    device_id="online",
+                    status="device",
+                    model="Pixel",
+                    connection_type=adb_connection.ConnectionType.USB,
+                ),
+                adb_connection.DeviceInfo(
+                    device_id="offline",
+                    status="offline",
+                    model=None,
+                    connection_type=adb_connection.ConnectionType.REMOTE,
+                ),
+            ]
+
+        def connect(self, address: str, timeout: int = 10):
+            return True, f"connected {address}"
+
+        def disconnect(self, device_id: str):
+            self.disconnects.append(device_id)
+            return True, f"disconnected {device_id}"
+
+    monkeypatch.setattr(adb_device_impl, "ADBConnection", FakeConnection)
+    manager = adb_device_impl.ADBDeviceManager("custom-adb")
+    infos = manager.list_devices()
+    assert infos[0].status == "online"
+    assert infos[0].connection_type == "usb"
+    assert manager.get_device("online") is manager.get_device("online")
+    with pytest.raises(KeyError, match="not found"):
+        manager.get_device("missing")
+    with pytest.raises(KeyError, match="offline"):
+        manager.get_device("offline")
+    assert manager.connect("1.2.3.4") == (True, "connected 1.2.3.4")
+    manager._devices["online"] = adb_device_impl.ADBDevice("online")
+    assert manager.disconnect("online") == (True, "disconnected online")
+    assert "online" not in manager._devices
+
+
 def test_adb_ip_sync_and_async(monkeypatch: pytest.MonkeyPatch) -> None:
     assert adb_ip._extract_ip("inet 192.168.1.5/24") == "192.168.1.5"
     assert adb_ip._extract_ip("inet 0.0.0.0") is None
@@ -484,6 +895,154 @@ def test_mdns_pair_touch_version_and_keyboard(monkeypatch: pytest.MonkeyPatch) -
     assert installer.auto_setup() == (True, "enabled")
     status = installer.get_status()
     assert status["status"] == "installed_but_disabled"
+
+
+def test_adb_keyboard_installer_download_install_enable_and_auto_setup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    import importlib.resources
+
+    cache_apk = tmp_path / "ADBKeyboard.apk"
+    monkeypatch.setattr(keyboard, "USER_CACHE_APK_PATH", cache_apk)
+    monkeypatch.setattr(
+        importlib.resources,
+        "files",
+        lambda package: (_ for _ in ()).throw(RuntimeError("no bundle")),
+    )
+    installer = keyboard.ADBKeyboardInstaller("serial")
+
+    run_results = iter(
+        [
+            _completed(stdout="package:com.android.adbkeyboard"),
+            _completed(stdout=keyboard.ADB_KEYBOARD_IME),
+            _completed(stdout=""),
+        ]
+    )
+
+    async def fake_run(cmd, timeout=30):
+        return next(run_results)
+
+    monkeypatch.setattr(keyboard, "run_cmd_silently", fake_run)
+    assert installer.is_installed() is True
+    assert installer.is_enabled() is True
+    assert installer.is_installed() is False
+
+    async def broken_run(cmd, timeout=30):
+        raise RuntimeError("adb failed")
+
+    monkeypatch.setattr(keyboard, "run_cmd_silently", broken_run)
+    assert installer.is_installed() is False
+    assert installer.is_enabled() is False
+
+    cache_apk.write_bytes(b"cached")
+    assert installer.get_apk_path() == cache_apk
+    assert installer.download_apk() is True
+
+    def fake_urlretrieve(url, path):
+        path.write_bytes(b"downloaded")
+
+    monkeypatch.setattr(keyboard.urllib.request, "urlretrieve", fake_urlretrieve)
+    assert installer.download_apk(force=True) is True
+
+    def empty_urlretrieve(url, path):
+        path.write_bytes(b"")
+
+    monkeypatch.setattr(keyboard.urllib.request, "urlretrieve", empty_urlretrieve)
+    assert installer.download_apk(force=True) is False
+
+    def failing_urlretrieve(url, path):
+        path.write_bytes(b"partial")
+        raise RuntimeError("network failed")
+
+    monkeypatch.setattr(keyboard.urllib.request, "urlretrieve", failing_urlretrieve)
+    assert installer.download_apk(force=True) is False
+    assert not cache_apk.exists()
+
+    monkeypatch.setattr(installer, "get_apk_path", lambda: cache_apk)
+    assert installer.install() == (False, "APK file not found. Please download first.")
+
+    cache_apk.write_bytes(b"apk")
+
+    async def install_ok(cmd, timeout=30):
+        return _completed(stdout="Success", returncode=1)
+
+    monkeypatch.setattr(keyboard, "run_cmd_silently", install_ok)
+    assert installer.install()[0] is True
+
+    async def install_fail(cmd, timeout=30):
+        return _completed(stdout="Failure", stderr="bad", returncode=1)
+
+    monkeypatch.setattr(keyboard, "run_cmd_silently", install_fail)
+    assert installer.install()[0] is False
+
+    async def install_broken(cmd, timeout=30):
+        raise RuntimeError("install crashed")
+
+    monkeypatch.setattr(keyboard, "run_cmd_silently", install_broken)
+    assert installer.install() == (False, "Installation error: install crashed")
+
+    async def enable_ok(cmd, timeout=30):
+        return _completed(returncode=0)
+
+    monkeypatch.setattr(keyboard, "run_cmd_silently", enable_ok)
+    assert installer.enable() == (True, "ADB Keyboard enabled successfully")
+
+    async def enable_nonzero(cmd, timeout=30):
+        return _completed(stdout="no", stderr="permission", returncode=1)
+
+    monkeypatch.setattr(keyboard, "run_cmd_silently", enable_nonzero)
+    monkeypatch.setattr(installer, "is_enabled", lambda: True)
+    assert installer.enable() == (True, "ADB Keyboard enabled (verified)")
+
+    monkeypatch.setattr(installer, "is_enabled", lambda: False)
+    assert installer.enable()[0] is False
+
+    async def enable_broken(cmd, timeout=30):
+        raise RuntimeError("enable crashed")
+
+    monkeypatch.setattr(keyboard, "run_cmd_silently", enable_broken)
+    assert installer.enable() == (False, "Enable error: enable crashed")
+
+    monkeypatch.setattr(installer, "is_installed", lambda: True)
+    monkeypatch.setattr(installer, "is_enabled", lambda: True)
+    assert installer.auto_setup()[0] is True
+
+    monkeypatch.setattr(installer, "is_enabled", lambda: False)
+    monkeypatch.setattr(installer, "enable", lambda: (True, "enabled"))
+    assert installer.auto_setup() == (True, "enabled")
+
+    monkeypatch.setattr(installer, "is_installed", lambda: False)
+    monkeypatch.setattr(installer, "download_apk", lambda: False)
+    assert installer.auto_setup() == (False, "Failed to download APK")
+
+    checks = iter([False, True])
+    enabled_checks = iter([False, True])
+    monkeypatch.setattr(installer, "is_installed", lambda: next(checks))
+    monkeypatch.setattr(installer, "is_enabled", lambda: next(enabled_checks))
+    monkeypatch.setattr(installer, "download_apk", lambda: True)
+    monkeypatch.setattr(installer, "install", lambda: (True, "installed"))
+    monkeypatch.setattr(installer, "enable", lambda: (True, "enabled"))
+    assert installer.auto_setup() == (True, "ADB Keyboard setup completed successfully")
+
+    checks = iter([False, True])
+    enabled_checks = iter([False, False])
+    monkeypatch.setattr(installer, "is_installed", lambda: next(checks))
+    monkeypatch.setattr(installer, "is_enabled", lambda: next(enabled_checks))
+    assert installer.auto_setup() == (False, "Setup completed but verification failed")
+
+    class FakeInstaller:
+        def __init__(self, device_id=None) -> None:
+            self.device_id = device_id
+
+        def auto_setup(self):
+            return True, "ok"
+
+        def is_installed(self) -> bool:
+            return False
+
+    monkeypatch.setattr(keyboard, "ADBKeyboardInstaller", FakeInstaller)
+    assert keyboard.auto_setup_adb_keyboard("serial") == (True, "ok")
+    assert keyboard.check_and_suggest_installation() is True
 
 
 def test_qr_pair_listener_and_manager(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_manager_device_coverage.py
+++ b/tests/test_manager_device_coverage.py
@@ -71,6 +71,59 @@ class FakeAgent:
         }
 
 
+class FakePhoneAgentManager:
+    def __init__(self, agent: Any) -> None:
+        self.agent = agent
+        self.acquired: list[tuple[str, str | None]] = []
+        self.released: list[tuple[str, str | None]] = []
+        self.registered: list[tuple[str, str | None]] = []
+        self.unregistered: list[tuple[str, str | None]] = []
+        self.errors: list[tuple[str, str, str | None]] = []
+
+    async def acquire_device_async(
+        self,
+        device_id: str,
+        *,
+        auto_initialize: bool = False,
+        context: str | None = None,
+    ) -> bool:
+        self.acquired.append((device_id, context))
+        return True
+
+    def get_agent_with_context(self, device_id: str, **kwargs):
+        return self.agent
+
+    def register_abort_handler(self, device_id: str, handler, context=None) -> None:
+        self.registered.append((device_id, context))
+
+    def unregister_abort_handler(self, device_id: str, context=None) -> None:
+        self.unregistered.append((device_id, context))
+
+    def set_error_state(self, device_id: str, message: str, context=None) -> None:
+        self.errors.append((device_id, message, context))
+
+    def release_device(self, device_id: str, context=None) -> None:
+        self.released.append((device_id, context))
+
+
+def _patch_task_tracing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(trace_module, "create_trace_id", lambda: "trace-test")
+    monkeypatch.setattr(trace_module, "write_replay_task_start", lambda **kwargs: None)
+    monkeypatch.setattr(trace_module, "write_replay_event", lambda **kwargs: None)
+    monkeypatch.setattr(
+        trace_module,
+        "get_step_timing_summary",
+        lambda step, trace_id=None: {"step": step},
+    )
+    monkeypatch.setattr(trace_module, "list_step_timing_summaries", lambda trace_id: [])
+    monkeypatch.setattr(trace_module, "get_trace_timing_summary", lambda **kwargs: None)
+    monkeypatch.setattr(trace_module, "clear_trace_data", lambda trace_id: None)
+    monkeypatch.setattr(
+        "AutoGLM_GUI.task_manager.record_trace_latency_metrics",
+        lambda **kwargs: None,
+    )
+
+
 def test_phone_agent_manager_lifecycle_state_and_abort(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -359,6 +412,195 @@ def test_task_manager_queue_cancel_worker_and_layered(
     asyncio.run(manager._execute_scheduled_layered_workflow(layered_task))
     assert store.get_task(layered_task["id"])["status"] == TaskStatus.SUCCEEDED.value
     assert reset_calls == [layered_task["id"]]
+    store.close()
+
+
+def test_task_manager_classic_chat_execution_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_task_tracing(monkeypatch)
+    store = TaskStore(tmp_path / "classic.db")
+    manager = TaskManager(store)
+    monkeypatch.setattr(manager, "_ensure_worker", lambda device_id: None)
+
+    fake_agent = FakeAgent()
+    fake_phone_manager = FakePhoneAgentManager(fake_agent)
+    monkeypatch.setattr(
+        PhoneAgentManager,
+        "get_instance",
+        classmethod(lambda cls: fake_phone_manager),
+    )
+
+    session = asyncio.run(
+        manager.create_chat_session(
+            device_id="device-1", device_serial="serial-1", mode="classic"
+        )
+    )
+    queued_task = asyncio.run(
+        manager.submit_chat_task(
+            session_id=session["id"],
+            device_id="device-1",
+            device_serial="serial-1",
+            message="classic task",
+            attachments=[
+                {"mime_type": "image/png", "data": "image"},
+                {"mime_type": 123, "data": "ignored"},
+            ],
+        )
+    )
+    task = store.get_task(queued_task["id"])
+    assert task is not None
+
+    asyncio.run(manager._execute_classic_chat(task))
+
+    completed = store.get_task(task["id"])
+    assert completed is not None
+    assert completed["status"] == TaskStatus.SUCCEEDED.value
+    assert completed["final_message"] == "done classic task"
+    assert completed["step_count"] == 1
+    assert fake_agent.attachments == [{"mime_type": "image/png", "data": "image"}]
+    assert fake_phone_manager.released == [("device-1", f"chat:{session['id']}")]
+    assert fake_phone_manager.unregistered == [("device-1", f"chat:{session['id']}")]
+    event_types = [event["event_type"] for event in store.list_task_events(task["id"])]
+    assert "thinking" in event_types
+    assert "step" in event_types
+    assert "done" in event_types
+
+    no_attachment_agent = SimpleNamespace(cancel=lambda: None)
+
+    async def unused_stream(text: str):
+        raise AssertionError("stream should not run")
+        yield {}
+
+    no_attachment_agent.stream = unused_stream
+    fake_phone_manager.agent = no_attachment_agent
+    unsupported = asyncio.run(
+        manager.submit_chat_task(
+            session_id=session["id"],
+            device_id="device-1",
+            device_serial="serial-1",
+            message="with image",
+            attachments=[{"mime_type": "image/png", "data": "image"}],
+        )
+    )
+    unsupported_task = store.get_task(unsupported["id"])
+    assert unsupported_task is not None
+
+    asyncio.run(manager._execute_classic_chat(unsupported_task))
+
+    failed = store.get_task(unsupported["id"])
+    assert failed is not None
+    assert failed["status"] == TaskStatus.FAILED.value
+    assert failed["stop_reason"] == "unsupported_image_attachments"
+    assert fake_phone_manager.errors[-1][1] == (
+        "Current agent does not support user image attachments"
+    )
+    store.close()
+
+
+def test_task_manager_scheduled_workflow_success_cancel_and_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_task_tracing(monkeypatch)
+    store = TaskStore(tmp_path / "scheduled.db")
+    manager = TaskManager(store)
+    monkeypatch.setattr(manager, "_ensure_worker", lambda device_id: None)
+
+    fake_agent = FakeAgent()
+    fake_phone_manager = FakePhoneAgentManager(fake_agent)
+    monkeypatch.setattr(
+        PhoneAgentManager,
+        "get_instance",
+        classmethod(lambda cls: fake_phone_manager),
+    )
+
+    scheduled = asyncio.run(
+        manager.enqueue_scheduled_task(
+            scheduled_task_id="sched-1",
+            workflow_uuid="workflow-1",
+            schedule_fire_id="fire-1",
+            device_id="device-1",
+            device_serial="serial-1",
+            input_text="scheduled task",
+        )
+    )
+    task = store.get_task(scheduled["id"])
+    assert task is not None
+
+    asyncio.run(manager._execute_scheduled_workflow(task))
+
+    completed = store.get_task(task["id"])
+    assert completed is not None
+    assert completed["status"] == TaskStatus.SUCCEEDED.value
+    assert completed["final_message"] == "done scheduled task"
+    assert fake_agent.reset_count == 1
+    assert fake_phone_manager.released == [("device-1", "scheduled")]
+
+    cancel_task = store.create_task_run(
+        source="scheduled",
+        executor_key="scheduled_workflow",
+        device_id="device-1",
+        device_serial="serial-1",
+        input_text="cancel me",
+    )
+    manager._cancel_requested.add(cancel_task["id"])
+    asyncio.run(manager._execute_scheduled_workflow(cancel_task))
+    cancelled = store.get_task(cancel_task["id"])
+    assert cancelled is not None
+    assert cancelled["status"] == TaskStatus.CANCELLED.value
+    assert cancelled["stop_reason"] == "user_stopped"
+
+    class BusyManager(FakePhoneAgentManager):
+        async def acquire_device_async(self, *args, **kwargs) -> bool:
+            raise DeviceBusyError("busy")
+
+    busy_manager = BusyManager(fake_agent)
+    monkeypatch.setattr(
+        PhoneAgentManager,
+        "get_instance",
+        classmethod(lambda cls: busy_manager),
+    )
+    busy_task = store.create_task_run(
+        source="scheduled",
+        executor_key="scheduled_workflow",
+        device_id="device-busy",
+        device_serial="serial-busy",
+        input_text="busy",
+    )
+    asyncio.run(manager._execute_scheduled_workflow(busy_task))
+    busy = store.get_task(busy_task["id"])
+    assert busy is not None
+    assert busy["status"] == TaskStatus.FAILED.value
+    assert busy["stop_reason"] == "device_busy"
+    assert busy_manager.errors[-1] == (
+        "device-busy",
+        "Device device-busy is busy. Please wait.",
+        "scheduled",
+    )
+
+    class InitErrorManager(FakePhoneAgentManager):
+        def get_agent_with_context(self, device_id: str, **kwargs):
+            raise AgentInitializationError("missing config")
+
+    init_manager = InitErrorManager(fake_agent)
+    monkeypatch.setattr(
+        PhoneAgentManager,
+        "get_instance",
+        classmethod(lambda cls: init_manager),
+    )
+    init_task = store.create_task_run(
+        source="scheduled",
+        executor_key="scheduled_workflow",
+        device_id="device-init",
+        device_serial="serial-init",
+        input_text="init",
+    )
+    asyncio.run(manager._execute_scheduled_workflow(init_task))
+    init_failed = store.get_task(init_task["id"])
+    assert init_failed is not None
+    assert init_failed["status"] == TaskStatus.FAILED.value
+    assert init_failed["stop_reason"] == "initialization_failed"
+    assert "missing config" in init_failed["final_message"]
     store.close()
 
 

--- a/tests/test_manager_device_coverage.py
+++ b/tests/test_manager_device_coverage.py
@@ -1,0 +1,554 @@
+"""Coverage for managers and device implementations."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import stat
+import threading
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import AutoGLM_GUI.adb_manager as adb_manager
+import AutoGLM_GUI.agents as agents_module
+import AutoGLM_GUI.agents.factory as factory
+import AutoGLM_GUI.config_manager as config_manager_module
+import AutoGLM_GUI.device_manager as device_manager_module
+import AutoGLM_GUI.layered_agent_service as layered_agent_service
+import AutoGLM_GUI.trace as trace_module
+from AutoGLM_GUI.config import AgentConfig, ModelConfig
+from AutoGLM_GUI.devices.mock_device import MockDevice, MockDeviceManager
+from AutoGLM_GUI.devices.remote_device import RemoteDevice, RemoteDeviceManager
+from AutoGLM_GUI.exceptions import (
+    AgentInitializationError,
+    AgentNotInitializedError,
+    DeviceBusyError,
+)
+from AutoGLM_GUI.phone_agent_manager import (
+    AgentMetadata,
+    AgentState,
+    PhoneAgentManager,
+)
+from AutoGLM_GUI.task_manager import TaskManager
+from AutoGLM_GUI.task_store import TaskStatus, TaskStore
+
+
+class FakeAgent:
+    def __init__(self) -> None:
+        self.reset_count = 0
+        self.cancel_count = 0
+        self.attachments: list[dict[str, Any]] = []
+
+    def reset(self) -> None:
+        self.reset_count += 1
+
+    async def cancel(self) -> None:
+        self.cancel_count += 1
+
+    def set_user_image_attachments(self, attachments: list[dict[str, Any]]) -> None:
+        self.attachments = attachments
+
+    async def stream(self, text: str):
+        yield {
+            "type": "thinking",
+            "data": {"chunk": "thinking"},
+        }
+        yield {
+            "type": "step",
+            "data": {"step": 1, "thinking": "think", "action": {"action": "Tap"}},
+        }
+        yield {
+            "type": "done",
+            "data": {
+                "message": f"done {text}",
+                "success": True,
+                "steps": 1,
+            },
+        }
+
+
+def test_phone_agent_manager_lifecycle_state_and_abort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = PhoneAgentManager()
+    fake_agent = FakeAgent()
+
+    class FakeDeviceManager:
+        refreshed = False
+
+        def get_device_protocol(self, device_id: str):
+            return SimpleNamespace(device_id=device_id)
+
+        def force_refresh(self) -> None:
+            self.refreshed = True
+
+    monkeypatch.setattr(
+        device_manager_module.DeviceManager,
+        "get_instance",
+        classmethod(lambda cls: FakeDeviceManager()),
+    )
+    monkeypatch.setattr(
+        agents_module,
+        "create_agent",
+        lambda **kwargs: fake_agent,
+    )
+
+    created = manager.initialize_agent_with_factory(
+        "device-1",
+        "custom",
+        ModelConfig(),
+        AgentConfig(device_id="actual-1"),
+        {},
+    )
+    assert created is fake_agent
+    assert (
+        manager.initialize_agent_with_factory(
+            "device-1",
+            "custom",
+            ModelConfig(),
+            AgentConfig(device_id="actual-1"),
+            {},
+        )
+        is fake_agent
+    )
+    assert manager.is_initialized("device-1")
+    assert manager.get_agent("device-1") is fake_agent
+    assert manager.get_agent_safe("device-1") is fake_agent
+    assert manager.get_config("device-1")[0].model_name == "autoglm-phone-9b"
+    assert manager.list_agents() == ["device-1"]
+
+    manager.reset_agent("device-1")
+    assert fake_agent.reset_count == 1
+    assert manager.acquire_device("device-1")
+    assert manager.get_state("device-1") == AgentState.BUSY
+    assert manager.acquire_device("device-1", raise_on_timeout=False) is False
+    with pytest.raises(DeviceBusyError):
+        manager.acquire_device("device-1")
+    manager.release_device("device-1")
+    assert manager.get_state("device-1") == AgentState.IDLE
+
+    with manager.use_agent("device-1", auto_initialize=False) as used:
+        assert used is fake_agent
+    assert manager.get_state("device-1") == AgentState.IDLE
+
+    event = threading.Event()
+    manager.register_abort_handler("device-1", event)
+    assert manager.is_streaming_active("device-1")
+    assert asyncio.run(manager.abort_streaming_chat_async("device-1")) is True
+    assert event.is_set()
+    manager.unregister_abort_handler("device-1")
+    assert not manager.is_streaming_active("device-1")
+
+    called: list[str] = []
+    manager.register_abort_handler("device-1", lambda: called.append("sync"))
+    assert asyncio.run(manager.abort_streaming_chat_async("device-1")) is True
+    assert called == ["sync"]
+
+    async_called: list[str] = []
+
+    async def async_abort() -> None:
+        async_called.append("async")
+
+    manager.register_abort_handler("device-1", async_abort)
+    assert asyncio.run(manager.abort_streaming_chat_async("device-1")) is True
+    assert async_called == ["async"]
+
+    manager.set_error_state("device-1", "boom")
+    assert manager.get_metadata("device-1").error_message == "boom"
+    assert manager.get_metadata_for_device("device-1").state == AgentState.ERROR
+    assert manager.abort_streaming_chat_async
+
+    manager.destroy_agent("device-1")
+    assert not manager.is_initialized("device-1")
+    with pytest.raises(AgentNotInitializedError):
+        manager.reset_agent("device-1")
+    with pytest.raises(AgentNotInitializedError):
+        manager.get_config("device-1")
+
+
+def test_phone_agent_manager_auto_init_errors_and_destroy_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = PhoneAgentManager()
+
+    with pytest.raises(AgentInitializationError, match="device_id"):
+        manager.initialize_agent_with_factory(
+            "device-1", "custom", ModelConfig(), AgentConfig(), {}
+        )
+
+    class MissingDeviceManager:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def get_device_protocol(self, device_id: str):
+            self.calls += 1
+            if self.calls == 1:
+                raise ValueError("missing")
+            return SimpleNamespace(device_id=device_id)
+
+        def force_refresh(self) -> None:
+            self.refreshed = True
+
+    monkeypatch.setattr(
+        device_manager_module.DeviceManager,
+        "get_instance",
+        classmethod(lambda cls: MissingDeviceManager()),
+    )
+    monkeypatch.setattr(agents_module, "create_agent", lambda **kwargs: FakeAgent())
+    agent = manager.initialize_agent_with_factory(
+        "device-2", "custom", ModelConfig(), AgentConfig(device_id="actual-2"), {}
+    )
+    assert isinstance(agent, FakeAgent)
+
+    class EffectiveConfig:
+        base_url = ""
+        api_key = "EMPTY"
+        model_name = "m"
+        agent_type = "custom"
+        agent_config_params = {}
+
+    fake_config = SimpleNamespace(
+        load_file_config=lambda: None,
+        sync_to_env=lambda: None,
+        get_effective_config=lambda: EffectiveConfig(),
+    )
+    monkeypatch.setattr(config_manager_module, "config_manager", fake_config)
+    with pytest.raises(AgentInitializationError, match="base_url"):
+        manager.get_agent_with_context("device-3", context="chat:s1")
+
+    manager._agents["bad"] = SimpleNamespace(
+        reset=lambda: (_ for _ in ()).throw(RuntimeError("reset"))
+    )
+    manager._metadata["bad"] = AgentMetadata(
+        device_id="bad",
+        state=AgentState.IDLE,
+        model_config=ModelConfig(),
+        agent_config=AgentConfig(),
+    )
+    assert manager.destroy_all_agents() >= 1
+
+
+def test_task_manager_queue_cancel_worker_and_layered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = TaskStore(tmp_path / "tasks.db")
+    manager = TaskManager(store)
+    ensured: list[str] = []
+    monkeypatch.setattr(
+        manager, "_ensure_worker", lambda device_id: ensured.append(device_id)
+    )
+
+    running = store.create_task_run(
+        source="chat",
+        executor_key="classic_chat",
+        device_id="device-1",
+        device_serial="serial-1",
+        input_text="running",
+        status=TaskStatus.RUNNING.value,
+    )
+    queued = store.create_task_run(
+        source="chat",
+        executor_key="classic_chat",
+        device_id="device-2",
+        device_serial="serial-2",
+        input_text="queued",
+    )
+    asyncio.run(manager.start())
+    assert store.get_task(running["id"])["status"] == TaskStatus.INTERRUPTED.value
+
+    session = asyncio.run(
+        manager.create_chat_session(
+            device_id="device-1", device_serial="serial-1", mode="classic"
+        )
+    )
+    submitted = asyncio.run(
+        manager.submit_chat_task(
+            session_id=session["id"],
+            device_id="device-1",
+            device_serial="serial-1",
+            message="hello",
+            attachments=[
+                {"mime_type": "image/png", "data": "abc"},
+                {"mime_type": 1, "data": "bad"},
+            ],
+        )
+    )
+    assert ensured[-1] == "device-1"
+    assert manager._get_task_user_image_attachments(submitted["id"]) == [
+        {"mime_type": "image/png", "data": "abc"}
+    ]
+    assert asyncio.run(manager.get_session(session["id"]))["id"] == session["id"]
+    assert (
+        asyncio.run(
+            manager.get_or_create_legacy_chat_session(
+                device_id="device-1", device_serial="serial-1", mode="classic"
+            )
+        )["id"]
+        == session["id"]
+    )
+    assert asyncio.run(manager.archive_session("missing")) is None
+
+    cancelled = asyncio.run(manager.cancel_task(queued["id"]))
+    assert cancelled["status"] == TaskStatus.CANCELLED.value
+    assert asyncio.run(manager.cancel_task("missing")) is None
+    assert asyncio.run(manager.wait_for_task("missing")) is None
+
+    abort_called: list[str] = []
+    running_task = store.create_task_run(
+        source="chat",
+        executor_key="classic_chat",
+        device_id="device-1",
+        device_serial="serial-1",
+        input_text="running",
+        status=TaskStatus.RUNNING.value,
+    )
+    manager._abort_handlers[running_task["id"]] = lambda: abort_called.append("abort")
+    asyncio.run(manager.cancel_task(running_task["id"]))
+    assert abort_called == ["abort"]
+
+    unsupported = store.create_task_run(
+        source="chat",
+        executor_key="missing",
+        device_id="device-9",
+        device_serial="serial-9",
+        input_text="bad",
+    )
+    monkeypatch.setattr(manager, "_ensure_worker", lambda device_id: None)
+    asyncio.run(manager._device_worker("device-9"))
+    assert store.get_task(unsupported["id"])["status"] == TaskStatus.FAILED.value
+
+    class FakeLayeredRun:
+        final_output = ""
+
+        def cancel(self) -> None:
+            self.cancelled = True
+
+        async def stream_events(self):
+            yield {"type": "tool_result", "payload": {"steps": 2}}
+            yield {
+                "type": "done",
+                "payload": {"content": "layered done", "success": True},
+            }
+
+    reset_calls: list[str] = []
+    monkeypatch.setattr(
+        layered_agent_service, "start_run", lambda **kwargs: FakeLayeredRun()
+    )
+    monkeypatch.setattr(
+        layered_agent_service,
+        "reset_session",
+        lambda session_id: reset_calls.append(session_id),
+    )
+    monkeypatch.setattr(trace_module, "write_replay_task_start", lambda **kwargs: None)
+    monkeypatch.setattr(trace_module, "write_replay_event", lambda **kwargs: None)
+    monkeypatch.setattr(trace_module, "list_step_timing_summaries", lambda trace_id: [])
+    monkeypatch.setattr(trace_module, "get_trace_timing_summary", lambda **kwargs: None)
+    monkeypatch.setattr(trace_module, "clear_trace_data", lambda trace_id: None)
+
+    layered_task = store.create_task_run(
+        source="scheduled",
+        executor_key="scheduled_layered_workflow",
+        device_id="device-1",
+        device_serial="serial-1",
+        input_text="layered",
+    )
+    asyncio.run(manager._execute_scheduled_layered_workflow(layered_task))
+    assert store.get_task(layered_task["id"])["status"] == TaskStatus.SUCCEEDED.value
+    assert reset_calls == [layered_task["id"]]
+    store.close()
+
+
+def test_mock_and_remote_devices() -> None:
+    class StateMachine:
+        def __init__(self) -> None:
+            self.current_state = SimpleNamespace(current_app="app")
+            self.taps: list[tuple[int, int]] = []
+            self.swipes: list[tuple[int, int, int, int]] = []
+
+        def get_current_screenshot(self):
+            return SimpleNamespace(base64_data="img", width=10, height=20)
+
+        def handle_tap(self, x: int, y: int) -> None:
+            self.taps.append((x, y))
+
+        def handle_swipe(self, sx: int, sy: int, ex: int, ey: int) -> None:
+            self.swipes.append((sx, sy, ex, ey))
+
+    sm = StateMachine()
+    mock = MockDevice("mock-1", sm)
+    assert mock.device_id == "mock-1"
+    assert mock.state_machine is sm
+    assert mock.get_screenshot().width == 10
+    mock.tap(1, 2)
+    mock.double_tap(3, 4)
+    mock.long_press(5, 6)
+    mock.swipe(1, 2, 3, 4)
+    mock.type_text("x")
+    mock.clear_text()
+    mock.back()
+    mock.home()
+    assert mock.launch_app("app")
+    assert mock.get_current_app() == "app"
+    assert mock.detect_and_set_adb_keyboard() == "com.mock.keyboard"
+    mock.restore_keyboard("ime")
+    assert sm.taps == [(1, 2), (3, 4), (5, 6)]
+    assert sm.swipes == [(1, 2, 3, 4)]
+
+    mock_manager = MockDeviceManager(sm, "mock-1")
+    assert mock_manager.list_devices()[0].model == "MockPhone"
+    assert mock_manager.get_device("mock-1").device_id == "mock-1"
+    with pytest.raises(KeyError):
+        mock_manager.get_device("missing")
+    assert mock_manager.connect("addr")[0]
+    assert mock_manager.disconnect("mock-1")[0]
+
+    class FakeResponse:
+        status_code = 200
+
+        def __init__(self, payload: Any) -> None:
+            self.payload = payload
+
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self):
+            return self.payload
+
+    class FakeClient:
+        def __init__(self, timeout: float = 30.0) -> None:
+            self.calls: list[tuple[str, str, Any]] = []
+            self.closed = False
+
+        def post(self, url: str, json=None):
+            self.calls.append(("post", url, json))
+            if url.endswith("/screenshot"):
+                return FakeResponse({"base64_data": "img", "width": 1, "height": 2})
+            if url.endswith("/launch_app"):
+                return FakeResponse({"success": False})
+            if url.endswith("/connect"):
+                return FakeResponse({"success": True, "message": "connected"})
+            if url.endswith("/disconnect"):
+                return FakeResponse({"success": True, "message": "disconnected"})
+            if url.endswith("/detect_keyboard"):
+                return FakeResponse({"original_ime": "ime"})
+            return FakeResponse({})
+
+        def get(self, url: str):
+            self.calls.append(("get", url, None))
+            if url.endswith("/devices"):
+                return FakeResponse(
+                    [
+                        {
+                            "device_id": "dev",
+                            "status": "online",
+                            "model": "Phone",
+                        }
+                    ]
+                )
+            return FakeResponse({"app_name": "app"})
+
+        def close(self) -> None:
+            self.closed = True
+
+    import AutoGLM_GUI.devices.remote_device as remote_module
+
+    remote_module.httpx.Client = FakeClient
+    remote = RemoteDevice("dev", "http://server/")
+    assert remote.device_id == "dev"
+    assert remote.get_screenshot().height == 2
+    remote.tap(1, 2)
+    remote.double_tap(1, 2)
+    remote.long_press(1, 2)
+    remote.swipe(1, 2, 3, 4)
+    remote.type_text("hi")
+    remote.clear_text()
+    remote.back()
+    remote.home()
+    assert remote.launch_app("Missing") is False
+    assert remote.get_current_app() == "app"
+    assert remote.detect_and_set_adb_keyboard() == "ime"
+    remote.restore_keyboard("ime")
+    with remote:
+        pass
+    assert remote._client.closed
+
+    remote_manager = RemoteDeviceManager("http://server/")
+    assert remote_manager.list_devices()[0].device_id == "dev"
+    assert remote_manager.get_device("dev") is remote_manager.get_device("dev")
+    assert remote_manager.connect("addr") == (True, "connected")
+    assert remote_manager.disconnect("dev") == (True, "disconnected")
+    remote_manager.close()
+
+
+def test_agent_factory_and_adb_manager(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    original_registry = factory.AGENT_REGISTRY.copy()
+    try:
+        factory.AGENT_REGISTRY.clear()
+        factory.register_agent("custom", lambda **kwargs: "agent")
+        factory.register_agent("custom", lambda **kwargs: "agent2")
+        assert factory.list_agent_types() == ["custom"]
+        assert factory.is_agent_type_registered("custom")
+        assert (
+            factory.create_agent(
+                "custom",
+                ModelConfig(),
+                AgentConfig(),
+                {},
+                SimpleNamespace(),
+            )
+            == "agent2"
+        )
+        with pytest.raises(ValueError, match="Unknown agent type"):
+            factory.create_agent(
+                "missing", ModelConfig(), AgentConfig(), {}, SimpleNamespace()
+            )
+
+        def bad_creator(**kwargs):
+            raise RuntimeError("bad")
+
+        factory.register_agent("bad", bad_creator)
+        with pytest.raises(RuntimeError, match="bad"):
+            factory.create_agent(
+                "bad", ModelConfig(), AgentConfig(), {}, SimpleNamespace()
+            )
+    finally:
+        factory.AGENT_REGISTRY.clear()
+        factory.AGENT_REGISTRY.update(original_registry)
+
+    monkeypatch.setattr(adb_manager.shutil, "which", lambda name: "/usr/bin/adb")
+    assert adb_manager.ensure_adb() == "/usr/bin/adb"
+
+    platform_tools = tmp_path / "platform-tools"
+    cached_adb = platform_tools / "adb"
+    cached_adb.parent.mkdir()
+    cached_adb.write_text("adb", encoding="utf-8")
+    monkeypatch.setattr(adb_manager.shutil, "which", lambda name: None)
+    monkeypatch.setattr(adb_manager, "_PLATFORM_TOOLS_DIR", platform_tools)
+    monkeypatch.setattr(adb_manager, "_ADB_BINARY", "adb")
+    assert adb_manager.ensure_adb() == str(cached_adb)
+
+    cached_adb.unlink()
+    data = io.BytesIO()
+    with zipfile.ZipFile(data, "w") as zf:
+        zf.writestr("platform-tools/adb", "adb")
+    monkeypatch.setattr(
+        adb_manager, "_download_with_progress", lambda url: data.getvalue()
+    )
+    monkeypatch.setattr(adb_manager, "_platform_name", lambda: "linux")
+    assert adb_manager.ensure_adb() == str(cached_adb)
+    assert cached_adb.stat().st_mode & stat.S_IXUSR
+
+    monkeypatch.setattr(
+        adb_manager,
+        "_download_with_progress",
+        lambda url: (_ for _ in ()).throw(RuntimeError("net")),
+    )
+    cached_adb.unlink()
+    with pytest.raises(RuntimeError, match="Failed to download"):
+        adb_manager.ensure_adb()

--- a/tests/test_qr_pairing.py
+++ b/tests/test_qr_pairing.py
@@ -1,0 +1,309 @@
+"""Unit tests for QR-based wireless ADB pairing."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from typing import Any
+
+import pytest
+
+import AutoGLM_GUI.adb_plus.qr_pair as qr_pair
+
+
+def _session(**kwargs: Any) -> qr_pair.PairingSession:
+    defaults = {
+        "session_id": "sid",
+        "name": "debug-name",
+        "password": "password",
+        "qr_payload": "payload",
+        "status": "listening",
+        "expires_at": 9999999999.0,
+    }
+    defaults.update(kwargs)
+    return qr_pair.PairingSession(**defaults)
+
+
+def _completed(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["adb"], returncode=returncode, stdout=stdout
+    )
+
+
+def test_pick_host_falls_back_and_handles_errors() -> None:
+    class RaisingInfo:
+        server = ""
+
+        def parsed_addresses(self) -> list[str]:
+            raise RuntimeError("bad addresses")
+
+    assert qr_pair._pick_host_from_info(RaisingInfo()) is None
+
+    class HostOnlyInfo:
+        server = "device.local."
+
+        def parsed_addresses(self) -> list[str]:
+            raise RuntimeError("bad addresses")
+
+    assert qr_pair._pick_host_from_info(HostOnlyInfo()) == "device.local"
+
+
+def test_adb_pair_and_connect_failure_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[list[str], int]] = []
+
+    def fake_run(cmd: list[str], timeout: int) -> subprocess.CompletedProcess[str]:
+        calls.append((cmd, timeout))
+        return _completed("failure", returncode=1)
+
+    monkeypatch.setattr(qr_pair, "run_cmd_silently_sync", fake_run)
+
+    assert qr_pair._adb_pair("1.2.3.4", 1234, "pass", "adbx") is False
+    assert qr_pair._adb_connect("1.2.3.4", 5555, "adbx") is False
+    assert calls == [
+        (["adbx", "pair", "1.2.3.4:1234", "pass"], 25),
+        (["adbx", "connect", "1.2.3.4:5555"], 20),
+    ]
+
+
+def test_listener_ignores_invalid_services(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _session()
+    listener = qr_pair.QRPairingListener(session, "adb")
+
+    class FakeZeroconf:
+        def __init__(self, info: Any) -> None:
+            self.info = info
+
+        def get_service_info(self, type_: str, name: str, timeout: int = 3000) -> Any:
+            return self.info
+
+    class NoHostInfo:
+        port = 1234
+        server = ""
+
+        def parsed_addresses(self) -> list[str]:
+            return []
+
+    class NoPortInfo:
+        port = None
+        server = "host.local."
+
+        def parsed_addresses(self) -> list[str]:
+            return []
+
+    listener.add_service(FakeZeroconf(None), qr_pair.PAIR_SERVICE_TYPE, "missing")
+    listener.add_service(
+        FakeZeroconf(NoHostInfo()), qr_pair.PAIR_SERVICE_TYPE, "nohost"
+    )
+    listener.add_service(
+        FakeZeroconf(NoPortInfo()), qr_pair.PAIR_SERVICE_TYPE, "noport"
+    )
+
+    assert session.status == "listening"
+    assert listener.attempted_pair == set()
+
+
+def test_listener_pair_and_connect_negative_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeInfo:
+        def __init__(self, host: str, port: int = 1234) -> None:
+            self.host = host
+            self.port = port
+            self.server = ""
+
+        def parsed_addresses(self) -> list[str]:
+            return [self.host]
+
+    class FakeZeroconf:
+        def __init__(self, info: FakeInfo) -> None:
+            self.info = info
+
+        def get_service_info(
+            self, type_: str, name: str, timeout: int = 3000
+        ) -> FakeInfo:
+            return self.info
+
+    pair_attempts: list[tuple[str, int, str, str]] = []
+    connect_attempts: list[tuple[str, int, str]] = []
+
+    def fake_pair(host: str, port: int, password: str, adb_path: str) -> bool:
+        pair_attempts.append((host, port, password, adb_path))
+        return False
+
+    def fake_connect(host: str, port: int, adb_path: str) -> bool:
+        connect_attempts.append((host, port, adb_path))
+        return False
+
+    monkeypatch.setattr(qr_pair, "_adb_pair", fake_pair)
+    monkeypatch.setattr(qr_pair, "_adb_connect", fake_connect)
+
+    session = _session()
+    listener = qr_pair.QRPairingListener(session, "adbx")
+    zc = FakeZeroconf(FakeInfo("192.168.1.2"))
+
+    listener.add_service(zc, qr_pair.PAIR_SERVICE_TYPE, "pair")
+    listener.add_service(zc, qr_pair.PAIR_SERVICE_TYPE, "pair")
+
+    assert pair_attempts == [("192.168.1.2", 1234, "password", "adbx")]
+    assert listener.paired is False
+    assert session.status == "pairing"
+
+    listener.paired = True
+    listener.last_paired_host = "192.168.1.99"
+    listener.add_service(zc, qr_pair.CONNECT_SERVICE_TYPE, "connect-other-host")
+    assert connect_attempts == []
+
+    listener.last_paired_host = "192.168.1.2"
+    listener.add_service(zc, qr_pair.CONNECT_SERVICE_TYPE, "connect")
+    listener.add_service(zc, qr_pair.CONNECT_SERVICE_TYPE, "connect")
+
+    assert connect_attempts == [("192.168.1.2", 1234, "adbx")]
+    assert listener.connected is False
+    assert session.status == "connecting"
+
+
+def test_manager_create_session_builds_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = qr_pair.QRPairingManager()
+    started: list[tuple[qr_pair.PairingSession, str]] = []
+
+    monkeypatch.setattr(qr_pair.uuid, "uuid4", lambda: "session-id")
+    monkeypatch.setattr(qr_pair.secrets, "token_hex", lambda n: f"hex{n}")
+    monkeypatch.setattr(
+        manager,
+        "_start_listener",
+        lambda session, adb_path: started.append((session, adb_path)),
+    )
+
+    session = manager.create_session(timeout=30, adb_path="adbx")
+
+    assert session.session_id == "session-id"
+    assert session.name == "debug-hex4"
+    assert session.password == "hex8"
+    assert session.qr_payload == "WIFI:T:ADB;S:debug-hex4;P:hex8;;"
+    assert session.status == "listening"
+    assert session.expires_at - session.created_at == 30
+    assert manager.get_session("session-id") is session
+    assert started == [(session, "adbx")]
+
+
+def test_start_listener_handles_connected_timeout_and_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeThread:
+        def __init__(self, target, name: str, daemon: bool) -> None:
+            self.target = target
+            self.name = name
+            self.daemon = daemon
+            self.started = False
+
+        def start(self) -> None:
+            self.started = True
+            self.target()
+
+        def is_alive(self) -> bool:
+            return False
+
+    class FakeZeroconf:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    def fake_browser(zc: FakeZeroconf, type_: str, listener: Any) -> None:
+        if type_ == qr_pair.CONNECT_SERVICE_TYPE:
+            listener.connected = True
+
+    monkeypatch.setattr(qr_pair.threading, "Thread", FakeThread)
+    monkeypatch.setattr(qr_pair, "Zeroconf", FakeZeroconf)
+    monkeypatch.setattr(qr_pair, "ServiceBrowser", fake_browser)
+
+    connected_session = _session(session_id="connected")
+    qr_pair.QRPairingManager()._start_listener(connected_session, "adb")
+    assert connected_session.thread.started is True
+    assert connected_session.status == "listening"
+    assert connected_session.zeroconf.closed is True
+
+    def passive_browser(zc: FakeZeroconf, type_: str, listener: Any) -> None:
+        return None
+
+    monkeypatch.setattr(qr_pair, "ServiceBrowser", passive_browser)
+    timeout_session = _session(session_id="timeout", expires_at=0)
+    qr_pair.QRPairingManager()._start_listener(timeout_session, "adb")
+    assert timeout_session.status == "timeout"
+
+    class BrokenZeroconf:
+        def __init__(self) -> None:
+            raise RuntimeError("zeroconf failed")
+
+    monkeypatch.setattr(qr_pair, "Zeroconf", BrokenZeroconf)
+    error_session = _session(session_id="error")
+    qr_pair.QRPairingManager()._start_listener(error_session, "adb")
+    assert error_session.status == "error"
+    assert error_session.error_message == "zeroconf failed"
+
+    class ClosingZeroconf(FakeZeroconf):
+        def close(self) -> None:
+            raise RuntimeError("close failed")
+
+    monkeypatch.setattr(qr_pair, "Zeroconf", ClosingZeroconf)
+    close_error_session = _session(session_id="close-error", expires_at=0)
+    qr_pair.QRPairingManager()._start_listener(close_error_session, "adb")
+    assert close_error_session.status == "timeout"
+
+
+def test_cancel_session_handles_close_errors_and_alive_threads() -> None:
+    manager = qr_pair.QRPairingManager()
+
+    class BrokenZeroconf:
+        def close(self) -> None:
+            raise RuntimeError("close failed")
+
+    class AliveThread:
+        def __init__(self) -> None:
+            self.joined_with: float | None = None
+            self.checks = 0
+
+        def is_alive(self) -> bool:
+            self.checks += 1
+            return True
+
+        def join(self, timeout: float) -> None:
+            self.joined_with = timeout
+
+    thread = AliveThread()
+    session = _session(zeroconf=BrokenZeroconf(), thread=thread)
+    manager._sessions["sid"] = session
+
+    assert manager.cancel_session("sid") is True
+    assert thread.joined_with == 2.0
+    assert thread.checks == 2
+
+
+@pytest.mark.anyio
+async def test_cleanup_expired_sessions_cancels_expired_then_propagates_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = qr_pair.QRPairingManager()
+    manager._sessions["expired"] = _session(session_id="expired", expires_at=0)
+    manager._sessions["active"] = _session(session_id="active", expires_at=9999999999)
+    cancelled: list[str] = []
+    sleeps = 0
+
+    async def fake_sleep(seconds: int) -> None:
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps > 1:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(qr_pair.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(
+        manager,
+        "cancel_session",
+        lambda session_id: cancelled.append(session_id) or True,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await manager.cleanup_expired_sessions()
+
+    assert cancelled == ["expired"]

--- a/tests/test_scrcpy_stream_edges.py
+++ b/tests/test_scrcpy_stream_edges.py
@@ -1,0 +1,289 @@
+"""Focused edge coverage for scrcpy stream lifecycle and parsing."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import AutoGLM_GUI.scrcpy_stream as scrcpy_stream
+from AutoGLM_GUI.scrcpy_protocol import (
+    SCRCPY_CODEC_H264,
+    ScrcpyMediaStreamPacket,
+    ScrcpyVideoStreamMetadata,
+    ScrcpyVideoStreamOptions,
+)
+from AutoGLM_GUI.scrcpy_stream import ScrcpyStreamer
+
+
+@pytest.fixture
+def fake_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ScrcpyStreamer, "_find_scrcpy_server", lambda self: "/server")
+
+
+def test_find_scrcpy_server_sources(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    instance = object.__new__(ScrcpyStreamer)
+    instance.tcp_socket = None
+    instance.scrcpy_process = None
+    instance.forward_cleanup_needed = False
+
+    bundled = tmp_path / "AutoGLM_GUI" / "resources" / "scrcpy-server-v3.3.3"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("server", encoding="utf-8")
+    monkeypatch.setattr(scrcpy_stream.sys, "_MEIPASS", str(tmp_path), raising=False)
+    assert ScrcpyStreamer._find_scrcpy_server(instance) == str(bundled)
+
+    monkeypatch.delattr(scrcpy_stream.sys, "_MEIPASS", raising=False)
+    assert ScrcpyStreamer._find_scrcpy_server(instance).endswith(
+        "AutoGLM_GUI/resources/scrcpy-server-v3.3.3"
+    )
+
+    env_server = tmp_path / "env-server"
+    env_server.write_text("server", encoding="utf-8")
+    monkeypatch.setenv("SCRCPY_SERVER_PATH", str(env_server))
+    monkeypatch.setattr(scrcpy_stream.Path, "exists", lambda self: False)
+    assert ScrcpyStreamer._find_scrcpy_server(instance) == str(env_server)
+
+    monkeypatch.delenv("SCRCPY_SERVER_PATH", raising=False)
+    monkeypatch.setattr(
+        scrcpy_stream.os.path,
+        "exists",
+        lambda path: path == "/usr/local/share/scrcpy/scrcpy-server",
+    )
+    assert (
+        ScrcpyStreamer._find_scrcpy_server(instance)
+        == "/usr/local/share/scrcpy/scrcpy-server"
+    )
+
+    monkeypatch.setattr(scrcpy_stream.os.path, "exists", lambda path: False)
+    with pytest.raises(FileNotFoundError, match="scrcpy-server not found"):
+        ScrcpyStreamer._find_scrcpy_server(instance)
+
+
+@pytest.mark.anyio
+async def test_port_available_success_and_wait_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert await scrcpy_stream.is_port_available(0) is True
+
+    async def unavailable(port: int, host: str) -> bool:
+        return False
+
+    monkeypatch.setattr(scrcpy_stream, "is_port_available", unavailable)
+    monkeypatch.setattr(scrcpy_stream.time, "time", lambda: 10.0)
+    assert (
+        await scrcpy_stream.wait_for_port_release(1234, timeout=0.0, poll_interval=0.0)
+        is False
+    )
+
+
+@pytest.mark.anyio
+async def test_cleanup_existing_server_warns_when_port_stays_busy(
+    fake_server: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
+
+    async def fake_run(cmd: list[str]) -> None:
+        calls.append(cmd)
+
+    monkeypatch.setattr(scrcpy_stream, "run_cmd_silently", fake_run)
+
+    async def unreleased(*args, **kwargs) -> bool:
+        return False
+
+    monkeypatch.setattr(scrcpy_stream, "wait_for_port_release", unreleased)
+
+    streamer = ScrcpyStreamer(device_id="serial", port=27183)
+    await streamer._cleanup_existing_server()
+
+    assert calls[-1] == ["adb", "-s", "serial", "forward", "--remove", "tcp:27183"]
+
+
+@pytest.mark.anyio
+async def test_start_server_reports_windows_process_error(
+    fake_server: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FailedWindowsProcess:
+        def poll(self) -> int:
+            return 1
+
+        def communicate(self) -> tuple[bytes, bytes]:
+            return b"stdout", b"fatal startup"
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    async def fake_spawn(cmd: list[str], capture_output: bool) -> FailedWindowsProcess:
+        return FailedWindowsProcess()
+
+    original_sleep = asyncio.sleep
+
+    monkeypatch.setattr(scrcpy_stream, "spawn_process", fake_spawn)
+    monkeypatch.setattr(scrcpy_stream, "is_windows", lambda: True)
+    monkeypatch.setattr(scrcpy_stream.asyncio, "sleep", lambda delay: original_sleep(0))
+
+    streamer = ScrcpyStreamer(device_id="serial")
+    with pytest.raises(RuntimeError, match="fatal startup"):
+        await streamer._start_server()
+
+
+@pytest.mark.anyio
+async def test_connect_socket_retries_and_reports_failure(
+    fake_server: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FailingSocket:
+        def settimeout(self, timeout: float | None) -> None:
+            return None
+
+        def setsockopt(self, level: int, optname: int, value: int) -> None:
+            raise OSError("buffer denied")
+
+        def connect(self, address: tuple[str, int]) -> None:
+            raise ConnectionRefusedError("closed")
+
+        def close(self) -> None:
+            raise RuntimeError("close failed")
+
+    original_sleep = asyncio.sleep
+
+    monkeypatch.setattr(scrcpy_stream.socket, "socket", lambda *a, **k: FailingSocket())
+    monkeypatch.setattr(scrcpy_stream.asyncio, "sleep", lambda delay: original_sleep(0))
+
+    streamer = ScrcpyStreamer(device_id="serial")
+    with pytest.raises(ConnectionError, match="Failed to connect"):
+        await streamer._connect_socket()
+
+
+@pytest.mark.anyio
+async def test_read_exactly_errors(fake_server: None) -> None:
+    streamer = ScrcpyStreamer(device_id="serial")
+    with pytest.raises(ConnectionError, match="Socket not connected"):
+        await streamer._read_exactly(1)
+
+    class ClosedSocket:
+        def recv(self, size: int) -> bytes:
+            return b""
+
+        def close(self) -> None:
+            return None
+
+    streamer.tcp_socket = ClosedSocket()  # type: ignore[assignment]
+    with pytest.raises(ConnectionError, match="Socket closed by remote"):
+        await streamer._read_exactly(1)
+
+
+class BufferSocket:
+    def __init__(self, data: bytes) -> None:
+        self.data = bytearray(data)
+
+    def recv(self, size: int) -> bytes:
+        chunk = bytes(self.data[:size])
+        del self.data[:size]
+        return chunk
+
+    def close(self) -> None:
+        return None
+
+
+@pytest.mark.anyio
+async def test_metadata_cache_and_legacy_parsing(fake_server: None) -> None:
+    streamer = ScrcpyStreamer(device_id="serial")
+    streamer._metadata = ScrcpyVideoStreamMetadata(
+        device_name="cached", width=1, height=2, codec=SCRCPY_CODEC_H264
+    )
+    assert await streamer.read_video_metadata() is streamer._metadata
+
+    name = b"Pixel" + b"\x00" * 59
+    legacy_size = (1080 << 16) | 2400
+    legacy = ScrcpyStreamer(device_id="serial")
+    legacy.stream_options = ScrcpyVideoStreamOptions(send_dummy_byte=False)
+    legacy.tcp_socket = BufferSocket(name + legacy_size.to_bytes(4, "big"))  # type: ignore[assignment]
+
+    metadata = await legacy.read_video_metadata()
+    assert metadata.device_name == "Pixel"
+    assert metadata.width == 1080
+    assert metadata.height == 2400
+
+    no_codec = ScrcpyStreamer(device_id="serial")
+    no_codec.stream_options = ScrcpyVideoStreamOptions(
+        send_dummy_byte=False, send_codec_meta=False
+    )
+    no_codec.tcp_socket = BufferSocket(
+        name + (720).to_bytes(2, "big") + (1280).to_bytes(2, "big")
+    )  # type: ignore[assignment]
+    metadata = await no_codec.read_video_metadata()
+    assert metadata.width == 720
+    assert metadata.height == 1280
+
+
+@pytest.mark.anyio
+async def test_read_media_packet_initializes_metadata_and_iterates(
+    fake_server: None,
+) -> None:
+    streamer = ScrcpyStreamer(device_id="serial")
+    streamer.stream_options = ScrcpyVideoStreamOptions(
+        send_dummy_byte=False,
+        send_device_meta=False,
+        send_codec_meta=False,
+    )
+    streamer.tcp_socket = BufferSocket(
+        (7).to_bytes(8, "big") + (3).to_bytes(4, "big") + b"abc"
+    )  # type: ignore[assignment]
+
+    packet = await streamer.read_media_packet()
+    assert packet == ScrcpyMediaStreamPacket(
+        type="data", data=b"abc", keyframe=False, pts=7
+    )
+
+    iterator = ScrcpyStreamer(device_id="serial")
+    expected = ScrcpyMediaStreamPacket(type="configuration", data=b"cfg")
+
+    async def fake_read_packet() -> ScrcpyMediaStreamPacket:
+        return expected
+
+    iterator.read_media_packet = fake_read_packet  # type: ignore[method-assign]
+    agen = iterator.iter_packets()
+    assert await agen.__anext__() is expected
+    await agen.aclose()
+
+
+def test_stop_handles_cleanup_errors(
+    fake_server: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class BadSocket:
+        def close(self) -> None:
+            raise OSError("socket close failed")
+
+    class FakePopen:
+        def terminate(self) -> None:
+            return None
+
+        def wait(self, timeout: float) -> None:
+            raise subprocess.TimeoutExpired("scrcpy", timeout)
+
+        def kill(self) -> None:
+            raise OSError("kill failed")
+
+    def failing_run(*args, **kwargs) -> None:
+        raise subprocess.SubprocessError("forward cleanup failed")
+
+    monkeypatch.setattr(scrcpy_stream.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(scrcpy_stream.subprocess, "run", failing_run)
+
+    streamer = ScrcpyStreamer(device_id="serial")
+    streamer.tcp_socket = BadSocket()  # type: ignore[assignment]
+    streamer.scrcpy_process = FakePopen()  # type: ignore[assignment]
+    streamer.forward_cleanup_needed = True
+
+    streamer.stop()
+
+    assert streamer.tcp_socket is None
+    assert streamer.scrcpy_process is None
+    assert streamer.forward_cleanup_needed is False

--- a/tests/test_serial_extraction.py
+++ b/tests/test_serial_extraction.py
@@ -1,6 +1,17 @@
 """Unit tests for mDNS serial extraction."""
 
+import subprocess
+
+import pytest
+
+import AutoGLM_GUI.adb_plus.serial as serial_module
 from AutoGLM_GUI.adb_plus.serial import extract_serial_from_mdns, get_device_serial
+
+
+def _completed(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["adb"], returncode=returncode, stdout=stdout
+    )
 
 
 class TestMdnsSerialExtraction:
@@ -138,3 +149,108 @@ class TestGetDeviceSerialIntegration:
         serial = get_device_serial(device_id)
         # Extraction fails, getprop attempted (fails in test env), uses fallback
         assert serial == device_id
+
+    def test_getprop_returns_first_valid_serial(self, monkeypatch: pytest.MonkeyPatch):
+        """Test getprop fallback skips empty/error values and returns a valid serial."""
+        results = iter(
+            [
+                _completed(""),
+                _completed("unknown"),
+                _completed("SERIAL123"),
+            ]
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], timeout: int) -> subprocess.CompletedProcess[str]:
+            calls.append(cmd)
+            return next(results)
+
+        monkeypatch.setattr(serial_module, "run_cmd_silently_sync", fake_run)
+
+        assert get_device_serial("usb-device", adb_path="adbx") == "SERIAL123"
+        assert [call[-1] for call in calls] == [
+            "ro.serialno",
+            "ro.boot.serialno",
+            "ro.product.serial",
+        ]
+
+    def test_getprop_exceptions_fall_through_to_next_prop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Test getprop exceptions are ignored before trying the next property."""
+        calls = 0
+
+        def fake_run(cmd: list[str], timeout: int) -> subprocess.CompletedProcess[str]:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise RuntimeError("adb failed")
+            return _completed("SERIAL456")
+
+        monkeypatch.setattr(serial_module, "run_cmd_silently_sync", fake_run)
+
+        assert get_device_serial("usb-device", adb_path="adbx") == "SERIAL456"
+        assert calls == 2
+
+
+@pytest.mark.anyio
+async def test_get_device_serial_async_uses_mdns_fast_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_if_called(
+        cmd: list[str], timeout: int
+    ) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("ADB should not be called for valid mDNS names")
+
+    monkeypatch.setattr(serial_module, "run_cmd_silently", fail_if_called)
+
+    assert (
+        await serial_module.get_device_serial_async("adb-ASYNC1._adb-tls-connect._tcp")
+        == "ASYNC1"
+    )
+
+
+@pytest.mark.anyio
+async def test_get_device_serial_async_returns_first_valid_getprop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    results = iter(
+        [
+            _completed("error: device offline"),
+            _completed("unknown"),
+            _completed("ASYNC123"),
+        ]
+    )
+    calls: list[list[str]] = []
+
+    async def fake_run(
+        cmd: list[str], timeout: int
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return next(results)
+
+    monkeypatch.setattr(serial_module, "run_cmd_silently", fake_run)
+
+    assert (
+        await serial_module.get_device_serial_async("wifi-device", adb_path="adbx")
+        == "ASYNC123"
+    )
+    assert [call[-1] for call in calls] == [
+        "ro.serialno",
+        "ro.boot.serialno",
+        "ro.product.serial",
+    ]
+
+
+@pytest.mark.anyio
+async def test_get_device_serial_async_exceptions_and_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def broken_run(
+        cmd: list[str], timeout: int
+    ) -> subprocess.CompletedProcess[str]:
+        raise RuntimeError("adb failed")
+
+    monkeypatch.setattr(serial_module, "run_cmd_silently", broken_run)
+
+    assert await serial_module.get_device_serial_async("wifi-device") == "wifi-device"

--- a/tests/test_service_entry_coverage.py
+++ b/tests/test_service_entry_coverage.py
@@ -1,0 +1,554 @@
+"""Coverage for service orchestration, actions, config, and CLI entry paths."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+import AutoGLM_GUI.__main__ as main_module
+import AutoGLM_GUI.actions.handler as action_handler_module
+import AutoGLM_GUI.adb_manager as adb_manager
+import AutoGLM_GUI.config_manager as config_manager_module
+import AutoGLM_GUI.device_manager as device_manager_module
+from AutoGLM_GUI.actions import ActionHandler
+from AutoGLM_GUI.config_manager import ConfigModel, ConfigSource, UnifiedConfigManager
+from AutoGLM_GUI.models.scheduled_task import ScheduledTask
+from AutoGLM_GUI.scheduler_manager import SchedulerManager
+
+
+class FakeActionDevice:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.launch_success = True
+        self.original_ime = "latin/.Ime"
+
+    def launch_app(self, app: str) -> bool:
+        self.calls.append(("launch_app", (app,)))
+        return self.launch_success
+
+    def tap(self, x: int, y: int) -> None:
+        self.calls.append(("tap", (x, y)))
+
+    def detect_and_set_adb_keyboard(self) -> str:
+        self.calls.append(("detect_and_set_adb_keyboard", ()))
+        return self.original_ime
+
+    def clear_text(self) -> None:
+        self.calls.append(("clear_text", ()))
+
+    def type_text(self, text: str) -> None:
+        self.calls.append(("type_text", (text,)))
+
+    def restore_keyboard(self, ime: str) -> None:
+        self.calls.append(("restore_keyboard", (ime,)))
+
+    def swipe(self, sx: int, sy: int, ex: int, ey: int) -> None:
+        self.calls.append(("swipe", (sx, sy, ex, ey)))
+
+    def back(self) -> None:
+        self.calls.append(("back", ()))
+
+    def home(self) -> None:
+        self.calls.append(("home", ()))
+
+    def double_tap(self, x: int, y: int) -> None:
+        self.calls.append(("double_tap", (x, y)))
+
+    def long_press(self, x: int, y: int) -> None:
+        self.calls.append(("long_press", (x, y)))
+
+
+def test_action_handler_covers_supported_and_error_actions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(action_handler_module, "trace_sleep", lambda *a, **k: None)
+    device = FakeActionDevice()
+    confirmations: list[str] = []
+    takeovers: list[str] = []
+    handler = ActionHandler(
+        device,
+        confirmation_callback=lambda message: confirmations.append(message) or True,
+        takeover_callback=lambda message: takeovers.append(message),
+    )
+
+    assert handler.execute(
+        {"_metadata": "finish", "message": "done"}, 100, 200
+    ).should_finish
+    assert (
+        handler.execute({"_metadata": "bad"}, 100, 200).message
+        == "Unknown action type: bad"
+    )
+    assert (
+        handler.execute({"_metadata": "do"}, 100, 200).message == "Unknown action: None"
+    )
+    assert (
+        handler.execute({"_metadata": "do", "action": "Nope"}, 100, 200).message
+        == "Unknown action: Nope"
+    )
+
+    assert handler.execute(
+        {"_metadata": "do", "action": "Launch", "app": "Settings"}, 100, 200
+    ).success
+    device.launch_success = False
+    assert (
+        "App not found"
+        in handler.execute(
+            {"_metadata": "do", "action": "Launch", "app": "Missing"}, 100, 200
+        ).message
+    )
+    assert (
+        handler.execute({"_metadata": "do", "action": "Launch"}, 100, 200).message
+        == "No app name specified"
+    )
+
+    assert handler.execute(
+        {
+            "_metadata": "do",
+            "action": "Tap",
+            "element": [500, 1000],
+            "message": "confirm",
+        },
+        100,
+        200,
+    ).success
+    assert confirmations == ["confirm"]
+    cancelling = ActionHandler(device, confirmation_callback=lambda _: False)
+    assert cancelling.execute(
+        {"_metadata": "do", "action": "Tap", "element": [1, 1], "message": "no"},
+        100,
+        200,
+    ).should_finish
+    assert (
+        handler.execute({"_metadata": "do", "action": "Tap"}, 100, 200).message
+        == "No element coordinates"
+    )
+
+    assert handler.execute(
+        {"_metadata": "do", "action": "Type", "text": "hello"}, 100, 200
+    ).success
+    device.original_ime = handler._ADB_IME
+    assert handler.execute(
+        {"_metadata": "do", "action": "Type_Name", "text": "x"}, 100, 200
+    ).success
+    assert handler.execute(
+        {"_metadata": "do", "action": "Swipe", "start": [0, 0], "end": [1000, 1000]},
+        100,
+        200,
+    ).success
+    assert (
+        handler.execute({"_metadata": "do", "action": "Swipe"}, 100, 200).message
+        == "Missing swipe coordinates"
+    )
+    assert handler.execute({"_metadata": "do", "action": "Back"}, 100, 200).success
+    assert handler.execute({"_metadata": "do", "action": "Home"}, 100, 200).success
+    assert handler.execute(
+        {"_metadata": "do", "action": "Double Tap", "element": [200, 300]}, 100, 200
+    ).success
+    assert (
+        handler.execute({"_metadata": "do", "action": "Double Tap"}, 100, 200).message
+        == "No element coordinates"
+    )
+    assert handler.execute(
+        {"_metadata": "do", "action": "Long Press", "element": [200, 300]}, 100, 200
+    ).success
+    assert (
+        handler.execute({"_metadata": "do", "action": "Long Press"}, 100, 200).message
+        == "No element coordinates"
+    )
+    assert handler.execute(
+        {"_metadata": "do", "action": "Wait", "duration": "not numeric"}, 100, 200
+    ).success
+    assert handler.execute(
+        {"_metadata": "do", "action": "Take_over", "message": "help"}, 100, 200
+    ).success
+    assert takeovers == ["help"]
+    assert handler.execute({"_metadata": "do", "action": "Note"}, 100, 200).success
+    assert handler.execute({"_metadata": "do", "action": "Call_API"}, 100, 200).success
+    assert (
+        handler.execute({"_metadata": "do", "action": "Interact"}, 100, 200).message
+        == "User interaction required"
+    )
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    device.tap = boom
+    assert (
+        handler.execute(
+            {"_metadata": "do", "action": "Tap", "element": [1, 1]}, 100, 200
+        ).message
+        == "Action failed: boom"
+    )
+
+
+def test_unified_config_manager_layers_conflicts_and_file_io(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    UnifiedConfigManager._instance = None
+    manager = UnifiedConfigManager()
+    manager._config_path = tmp_path / "config.json"
+
+    with pytest.raises(ValueError, match="base_url"):
+        ConfigModel(base_url="localhost")
+    with pytest.raises(ValueError, match="model_name"):
+        ConfigModel(model_name=" ")
+    with pytest.raises(ValueError, match="decision_base_url"):
+        ConfigModel(decision_base_url="bad")
+
+    assert manager.load_file_config() is False
+    assert manager.get_config_source() == ConfigSource.DEFAULT
+    assert manager.save_file_config(
+        "https://file.test/v1",
+        "file-model",
+        api_key="file-key",
+        agent_type="glm",
+        default_max_steps=None,
+        default_max_steps_set=True,
+        layered_max_turns=None,
+        layered_max_turns_set=True,
+        decision_base_url="https://decision.test/v1",
+        decision_model_name="decision",
+        decision_api_key="decision-key",
+    )
+    assert manager.load_file_config(force_reload=True)
+    assert manager.get_field_source("base_url") == ConfigSource.FILE
+    assert manager.get_effective_config().agent_type == "glm-async"
+
+    monkeypatch.setenv("AUTOGLM_BASE_URL", "https://env.test/v1")
+    monkeypatch.setenv("AUTOGLM_MODEL_NAME", "env-model")
+    monkeypatch.setenv("AUTOGLM_API_KEY", "env-key")
+    monkeypatch.setenv("AUTOGLM_DEFAULT_MAX_STEPS", "25")
+    monkeypatch.setenv("AUTOGLM_LAYERED_MAX_TURNS", "5")
+    monkeypatch.setenv("AUTOGLM_DECISION_BASE_URL", "https://env-decision.test/v1")
+    monkeypatch.setenv("AUTOGLM_DECISION_MODEL_NAME", "env-decision")
+    monkeypatch.setenv("AUTOGLM_DECISION_API_KEY", "env-decision-key")
+    manager.load_env_config()
+    manager.set_cli_config(
+        base_url="https://cli.test/v1",
+        model_name="cli-model",
+        api_key="cli-key",
+        layered_max_turns=9,
+    )
+
+    effective = manager.get_effective_config()
+    assert effective.base_url == "https://cli.test/v1"
+    assert effective.model_name == "cli-model"
+    assert effective.default_max_steps == 25
+    conflicts = manager.detect_conflicts()
+    assert {conflict.field for conflict in conflicts} == {
+        "base_url",
+        "model_name",
+        "api_key",
+    }
+    manager.sync_to_env()
+    assert manager.to_dict()["layered_max_turns"] == 9
+    assert manager.delete_file_config() is True
+    assert manager.delete_file_config() is True
+
+    manager._config_path.write_text("{bad", encoding="utf-8")
+    assert manager.load_file_config(force_reload=True) is False
+    manager._cli_layer = config_manager_module.ConfigLayer(source=ConfigSource.CLI)
+    manager._env_layer = config_manager_module.ConfigLayer(source=ConfigSource.ENV)
+    manager._file_layer.base_url = "bad"
+    manager._file_layer.explicit_keys = {"base_url"}
+    manager._effective_config = None
+    assert manager.get_effective_config().base_url == ""
+
+    UnifiedConfigManager._instance = None
+
+
+class FakeScheduler:
+    def __init__(self) -> None:
+        self.jobs: dict[str, Any] = {}
+        self.started = False
+        self.shutdown_called = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def shutdown(self, wait: bool = False) -> None:
+        self.shutdown_called = wait is False
+
+    def add_job(self, func, trigger, id, args, replace_existing):
+        self.jobs[id] = SimpleNamespace(
+            func=func,
+            trigger=trigger,
+            args=args,
+            next_run_time=datetime(2026, 1, 1),
+        )
+
+    def get_job(self, task_id: str):
+        return self.jobs.get(task_id)
+
+    def remove_job(self, task_id: str) -> None:
+        self.jobs.pop(task_id, None)
+
+
+@pytest.fixture
+def scheduler(tmp_path: Path) -> SchedulerManager:
+    SchedulerManager._instance = None
+    manager = SchedulerManager()
+    manager._tasks_path = tmp_path / "scheduled_tasks.json"
+    manager._scheduler = FakeScheduler()
+    manager._tasks = {}
+    yield manager
+    SchedulerManager._instance = None
+
+
+def test_scheduler_crud_persistence_jobs_and_resolution(
+    scheduler: SchedulerManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    task = scheduler.create_task(
+        "Morning",
+        "wf-1",
+        ["serial-1"],
+        "0 8 * * *",
+        enabled=True,
+        execution_mode="classic",
+    )
+    assert task.id in scheduler._scheduler.jobs
+    assert scheduler.get_task(task.id) is task
+    assert scheduler.list_tasks() == [task]
+    assert scheduler.get_next_run_time(task.id) == datetime(2026, 1, 1)
+
+    scheduler.update_task(task.id, enabled=False)
+    assert task.id not in scheduler._scheduler.jobs
+    scheduler.set_enabled(task.id, True)
+    assert task.id in scheduler._scheduler.jobs
+    scheduler.update_task(task.id, cron_expression="5 9 * * *")
+    assert task.id in scheduler._scheduler.jobs
+    assert scheduler.set_enabled("missing", True) is False
+    assert scheduler.update_task("missing", name="x") is None
+
+    scheduler._add_job(
+        ScheduledTask(name="Bad", workflow_uuid="wf", cron_expression="bad")
+    )
+    scheduler._scheduler.get_job = lambda task_id: (_ for _ in ()).throw(
+        RuntimeError("job failed")
+    )
+    scheduler._remove_job(task.id)
+
+    scheduler._save_tasks()
+    scheduler._tasks = {}
+    scheduler._load_tasks()
+    assert list(scheduler._tasks.values())[0].name == "Morning"
+    scheduler._tasks_path.write_text("{bad", encoding="utf-8")
+    scheduler._load_tasks()
+
+    assert scheduler.delete_task(task.id) is True
+    assert scheduler.delete_task(task.id) is False
+
+    class FakeGroupManager:
+        @staticmethod
+        def get_all_assignments() -> dict[str, str]:
+            return {"assigned": "other"}
+
+        @staticmethod
+        def get_devices_in_group(group_id: str) -> list[str]:
+            return ["grouped"]
+
+    class FakeDeviceManager:
+        @staticmethod
+        def get_devices():
+            return [
+                SimpleNamespace(serial="default-1"),
+                SimpleNamespace(serial="assigned"),
+            ]
+
+    import AutoGLM_GUI.device_group_manager as group_module
+
+    monkeypatch.setattr(group_module, "device_group_manager", FakeGroupManager())
+    monkeypatch.setattr(
+        device_manager_module.DeviceManager,
+        "get_instance",
+        classmethod(lambda cls: FakeDeviceManager()),
+    )
+    assert scheduler._resolve_device_serialnos(
+        ScheduledTask(name="Default", workflow_uuid="wf", device_group_id="default")
+    ) == ["default-1"]
+    assert scheduler._resolve_device_serialnos(
+        ScheduledTask(name="Group", workflow_uuid="wf", device_group_id="g")
+    ) == ["grouped"]
+
+
+def test_scheduler_single_device_execution_paths(scheduler: SchedulerManager) -> None:
+    online_device = SimpleNamespace(
+        serial="serial-1",
+        state=SimpleNamespace(value="online"),
+        primary_device_id="device-1",
+        model="Pixel",
+    )
+
+    class FakeDeviceManager:
+        @staticmethod
+        def get_devices():
+            return [online_device]
+
+    class FakeAgent:
+        step_count = 1
+
+        def reset(self) -> None:
+            self.reset_called = True
+
+        async def stream(self, text):
+            yield {
+                "type": "step",
+                "data": {"thinking": "think", "action": {"action": "Tap"}, "step": 1},
+            }
+            yield {"type": "done", "data": {"message": "done", "success": True}}
+
+    class FakePhoneManager:
+        def __init__(self, acquired: bool = True, fail_stream: bool = False) -> None:
+            self.acquired = acquired
+            self.fail_stream = fail_stream
+            self.released: list[str] = []
+
+        async def acquire_device_async(self, *args, **kwargs):
+            return self.acquired
+
+        def get_agent(self, device_id: str):
+            if self.fail_stream:
+                raise RuntimeError("agent failed")
+            return FakeAgent()
+
+        def release_device(self, device_id: str) -> None:
+            self.released.append(device_id)
+
+    class FakeHistory:
+        def __init__(self) -> None:
+            self.records = []
+
+        def add_record(self, serialno, record) -> None:
+            self.records.append((serialno, record))
+
+    history = FakeHistory()
+    manager = FakePhoneManager()
+    result = asyncio.run(
+        scheduler._execute_single_device(
+            "serial-1",
+            {"text": "do it"},
+            "Morning",
+            manager,
+            FakeDeviceManager(),
+            history,
+        )
+    )
+    assert result.success is True
+    assert result.device_model == "Pixel"
+    assert manager.released == ["device-1"]
+    assert history.records[0][1].messages[-1].action == {"action": "Tap"}
+
+    busy = asyncio.run(
+        scheduler._execute_single_device(
+            "serial-1",
+            {"text": "do it"},
+            "Morning",
+            FakePhoneManager(acquired=False),
+            FakeDeviceManager(),
+            history,
+        )
+    )
+    assert busy.message == "Device busy"
+
+    offline = asyncio.run(
+        scheduler._execute_single_device(
+            "missing",
+            {"text": "do it"},
+            "Morning",
+            FakePhoneManager(),
+            FakeDeviceManager(),
+            history,
+        )
+    )
+    assert offline.message == "Device offline"
+
+    failed = asyncio.run(
+        scheduler._execute_single_device(
+            "serial-1",
+            {"text": "do it"},
+            "Morning",
+            FakePhoneManager(fail_stream=True),
+            FakeDeviceManager(),
+            history,
+        )
+    )
+    assert failed.success is False
+    assert failed.message == "agent failed"
+
+
+def test_main_entry_success_error_and_browser_paths(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert isinstance(main_module.find_available_port(0, max_attempts=1), int)
+    with pytest.raises(RuntimeError):
+        main_module.find_available_port(1, max_attempts=0)
+
+    opened: list[str] = []
+    monkeypatch.setattr(main_module.time, "sleep", lambda delay: None)
+    monkeypatch.setattr(main_module.webbrowser, "open", lambda url: opened.append(url))
+
+    class ImmediateThread:
+        def __init__(self, target, daemon):
+            self.target = target
+
+        def start(self) -> None:
+            self.target()
+
+    monkeypatch.setattr(main_module.threading, "Thread", ImmediateThread)
+    main_module.open_browser("0.0.0.0", 1234, use_ssl=True, delay=0)
+    assert opened == ["https://127.0.0.1:1234"]
+
+    fake_uvicorn = ModuleType("uvicorn")
+    uvicorn_runs: list[dict[str, Any]] = []
+    fake_uvicorn.run = lambda app, **kwargs: uvicorn_runs.append({"app": app, **kwargs})
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+    monkeypatch.setattr(adb_manager, "ensure_adb", lambda: "/adb")
+    monkeypatch.setattr(
+        device_manager_module.DeviceManager,
+        "get_instance",
+        classmethod(lambda cls, adb_path=None: SimpleNamespace(adb_path=adb_path)),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "autoglm-gui",
+            "--base-url",
+            "https://model.test/v1",
+            "--model",
+            "m",
+            "--apikey",
+            "k",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "8765",
+            "--no-browser",
+            "--no-log-file",
+            "--layered-max-turns",
+            "3",
+        ],
+    )
+    main_module.main()
+    assert uvicorn_runs[-1]["port"] == 8765
+    assert uvicorn_runs[-1]["host"] == "127.0.0.1"
+    assert "API Key" in capsys.readouterr().out
+
+    monkeypatch.setattr(sys, "argv", ["autoglm-gui", "--adb-terminal-repl"])
+    monkeypatch.setattr(main_module, "adb_terminal_repl_main", lambda: 7)
+    with pytest.raises(SystemExit) as exc:
+        main_module.main()
+    assert exc.value.code == 7
+
+    monkeypatch.setattr(sys, "argv", ["autoglm-gui", "--port", "9999", "--no-browser"])
+    monkeypatch.setattr(
+        adb_manager, "ensure_adb", lambda: (_ for _ in ()).throw(RuntimeError("no adb"))
+    )
+    main_module.main()
+    assert uvicorn_runs[-1]["port"] == 9999

--- a/tests/test_socketio_server.py
+++ b/tests/test_socketio_server.py
@@ -1,0 +1,339 @@
+"""Unit tests for Socket.IO scrcpy stream orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import AutoGLM_GUI.socketio_server as socketio_server
+from AutoGLM_GUI.scrcpy_protocol import ScrcpyMediaStreamPacket
+
+
+@pytest.fixture(autouse=True)
+def reset_socketio_state() -> None:
+    socketio_server._socket_streamers.clear()
+    socketio_server._stream_tasks.clear()
+    socketio_server._device_locks.clear()
+    yield
+    socketio_server._socket_streamers.clear()
+    socketio_server._stream_tasks.clear()
+    socketio_server._device_locks.clear()
+
+
+class FakeTask:
+    def __init__(self) -> None:
+        self.cancelled = False
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+
+class FakeStreamer:
+    def __init__(self, device_id: str = "device-1") -> None:
+        self.device_id = device_id
+        self.stopped = False
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+def test_classify_error_variants() -> None:
+    assert (
+        socketio_server._classify_error(OSError("Address already in use"))["type"]
+        == "port_conflict"
+    )
+    assert (
+        socketio_server._classify_error(RuntimeError("Port 27183 occupied"))["type"]
+        == "port_conflict"
+    )
+    assert (
+        socketio_server._classify_error(RuntimeError("Device abc not found"))["type"]
+        == "device_offline"
+    )
+    assert (
+        socketio_server._classify_error(TimeoutError("timed out"))["type"] == "timeout"
+    )
+    assert (
+        socketio_server._classify_error(RuntimeError("Failed to connect"))["type"]
+        == "connection_failed"
+    )
+    assert socketio_server._classify_error(RuntimeError("boom"))["type"] == "unknown"
+
+
+def test_stop_streamers_filters_by_device() -> None:
+    stale_task = FakeTask()
+    kept_task = FakeTask()
+    matching = FakeStreamer("device-1")
+    other = FakeStreamer("device-2")
+
+    socketio_server._socket_streamers.update(
+        {
+            "empty": None,  # type: ignore[dict-item]
+            "matching": matching,  # type: ignore[dict-item]
+            "other": other,  # type: ignore[dict-item]
+        }
+    )
+    socketio_server._stream_tasks.update(
+        {
+            "matching": stale_task,  # type: ignore[dict-item]
+            "other": kept_task,  # type: ignore[dict-item]
+        }
+    )
+
+    socketio_server.stop_streamers("device-1")
+
+    assert stale_task.cancelled is True
+    assert matching.stopped is True
+    assert kept_task.cancelled is False
+    assert other.stopped is False
+    assert "matching" not in socketio_server._socket_streamers
+    assert "other" in socketio_server._socket_streamers
+
+    socketio_server.stop_streamers()
+    assert kept_task.cancelled is True
+    assert other.stopped is True
+
+
+@pytest.mark.anyio
+async def test_disconnect_stops_stream_for_sid() -> None:
+    task = FakeTask()
+    streamer = FakeStreamer()
+    socketio_server._stream_tasks["sid-1"] = task  # type: ignore[assignment]
+    socketio_server._socket_streamers["sid-1"] = streamer  # type: ignore[assignment]
+
+    await socketio_server.connect("sid-1", {})
+    await socketio_server.disconnect("sid-1")
+
+    assert task.cancelled is True
+    assert streamer.stopped is True
+    assert socketio_server._stream_tasks == {}
+    assert socketio_server._socket_streamers == {}
+
+
+def test_packet_to_payload_includes_frame_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(socketio_server.time, "time", lambda: 12.345)
+    payload = socketio_server._packet_to_payload(
+        ScrcpyMediaStreamPacket(type="data", data=b"frame", keyframe=True, pts=123)
+    )
+
+    assert payload == {
+        "type": "data",
+        "data": b"frame",
+        "timestamp": 12345,
+        "keyframe": True,
+        "pts": 123,
+    }
+
+    config_payload = socketio_server._packet_to_payload(
+        ScrcpyMediaStreamPacket(type="config", data=b"cfg")
+    )
+    assert config_payload == {
+        "type": "config",
+        "data": b"cfg",
+        "timestamp": 12345,
+    }
+
+
+@pytest.mark.anyio
+async def test_stream_packets_emits_payloads_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class PacketStreamer(FakeStreamer):
+        async def iter_packets(self):
+            yield ScrcpyMediaStreamPacket(type="data", data=b"abc")
+
+    emitted: list[tuple[str, dict[str, Any], str]] = []
+
+    async def fake_emit(event: str, payload: dict[str, Any], to: str) -> None:
+        emitted.append((event, payload, to))
+
+    task = FakeTask()
+    streamer = PacketStreamer()
+    socketio_server._stream_tasks["sid-1"] = task  # type: ignore[assignment]
+    socketio_server._socket_streamers["sid-1"] = streamer  # type: ignore[assignment]
+    monkeypatch.setattr(socketio_server.sio, "emit", fake_emit)
+
+    await socketio_server._stream_packets("sid-1", streamer)  # type: ignore[arg-type]
+
+    assert emitted[0][0] == "video-data"
+    assert emitted[0][1]["data"] == b"abc"
+    assert emitted[0][2] == "sid-1"
+    assert task.cancelled is True
+    assert streamer.stopped is True
+    assert socketio_server._stream_tasks == {}
+    assert socketio_server._socket_streamers == {}
+
+
+@pytest.mark.anyio
+async def test_stream_packets_emits_errors_and_handles_emit_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ErrorStreamer(FakeStreamer):
+        async def iter_packets(self):
+            raise RuntimeError("stream failed")
+            yield  # pragma: no cover
+
+    emitted: list[tuple[str, dict[str, Any], str]] = []
+
+    async def fake_emit(event: str, payload: dict[str, Any], to: str) -> None:
+        emitted.append((event, payload, to))
+
+    monkeypatch.setattr(socketio_server.sio, "emit", fake_emit)
+    await socketio_server._stream_packets("sid-1", ErrorStreamer())  # type: ignore[arg-type]
+
+    assert emitted == [("error", {"message": "stream failed"}, "sid-1")]
+
+    async def failing_emit(event: str, payload: dict[str, Any], to: str) -> None:
+        raise RuntimeError("emit failed")
+
+    monkeypatch.setattr(socketio_server.sio, "emit", failing_emit)
+    await socketio_server._stream_packets("sid-2", ErrorStreamer())  # type: ignore[arg-type]
+
+
+@pytest.mark.anyio
+async def test_stream_packets_reraises_cancelled_error() -> None:
+    class CancelledStreamer(FakeStreamer):
+        async def iter_packets(self):
+            raise asyncio.CancelledError
+            yield  # pragma: no cover
+
+    streamer = CancelledStreamer()
+    socketio_server._socket_streamers["sid-1"] = streamer  # type: ignore[assignment]
+
+    with pytest.raises(asyncio.CancelledError):
+        await socketio_server._stream_packets("sid-1", streamer)  # type: ignore[arg-type]
+
+    assert streamer.stopped is True
+
+
+@pytest.mark.anyio
+async def test_connect_device_rejects_missing_device_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    emitted: list[tuple[str, dict[str, Any], str]] = []
+
+    async def fake_emit(event: str, payload: dict[str, Any], to: str) -> None:
+        emitted.append((event, payload, to))
+
+    monkeypatch.setattr(socketio_server.sio, "emit", fake_emit)
+
+    await socketio_server.connect_device("sid-1", None)
+
+    assert emitted == [
+        (
+            "error",
+            {"message": "Device ID is required", "type": "invalid_request"},
+            "sid-1",
+        )
+    ]
+
+
+@pytest.mark.anyio
+async def test_connect_device_starts_stream_and_replaces_existing_device_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[Any] = []
+
+    class StartedStreamer(FakeStreamer):
+        def __init__(self, device_id: str, max_size: int, bit_rate: int) -> None:
+            super().__init__(device_id)
+            self.max_size = max_size
+            self.bit_rate = bit_rate
+            self.started = False
+            created.append(self)
+
+        async def start(self) -> None:
+            self.started = True
+
+        async def read_video_metadata(self) -> Any:
+            return SimpleNamespace(
+                device_name="Pixel",
+                width=1080,
+                height=2400,
+                codec=0x68323634,
+            )
+
+    emitted: list[tuple[str, dict[str, Any], str]] = []
+
+    async def fake_emit(event: str, payload: dict[str, Any], to: str) -> None:
+        emitted.append((event, payload, to))
+
+    created_tasks: list[Any] = []
+
+    def fake_create_task(coro):
+        created_tasks.append(coro)
+        coro.close()
+        return FakeTask()
+
+    old_task = FakeTask()
+    old_streamer = FakeStreamer("device-1")
+    socketio_server._stream_tasks["old-sid"] = old_task  # type: ignore[assignment]
+    socketio_server._socket_streamers["old-sid"] = old_streamer  # type: ignore[assignment]
+
+    monkeypatch.setattr(socketio_server, "ScrcpyStreamer", StartedStreamer)
+    monkeypatch.setattr(socketio_server.sio, "emit", fake_emit)
+    monkeypatch.setattr(socketio_server.asyncio, "create_task", fake_create_task)
+
+    await socketio_server.connect_device(
+        "sid-1",
+        {"deviceId": "device-1", "maxSize": "720", "bitRate": "1000"},
+    )
+
+    assert old_task.cancelled is True
+    assert old_streamer.stopped is True
+    assert created[0].started is True
+    assert created[0].max_size == 720
+    assert created[0].bit_rate == 1000
+    assert emitted == [
+        (
+            "video-metadata",
+            {
+                "deviceName": "Pixel",
+                "width": 1080,
+                "height": 2400,
+                "codec": 0x68323634,
+            },
+            "sid-1",
+        )
+    ]
+    assert socketio_server._socket_streamers["sid-1"] is created[0]
+    assert isinstance(socketio_server._stream_tasks["sid-1"], FakeTask)
+    assert len(created_tasks) == 1
+
+
+@pytest.mark.anyio
+async def test_connect_device_emits_classified_start_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[Any] = []
+
+    class FailingStreamer(FakeStreamer):
+        def __init__(self, device_id: str, max_size: int, bit_rate: int) -> None:
+            super().__init__(device_id)
+            created.append(self)
+
+        async def start(self) -> None:
+            raise TimeoutError("startup timeout")
+
+        async def read_video_metadata(self) -> Any:
+            raise AssertionError("metadata should not be read")
+
+    emitted: list[tuple[str, dict[str, Any], str]] = []
+
+    async def fake_emit(event: str, payload: dict[str, Any], to: str) -> None:
+        emitted.append((event, payload, to))
+
+    monkeypatch.setattr(socketio_server, "ScrcpyStreamer", FailingStreamer)
+    monkeypatch.setattr(socketio_server.sio, "emit", fake_emit)
+
+    await socketio_server.connect_device("sid-1", {"device_id": "device-1"})
+
+    assert created[0].stopped is True
+    assert emitted[0][0] == "error"
+    assert emitted[0][1]["type"] == "timeout"
+    assert emitted[0][2] == "sid-1"

--- a/tests/test_terminal_service.py
+++ b/tests/test_terminal_service.py
@@ -5,10 +5,25 @@ from __future__ import annotations
 import asyncio
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 import AutoGLM_GUI.adb_terminal_service as terminal_service
+
+
+def _session(**kwargs: object) -> terminal_service.TerminalSession:
+    defaults = {
+        "session_id": "terminal-1",
+        "cwd": "/tmp",
+        "command": ["/bin/sh"],
+        "env": {"TERM": "xterm-256color"},
+        "created_by": "127.0.0.1",
+        "origin": "http://localhost:3000",
+        "owner_token_hash": "token-hash",
+    }
+    defaults.update(kwargs)
+    return terminal_service.TerminalSession(**defaults)
 
 
 def test_build_terminal_environment_includes_project_tools(
@@ -55,6 +70,47 @@ def test_resolve_default_shell_command_uses_cli_flag_for_non_python_executable(
     command = terminal_service._resolve_default_shell_command()
 
     assert command == ["/tmp/autoglm-gui", "--adb-terminal-repl"]
+
+
+def test_terminal_helpers_cover_frozen_python_env_and_path_dedup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(terminal_service.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(terminal_service.sys, "executable", "/tmp/app")
+    assert terminal_service._resolve_default_shell_command() == [
+        "/tmp/app",
+        "--adb-terminal-repl",
+    ]
+
+    monkeypatch.setattr(terminal_service.sys, "frozen", False, raising=False)
+    monkeypatch.setattr(terminal_service.sys, "executable", "/tmp/python3")
+    assert terminal_service._resolve_default_shell_command() == [
+        "/tmp/python3",
+        "-m",
+        "AutoGLM_GUI.adb_terminal_repl",
+    ]
+
+    env_server = tmp_path / "scrcpy-server"
+    env_server.write_text("server", encoding="utf-8")
+    monkeypatch.setattr(
+        terminal_service,
+        "_get_project_root",
+        lambda: tmp_path / "missing-project",
+    )
+    monkeypatch.setenv("SCRCPY_SERVER_PATH", str(env_server))
+    assert terminal_service._detect_scrcpy_server_path() == str(env_server)
+
+    env = {"path": f"{tmp_path / 'a'}:{tmp_path / 'old'}:{tmp_path / 'a'}"}
+    terminal_service._prepend_path_entries(
+        env,
+        [tmp_path / "a", tmp_path / "b", tmp_path / "a", Path("")],
+    )
+    assert env["path"].split(":") == [
+        str(tmp_path / "a"),
+        str(tmp_path / "b"),
+        ".",
+        str(tmp_path / "old"),
+    ]
 
 
 @pytest.mark.anyio
@@ -120,17 +176,42 @@ async def test_create_session_removes_registry_entries_when_start_fails(
 
 
 @pytest.mark.anyio
+async def test_create_session_validates_cwd_and_manager_auth_close(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manager = terminal_service.TerminalSessionManager()
+    missing = tmp_path / "missing"
+    with pytest.raises(ValueError, match="does not exist"):
+        await manager.create_session(cwd=str(missing))
+
+    not_dir = tmp_path / "file"
+    not_dir.write_text("x", encoding="utf-8")
+    with pytest.raises(ValueError, match="not a directory"):
+        await manager.create_session(cwd=str(not_dir))
+
+    async def fake_close(self: terminal_service.TerminalSession) -> None:
+        self.status = "closed"
+
+    session = _session()
+    token = "secret"
+    session.owner_token_hash = terminal_service._hash_session_token(token)
+    manager._sessions[session.session_id] = session
+    manager._session_token_hashes[session.session_id] = session.owner_token_hash
+    monkeypatch.setattr(terminal_service.TerminalSession, "close", fake_close)
+
+    assert manager.get_session(session.session_id) is session
+    assert manager.authenticate_session(session.session_id, None) is None
+    assert manager.authenticate_session(session.session_id, "wrong") is None
+    assert manager.authenticate_session("missing", token) is None
+    assert manager.authenticate_session(session.session_id, token) is session
+    assert await manager.close_session("missing") is False
+    assert await manager.close_session(session.session_id) is True
+    assert session.status == "closed"
+
+
+@pytest.mark.anyio
 async def test_terminal_output_limit_triggers_close() -> None:
-    session = terminal_service.TerminalSession(
-        session_id="terminal-1",
-        cwd="/tmp",
-        command=["/bin/sh"],
-        env={"TERM": "xterm-256color"},
-        created_by="127.0.0.1",
-        origin="http://localhost:3000",
-        owner_token_hash="token-hash",
-        max_output_bytes=4,
-    )
+    session = _session(max_output_bytes=4)
 
     closed = asyncio.Event()
 
@@ -152,17 +233,7 @@ async def test_terminal_output_limit_triggers_close() -> None:
 
 
 def test_append_to_buffer_accounts_for_deque_auto_eviction() -> None:
-    session = terminal_service.TerminalSession(
-        session_id="terminal-1",
-        cwd="/tmp",
-        command=["/bin/sh"],
-        env={"TERM": "xterm-256color"},
-        created_by="127.0.0.1",
-        origin="http://localhost:3000",
-        owner_token_hash="token-hash",
-        buffer_size=2,
-        max_buffer_bytes=4096,
-    )
+    session = _session(buffer_size=2, max_buffer_bytes=4096)
 
     first = {"type": "output", "data": "first"}
     second = {"type": "output", "data": "second"}
@@ -178,6 +249,297 @@ def test_append_to_buffer_accounts_for_deque_auto_eviction() -> None:
 
     assert [event for event, _ in session._buffer] == [second, third]
     assert session._buffer_bytes == second_size + third_size
+
+
+@pytest.mark.anyio
+async def test_terminal_session_publish_buffer_response_and_subscribers() -> None:
+    session = _session(buffer_size=10, max_buffer_bytes=300)
+    session.exit_code = 0
+    response = session.to_response()
+    assert response["session_id"] == "terminal-1"
+    assert response["exit_code"] == 0
+
+    await session._publish_output("stdout", b"hello")
+    queue, replay = session.subscribe()
+    assert replay[-1]["data"] == "hello"
+
+    class BadQueue:
+        def put_nowait(self, event: dict[str, object]) -> None:
+            raise RuntimeError("closed")
+
+    bad_queue = BadQueue()
+    session._subscribers.add(bad_queue)  # type: ignore[arg-type]
+    await session._publish({"type": "notice", "message": "world"})
+    assert await queue.get() == {"type": "notice", "message": "world"}
+    assert bad_queue not in session._subscribers
+    session.unsubscribe(queue)
+    assert queue not in session._subscribers
+
+    session._append_to_buffer({"type": "output", "data": "x" * 400}, 528)
+    assert session._buffer_bytes <= session._max_buffer_bytes
+    assert session._estimate_event_size({"type": "status", "status": "running"}) == 256
+
+
+@pytest.mark.anyio
+async def test_terminal_session_start_write_resize_and_error_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _session()
+    published: list[dict[str, object]] = []
+
+    async def fake_publish(event: dict[str, object]) -> None:
+        published.append(event)
+
+    async def fake_start_posix() -> None:
+        session._master_fd = 99
+
+    monkeypatch.setattr(session, "_publish", fake_publish)
+    monkeypatch.setattr(session, "_start_posix", fake_start_posix)
+    monkeypatch.setattr(terminal_service, "is_windows", lambda: False)
+
+    await session.start()
+    await session.start()
+    assert session.status == "running"
+    assert [event["status"] for event in published if event["type"] == "status"] == [
+        "starting",
+        "running",
+    ]
+
+    written: list[tuple[int, bytes]] = []
+    monkeypatch.setattr(
+        terminal_service.os,
+        "write",
+        lambda fd, data: written.append((fd, data)) or len(data),
+    )
+    await session.write("")
+    await session.write("abc")
+    assert written == [(99, b"abc")]
+
+    import fcntl
+
+    resized: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        fcntl,
+        "ioctl",
+        lambda fd, request, data: resized.append((fd, len(data))),
+    )
+    await session.resize(0, 0)
+    assert resized == [(99, 8)]
+
+    error_session = _session(session_id="terminal-error")
+
+    async def failing_start() -> None:
+        raise RuntimeError("spawn failed")
+
+    monkeypatch.setattr(error_session, "_start_posix", failing_start)
+    monkeypatch.setattr(error_session, "_publish", fake_publish)
+    with pytest.raises(RuntimeError, match="spawn failed"):
+        await error_session.start()
+    assert error_session.status == "error"
+    assert error_session.exit_code == -1
+
+
+@pytest.mark.anyio
+async def test_terminal_windows_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeStdin:
+        def __init__(self) -> None:
+            self.data = b""
+
+        def write(self, data: bytes) -> None:
+            self.data += data
+
+        async def drain(self) -> None:
+            return None
+
+    class FakeStdout:
+        def __init__(self, chunks: list[bytes]) -> None:
+            self.chunks = chunks
+
+        async def read(self, size: int) -> bytes:
+            return self.chunks.pop(0) if self.chunks else b""
+
+    class FakeWindowsProcess:
+        def __init__(self) -> None:
+            self.stdin = FakeStdin()
+            self.stdout = FakeStdout([b"win-out", b""])
+            self.terminated = False
+            self.killed = False
+            self.wait_calls = 0
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def kill(self) -> None:
+            self.killed = True
+
+        async def wait(self) -> int:
+            self.wait_calls += 1
+            return 7
+
+    monkeypatch.setattr(
+        terminal_service.asyncio.subprocess, "Process", FakeWindowsProcess
+    )
+    monkeypatch.setattr(terminal_service, "is_windows", lambda: True)
+
+    created_process = FakeWindowsProcess()
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        return created_process
+
+    created_coros = []
+
+    def fake_create_task(coro):
+        created_coros.append(coro)
+        coro.close()
+        return SimpleNamespace(cancel=lambda: None)
+
+    monkeypatch.setattr(
+        terminal_service.asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+    )
+    monkeypatch.setattr(terminal_service.asyncio, "create_task", fake_create_task)
+
+    session = _session(command=["cmd"])
+    await session._start_windows()
+    assert session._process is created_process
+    assert len(created_coros) == 2
+
+    session.status = "running"
+    await session.write("hello")
+    assert created_process.stdin.data == b"hello"
+
+    output: list[tuple[str, bytes]] = []
+
+    async def fake_publish_output(stream: str, chunk: bytes) -> bool:
+        output.append((stream, chunk))
+        return True
+
+    monkeypatch.setattr(session, "_publish_output", fake_publish_output)
+    await session._read_windows_output()
+    assert output == [("stdout", b"win-out")]
+
+    exit_events: list[dict[str, object]] = []
+
+    async def fake_publish(event: dict[str, object]) -> None:
+        exit_events.append(event)
+
+    async def fake_finalize() -> None:
+        session.status = "closed"
+
+    monkeypatch.setattr(session, "_publish", fake_publish)
+    monkeypatch.setattr(session, "_finalize_close", fake_finalize)
+    session.status = "running"
+    await session._wait_for_process()
+    assert session.exit_code == 7
+    assert exit_events == [{"type": "exit", "exit_code": 7}]
+
+    async def timeout_wait_for(awaitable, timeout):
+        awaitable.close()
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(terminal_service.asyncio, "wait_for", timeout_wait_for)
+    await session._terminate_process()
+    assert created_process.terminated is True
+    assert created_process.killed is True
+
+
+@pytest.mark.anyio
+async def test_terminal_posix_start_read_wait_terminate_and_finalize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakePosixProcess:
+        def __init__(self, *args, **kwargs) -> None:
+            self.pid = 4321
+            self.wait_calls = 0
+
+        def wait(self) -> int:
+            self.wait_calls += 1
+            return 3
+
+    import pty
+
+    monkeypatch.setattr(terminal_service.subprocess, "Popen", FakePosixProcess)
+    monkeypatch.setattr(terminal_service, "is_windows", lambda: False)
+    monkeypatch.setattr(pty, "openpty", lambda: (201, 202))
+
+    closed_fds: list[int] = []
+    monkeypatch.setattr(terminal_service.os, "close", lambda fd: closed_fds.append(fd))
+
+    created_coros = []
+    original_create_task = asyncio.create_task
+
+    def fake_create_task(coro):
+        created_coros.append(coro)
+        coro.close()
+        return SimpleNamespace(cancel=lambda: None)
+
+    monkeypatch.setattr(terminal_service.asyncio, "create_task", fake_create_task)
+
+    session = _session()
+    await session._start_posix()
+    assert session._master_fd == 201
+    assert isinstance(session._process, FakePosixProcess)
+    assert closed_fds == [202]
+    assert len(created_coros) == 2
+
+    reads = iter([b"abc", b""])
+
+    async def fake_to_thread(func, *args):
+        if func is terminal_service.os.read:
+            return next(reads)
+        return func(*args)
+
+    output: list[bytes] = []
+
+    async def fake_publish_output(stream: str, chunk: bytes) -> bool:
+        output.append(chunk)
+        return True
+
+    monkeypatch.setattr(terminal_service.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(session, "_publish_output", fake_publish_output)
+    await session._read_posix_output()
+    assert output == [b"abc"]
+
+    exit_events: list[dict[str, object]] = []
+
+    async def fake_publish(event: dict[str, object]) -> None:
+        exit_events.append(event)
+
+    async def fake_finalize() -> None:
+        session.status = "closed"
+
+    monkeypatch.setattr(session, "_publish", fake_publish)
+    monkeypatch.setattr(session, "_finalize_close", fake_finalize)
+    session.status = "running"
+    await session._wait_for_process()
+    assert session.exit_code == 3
+    assert exit_events == [{"type": "exit", "exit_code": 3}]
+
+    killed: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        terminal_service.os, "killpg", lambda pid, sig: killed.append((pid, sig))
+    )
+
+    async def timeout_wait_for(awaitable, timeout):
+        awaitable.close()
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(terminal_service.asyncio, "wait_for", timeout_wait_for)
+    await session._terminate_process()
+    assert killed == [
+        (4321, terminal_service.signal.SIGTERM),
+        (4321, terminal_service.signal.SIGKILL),
+    ]
+
+    task_session = _session()
+    task_session.status = "running"
+    task_session._master_fd = 303
+    task_session._reader_task = original_create_task(asyncio.sleep(10))
+    task_session._wait_task = original_create_task(asyncio.sleep(10))
+    await task_session._finalize_close()
+    assert task_session.status == "closed"
+    assert task_session._reader_task is None
+    assert task_session._wait_task is None
+    assert task_session._master_fd is None
 
 
 @pytest.mark.anyio

--- a/tests/test_version_api.py
+++ b/tests/test_version_api.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import urllib.error
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -29,6 +32,8 @@ def test_parse_version_handles_common_formats() -> None:
     assert version_api.parse_version("1.2.3") == (1, 2, 3)
     assert version_api.parse_version("v2.0.1") == (2, 0, 1)
     assert version_api.parse_version("3.4.5-beta") == (3, 4, 5)
+    assert version_api.parse_version("4.5.6+build") == (4, 5, 6)
+    assert version_api.parse_version("not-a-version") is None
     assert version_api.parse_version("dev") is None
 
 
@@ -36,6 +41,81 @@ def test_compare_versions() -> None:
     assert version_api.compare_versions("1.0.0", "1.0.1") is True
     assert version_api.compare_versions("1.0.0", "1.0.0") is False
     assert version_api.compare_versions("dev", "9.9.9") is False
+
+
+def test_fetch_latest_release_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResponse:
+        def __enter__(self) -> "FakeResponse":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps({"tag_name": "v1.2.3"}).encode("utf-8")
+
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(request, timeout: int) -> FakeResponse:
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(version_api.urllib.request, "urlopen", fake_urlopen)
+
+    assert version_api.fetch_latest_release() == {"tag_name": "v1.2.3"}
+    assert captured["timeout"] == 10
+    assert captured["request"].headers["User-agent"].startswith("AutoGLM-GUI/")
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        urllib.error.HTTPError(
+            version_api.GITHUB_API_URL,
+            403,
+            "rate limited",
+            hdrs=None,
+            fp=None,
+        ),
+        urllib.error.HTTPError(
+            version_api.GITHUB_API_URL,
+            500,
+            "server error",
+            hdrs=None,
+            fp=None,
+        ),
+        urllib.error.URLError("offline"),
+        RuntimeError("unexpected"),
+    ],
+)
+def test_fetch_latest_release_error_paths(
+    monkeypatch: pytest.MonkeyPatch, error: Exception
+) -> None:
+    def fake_urlopen(request, timeout: int):
+        raise error
+
+    monkeypatch.setattr(version_api.urllib.request, "urlopen", fake_urlopen)
+
+    assert version_api.fetch_latest_release() is None
+
+
+def test_fetch_latest_release_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResponse:
+        def __enter__(self) -> "FakeResponse":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b"{bad-json"
+
+    monkeypatch.setattr(
+        version_api.urllib.request, "urlopen", lambda request, timeout: FakeResponse()
+    )
+
+    assert version_api.fetch_latest_release() is None
 
 
 def test_version_endpoint_success(


### PR DESCRIPTION
## Summary
- Raise Python test coverage from the initial local 58% baseline to a local reference of 86%.
- Add focused fake-backed coverage for parsers/file managers, optional agent adapters, adb/scrcpy hardware boundaries, terminal/session orchestration, Socket.IO streaming, QR pairing, ADB helper utilities, and service/manager workflows.
- Merge latest main so the PR branch matches the remote pull_request merge environment, including Gemini reasoning-content handling.
- Keep tests isolated from real devices, real model calls, and external network calls by using monkeypatch/fake subprocess, socket, process, and client objects.

## Local verification
- uv run python scripts/lint.py --backend --check-only
- uv run pytest --cov=AutoGLM_GUI --cov-report=term-missing --cov-report=xml

Latest local coverage reference: 488 passed, 2 skipped; TOTAL 11007 statements / 1594 missed, reported as 86%.

Remote source of truth: Python Coverage passed on commit 2d99c3a with 517 passed, 1 skipped; TOTAL 11051 statements / 1602 missed, reported as 86%.
