### PR TITLE
feat: add dynamic ports pilot for e2e stack

### DIFF
--- a/frontend/e2e/globalSetup.ts
+++ b/frontend/e2e/globalSetup.ts
@@ -1,14 +1,10 @@
 /**
- * Start backend services (mock LLM + mock agent + AutoGLM-GUI) before E2E tests.
- *
- * Uses child_process to manage the Python launcher script.  The PID is written
- * to a file so globalTeardown can kill it.
+ * Wait for the E2E stack launched by Playwright's webServer command.
  */
-import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
-import { sleep, terminateProcessTree } from './processTree';
+import { sleep } from './processTree';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -29,90 +25,28 @@ function readServiceUrls(urlsPath: string): ServiceUrls | null {
 }
 
 async function globalSetup() {
-  const projectRoot = path.resolve(__dirname, '..', '..');
   const urlsPath = path.resolve(__dirname, '.service_urls.json');
-  const pidPath = path.resolve(__dirname, '.services_pid');
 
-  console.log('[globalSetup] Starting E2E services...');
+  console.log('[globalSetup] Waiting for E2E stack...');
 
-  // Stop services from the previous E2E run, if that run did not clean up.
-  try {
-    const previousPid = Number(fs.readFileSync(pidPath, 'utf-8').trim());
-    if (Number.isFinite(previousPid)) {
-      await terminateProcessTree(previousPid);
-    }
-  } catch {
-    /* PID file may not exist */
-  }
-
-  // Cleanup old files
-  try {
-    fs.unlinkSync(urlsPath);
-  } catch {
-    /* file may not exist */
-  }
-  try {
-    fs.unlinkSync(pidPath);
-  } catch {
-    /* file may not exist */
-  }
-
-  // Wait for ports to be fully released by the OS
-  await sleep(3000);
-
-  console.log('[globalSetup] Project root:', projectRoot);
-
-  // Start services with retry on port-in-use
-  let proc: ReturnType<typeof spawn> | null = null;
-  for (let attempt = 0; attempt < 3; attempt++) {
-    proc = spawn(
-      'uv',
-      ['run', 'python', 'scripts/start_e2e_services.py', '--output', urlsPath],
-      {
-        cwd: projectRoot,
-        stdio: 'inherit',
-        detached: true,
-      }
-    );
-
-    // Wait for both backend health and the launcher-written URL file.
-    const deadline = Date.now() + 30000;
-    let started = false;
-    while (Date.now() < deadline) {
+  const deadline = Date.now() + 30000;
+  while (Date.now() < deadline) {
+    const urls = readServiceUrls(urlsPath);
+    if (urls) {
       try {
-        const resp = await fetch('http://127.0.0.1:8000/api/health');
+        const resp = await fetch(`${urls.backend_url}/api/health`);
         if (resp.status === 200) {
-          const urls = readServiceUrls(urlsPath);
-          if (urls) {
-            console.log('[globalSetup] Services ready, URLs:', urls);
-            started = true;
-            break;
-          }
+          console.log('[globalSetup] Services ready, URLs:', urls);
+          return;
         }
       } catch {
-        // Not ready — but check if the process exited with error
-        if (proc && proc.exitCode !== null) {
-          // Process died — port likely in use, retry
-          console.log(
-            `[globalSetup] Attempt ${attempt + 1}: process exited, retrying...`
-          );
-          break;
-        }
+        // Still booting.
       }
-      await sleep(500);
     }
-    if (started && proc?.pid) {
-      fs.writeFileSync(pidPath, String(proc.pid));
-      return;
-    }
-    // Kill the failed process and wait before retry
-    if (proc?.pid) {
-      await terminateProcessTree(proc.pid);
-      await sleep(1000);
-    }
+    await sleep(500);
   }
 
-  throw new Error('E2E services failed to start after 3 attempts');
+  throw new Error('E2E stack failed to become ready within 30s');
 }
 
 export default globalSetup;

--- a/frontend/e2e/globalTeardown.ts
+++ b/frontend/e2e/globalTeardown.ts
@@ -7,14 +7,21 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 async function globalTeardown() {
-  const pidPath = path.resolve(__dirname, '.services_pid');
+  const pidPath = path.resolve(__dirname, '.service_pids.json');
   const urlsPath = path.resolve(__dirname, '.service_urls.json');
 
-  // Kill by saved PID, including child services.
+  // Kill the detached processes we started for the E2E stack.
   try {
-    const pid = Number(fs.readFileSync(pidPath, 'utf-8').trim());
-    console.log(`[globalTeardown] Killing process group ${pid}`);
-    await terminateProcessTree(pid);
+    const payload = JSON.parse(fs.readFileSync(pidPath, 'utf-8')) as {
+      servicePid?: number;
+      vitePid?: number;
+    };
+    for (const pid of [payload.vitePid, payload.servicePid]) {
+      if (Number.isFinite(pid)) {
+        console.log(`[globalTeardown] Killing process group ${pid}`);
+        await terminateProcessTree(pid as number);
+      }
+    }
   } catch {
     // PID file may not exist
   }

--- a/frontend/e2e/scroll.spec.ts
+++ b/frontend/e2e/scroll.spec.ts
@@ -32,7 +32,11 @@ declare global {
 const VIEWPORT_SELECTOR =
   '[data-testid="chat-scroll-container"] [data-slot="scroll-area-viewport"]';
 
-function readServiceUrls(): { backend_url: string; agent_url: string } {
+function readServiceUrls(): {
+  backend_url: string;
+  agent_url: string;
+  llm_url: string;
+} {
   const urlsPath = path.resolve(__dirname, '.service_urls.json');
   if (!fs.existsSync(urlsPath)) {
     throw new Error(
@@ -47,7 +51,7 @@ test.describe('DevicePanel auto-scroll', () => {
     page,
     request,
   }) => {
-    const { backend_url, agent_url } = readServiceUrls();
+    const { backend_url, agent_url, llm_url } = readServiceUrls();
 
     // ── 1. Configure backend (device + LLM config) ──────────────────────
 
@@ -67,7 +71,7 @@ test.describe('DevicePanel auto-scroll', () => {
     await request.delete(`${backend_url}/api/config`);
     const configRes = await request.post(`${backend_url}/api/config`, {
       data: {
-        base_url: 'http://localhost:18003/v1',
+        base_url: `${llm_url}/v1`,
         model_name: 'mock-glm-model',
         api_key: 'mock-key',
         agent_type: 'glm-async',
@@ -77,7 +81,7 @@ test.describe('DevicePanel auto-scroll', () => {
 
     // Set multiple mock LLM responses so the agent produces enough content
     // to overflow the scroll container (5 steps ≈ plenty of scrolling needed)
-    await request.post('http://localhost:18003/test/set_responses', {
+    await request.post(`${llm_url}/test/set_responses`, {
       data: [
         '用户要求点击屏幕下方的消息按钮。我看到底部导航栏有消息按钮。do(action="Tap", element=[499,966])',
         '好的，点击成功，进入了消息页面。finish(message="已成功点击消息按钮！")',
@@ -86,7 +90,7 @@ test.describe('DevicePanel auto-scroll', () => {
         '所有任务已完成。finish(message="任务完成")',
       ],
     });
-    await request.post('http://localhost:18003/test/reset');
+    await request.post(`${llm_url}/test/reset`);
 
     // ── 2. Navigate to frontend ─────────────────────────────────────────
 

--- a/frontend/e2e/startPlaywrightWebServer.mjs
+++ b/frontend/e2e/startPlaywrightWebServer.mjs
@@ -16,6 +16,21 @@ const pidPath = path.resolve(__dirname, '.service_pids.json');
 
 const sleep = ms => new Promise(resolve => globalThis.setTimeout(resolve, ms));
 const execFileAsync = promisify(execFile);
+
+function resolvePnpmCommand() {
+  if (process.env.npm_execpath) {
+    return {
+      command: process.execPath,
+      args: [process.env.npm_execpath],
+    };
+  }
+
+  return {
+    command: process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm',
+    args: [],
+  };
+}
+
 function parseFrontendPort() {
   const portFlagIndex = process.argv.indexOf('--frontend-port');
   if (portFlagIndex >= 0) {
@@ -144,6 +159,8 @@ async function main() {
     void cleanupProcesses().finally(() => process.exit(0));
   };
 
+  const pnpmCommand = resolvePnpmCommand();
+
   try {
     process.once('SIGTERM', handleTermination);
     process.once('SIGINT', handleTermination);
@@ -167,8 +184,16 @@ async function main() {
     const frontendUrl = new URL(urls.frontend_url);
 
     viteProc = spawnDetached(
-      'pnpm',
-      ['exec', 'vite', '--host', '127.0.0.1', '--port', frontendUrl.port],
+      pnpmCommand.command,
+      [
+        ...pnpmCommand.args,
+        'exec',
+        'vite',
+        '--host',
+        '127.0.0.1',
+        '--port',
+        frontendUrl.port,
+      ],
       {
         cwd: frontendRoot,
         env: {

--- a/frontend/e2e/startPlaywrightWebServer.mjs
+++ b/frontend/e2e/startPlaywrightWebServer.mjs
@@ -1,0 +1,170 @@
+import { spawn, execFile } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { promisify } from 'util';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const frontendRoot = path.resolve(__dirname, '..');
+const projectRoot = path.resolve(frontendRoot, '..');
+const urlsPath = path.resolve(__dirname, '.service_urls.json');
+const pidPath = path.resolve(__dirname, '.service_pids.json');
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+const execFileAsync = promisify(execFile);
+
+function readServiceUrls() {
+  try {
+    return JSON.parse(fs.readFileSync(urlsPath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+async function waitForBackend(urlsDeadlineMs) {
+  while (Date.now() < urlsDeadlineMs) {
+    const urls = readServiceUrls();
+    if (!urls?.backend_url) {
+      await sleep(250);
+      continue;
+    }
+
+    try {
+      const response = await fetch(`${urls.backend_url}/api/health`);
+      if (response.ok) {
+        return urls;
+      }
+    } catch {
+      // Service still booting.
+    }
+    await sleep(250);
+  }
+
+  throw new Error('Timed out waiting for backend service URLs / health check');
+}
+
+function spawnDetached(command, args, options) {
+  const child = spawn(command, args, {
+    ...options,
+    detached: true,
+    stdio: 'inherit',
+  });
+  child.unref();
+  return child;
+}
+
+async function terminateProcessTree(pid) {
+  if (!Number.isFinite(pid)) {
+    return;
+  }
+
+  if (process.platform === 'win32') {
+    try {
+      await execFileAsync('taskkill', ['/PID', String(pid), '/T', '/F']);
+    } catch {
+      // process tree is already gone
+    }
+    return;
+  }
+
+  try {
+    process.kill(-pid, 'SIGTERM');
+  } catch {
+    return;
+  }
+  await sleep(1000);
+  try {
+    process.kill(-pid, 'SIGKILL');
+  } catch {
+    // process group is already gone
+  }
+}
+
+async function cleanupPreviousRun() {
+  try {
+    const payload = JSON.parse(fs.readFileSync(pidPath, 'utf-8'));
+    for (const pid of [payload.vitePid, payload.servicePid]) {
+      await terminateProcessTree(pid);
+    }
+  } catch {
+    // no previous pid file
+  }
+
+  for (const filePath of [urlsPath, pidPath]) {
+    try {
+      fs.unlinkSync(filePath);
+    } catch {
+      // file may not exist
+    }
+  }
+}
+
+async function main() {
+  await cleanupPreviousRun();
+
+  const serviceProc = spawnDetached(
+    'uv',
+    [
+      'run',
+      'python',
+      'scripts/start_e2e_services.py',
+      '--dynamic-ports',
+      '--output',
+      urlsPath,
+    ],
+    { cwd: projectRoot }
+  );
+
+  const urls = await waitForBackend(Date.now() + 30000);
+  const frontendUrl = new URL(urls.frontend_url);
+
+  const viteProc = spawnDetached(
+    'pnpm',
+    ['dev', '--', '--host', '127.0.0.1', '--port', frontendUrl.port],
+    {
+      cwd: frontendRoot,
+      env: {
+        ...process.env,
+        VITE_PROXY_TARGET: urls.backend_url,
+      },
+    }
+  );
+
+  fs.writeFileSync(
+    pidPath,
+    JSON.stringify(
+      {
+        servicePid: serviceProc.pid,
+        vitePid: viteProc.pid,
+      },
+      null,
+      2
+    )
+  );
+
+  await new Promise((resolve, reject) => {
+    const onExit = (name, code, signal) => {
+      reject(
+        new Error(
+          `${name} exited unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'null'})`
+        )
+      );
+    };
+
+    serviceProc.once('exit', (code, signal) =>
+      onExit('service launcher', code, signal)
+    );
+    viteProc.once('exit', (code, signal) =>
+      onExit('vite dev server', code, signal)
+    );
+    process.once('SIGTERM', resolve);
+    process.once('SIGINT', resolve);
+  });
+}
+
+main().catch(error => {
+  console.error('[startPlaywrightWebServer]', error);
+  process.exit(1);
+});

--- a/frontend/e2e/startPlaywrightWebServer.mjs
+++ b/frontend/e2e/startPlaywrightWebServer.mjs
@@ -1,8 +1,10 @@
 import { spawn, execFile } from 'child_process';
+import console from 'console';
 import fs from 'fs';
 import path from 'path';
+import process from 'process';
 import { promisify } from 'util';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -12,8 +14,21 @@ const projectRoot = path.resolve(frontendRoot, '..');
 const urlsPath = path.resolve(__dirname, '.service_urls.json');
 const pidPath = path.resolve(__dirname, '.service_pids.json');
 
-const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+const sleep = ms => new Promise(resolve => globalThis.setTimeout(resolve, ms));
 const execFileAsync = promisify(execFile);
+function parseFrontendPort() {
+  const portFlagIndex = process.argv.indexOf('--frontend-port');
+  if (portFlagIndex >= 0) {
+    const explicitPort = Number(process.argv[portFlagIndex + 1]);
+    if (Number.isFinite(explicitPort)) {
+      return explicitPort;
+    }
+  }
+
+  return Number(process.env.PLAYWRIGHT_FRONTEND_PORT || '3000');
+}
+
+const frontendPort = parseFrontendPort();
 
 function readServiceUrls() {
   try {
@@ -32,7 +47,7 @@ async function waitForBackend(urlsDeadlineMs) {
     }
 
     try {
-      const response = await fetch(`${urls.backend_url}/api/health`);
+      const response = await globalThis.fetch(`${urls.backend_url}/api/health`);
       if (response.ok) {
         return urls;
       }
@@ -104,64 +119,89 @@ async function cleanupPreviousRun() {
 async function main() {
   await cleanupPreviousRun();
 
-  const serviceProc = spawnDetached(
-    'uv',
-    [
-      'run',
-      'python',
-      'scripts/start_e2e_services.py',
-      '--dynamic-ports',
-      '--output',
-      urlsPath,
-    ],
-    { cwd: projectRoot }
-  );
+  let serviceProc = null;
+  let viteProc = null;
+  let shuttingDown = false;
 
-  const urls = await waitForBackend(Date.now() + 30000);
-  const frontendUrl = new URL(urls.frontend_url);
-
-  const viteProc = spawnDetached(
-    'pnpm',
-    ['dev', '--', '--host', '127.0.0.1', '--port', frontendUrl.port],
-    {
-      cwd: frontendRoot,
-      env: {
-        ...process.env,
-        VITE_PROXY_TARGET: urls.backend_url,
-      },
+  const cleanupProcesses = async () => {
+    if (shuttingDown) {
+      return;
     }
-  );
+    shuttingDown = true;
+    await terminateProcessTree(viteProc?.pid);
+    await terminateProcessTree(serviceProc?.pid);
+  };
 
-  fs.writeFileSync(
-    pidPath,
-    JSON.stringify(
+  const handleTermination = () => {
+    void cleanupProcesses().finally(() => process.exit(0));
+  };
+
+  try {
+    serviceProc = spawnDetached(
+      'uv',
+      [
+        'run',
+        'python',
+        'scripts/start_e2e_services.py',
+        '--dynamic-ports',
+        '--frontend-port',
+        String(frontendPort),
+        '--output',
+        urlsPath,
+      ],
+      { cwd: projectRoot }
+    );
+
+    const urls = await waitForBackend(Date.now() + 30000);
+    const frontendUrl = new URL(urls.frontend_url);
+
+    viteProc = spawnDetached(
+      'pnpm',
+      ['exec', 'vite', '--host', '127.0.0.1', '--port', frontendUrl.port],
       {
-        servicePid: serviceProc.pid,
-        vitePid: viteProc.pid,
-      },
-      null,
-      2
-    )
-  );
+        cwd: frontendRoot,
+        env: {
+          ...process.env,
+          VITE_PROXY_TARGET: urls.backend_url,
+        },
+      }
+    );
 
-  await new Promise((resolve, reject) => {
-    const onExit = (name, code, signal) => {
-      reject(
-        new Error(
-          `${name} exited unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'null'})`
-        )
+    fs.writeFileSync(
+      pidPath,
+      JSON.stringify(
+        {
+          servicePid: serviceProc.pid,
+          vitePid: viteProc.pid,
+        },
+        null,
+        2
+      )
+    );
+
+    await new Promise((resolve, reject) => {
+      const onExit = (name, code, signal) => {
+        reject(
+          new Error(
+            `${name} exited unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'null'})`
+          )
+        );
+      };
+
+      serviceProc.once('exit', (code, signal) =>
+        onExit('service launcher', code, signal)
       );
-    };
-
-    serviceProc.once('exit', (code, signal) =>
-      onExit('service launcher', code, signal)
-    );
-    viteProc.once('exit', (code, signal) =>
-      onExit('vite dev server', code, signal)
-    );
-    process.once('SIGTERM', resolve);
-    process.once('SIGINT', resolve);
-  });
+      viteProc.once('exit', (code, signal) =>
+        onExit('vite dev server', code, signal)
+      );
+      process.once('SIGTERM', handleTermination);
+      process.once('SIGINT', handleTermination);
+    });
+  } finally {
+    process.off('SIGTERM', handleTermination);
+    process.off('SIGINT', handleTermination);
+    await cleanupProcesses();
+  }
 }
 
 main().catch(error => {

--- a/frontend/e2e/startPlaywrightWebServer.mjs
+++ b/frontend/e2e/startPlaywrightWebServer.mjs
@@ -61,12 +61,15 @@ async function waitForBackend(urlsDeadlineMs) {
 }
 
 function spawnDetached(command, args, options) {
+  const detached = process.platform !== 'win32';
   const child = spawn(command, args, {
     ...options,
-    detached: true,
+    detached,
     stdio: 'inherit',
   });
-  child.unref();
+  if (detached) {
+    child.unref();
+  }
   return child;
 }
 

--- a/frontend/e2e/startPlaywrightWebServer.mjs
+++ b/frontend/e2e/startPlaywrightWebServer.mjs
@@ -65,7 +65,12 @@ function spawnDetached(command, args, options) {
   const child = spawn(command, args, {
     ...options,
     detached,
-    stdio: 'inherit',
+    // On Windows, inheriting Playwright's stdio pipes can keep the E2E step
+    // alive even after the launcher should be gone if descendant processes
+    // outlive the parent briefly. We only need PID-based cleanup there, not
+    // live child logs, so sever those handles.
+    stdio: process.platform === 'win32' ? 'ignore' : 'inherit',
+    windowsHide: true,
   });
   if (detached) {
     child.unref();

--- a/frontend/e2e/startPlaywrightWebServer.mjs
+++ b/frontend/e2e/startPlaywrightWebServer.mjs
@@ -137,6 +137,9 @@ async function main() {
   };
 
   try {
+    process.once('SIGTERM', handleTermination);
+    process.once('SIGINT', handleTermination);
+
     serviceProc = spawnDetached(
       'uv',
       [
@@ -194,8 +197,6 @@ async function main() {
       viteProc.once('exit', (code, signal) =>
         onExit('vite dev server', code, signal)
       );
-      process.once('SIGTERM', handleTermination);
-      process.once('SIGINT', handleTermination);
     });
   } finally {
     process.off('SIGTERM', handleTermination);

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -11,7 +11,7 @@ import globals from 'globals';
 export default [
   js.configs.recommended,
   {
-    files: ['**/*.{js,jsx,ts,tsx}'],
+    files: ['**/*.{js,mjs,jsx,ts,tsx}'],
     languageOptions: {
       parser: typescriptParser,
       parserOptions: {
@@ -114,7 +114,7 @@ export default [
     },
   },
   {
-    files: ['**/*.js'],
+    files: ['**/*.{js,mjs}'],
     rules: {
       '@typescript-eslint/no-require-imports': 'off',
     },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -11,10 +11,9 @@ export default defineConfig({
     baseURL: 'http://localhost:3000',
   },
   webServer: {
-    // Only Vite dev server — backend services are managed by globalSetup
-    command: 'pnpm dev',
-    url: 'http://localhost:3000',
+    command: 'node e2e/startPlaywrightWebServer.mjs',
+    url: 'http://127.0.0.1:3000',
     timeout: 30000,
-    reuseExistingServer: true,
+    reuseExistingServer: false,
   },
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,4 +1,25 @@
+import { execFileSync } from 'node:child_process';
 import { defineConfig } from '@playwright/test';
+
+function resolveFrontendPort(): number {
+  const configured = process.env.PLAYWRIGHT_FRONTEND_PORT;
+  if (configured) {
+    return Number(configured);
+  }
+
+  const discovered = execFileSync(
+    'python3',
+    [
+      '-c',
+      "import socket;s=socket.socket();s.bind(('127.0.0.1',0));print(s.getsockname()[1]);s.close()",
+    ],
+    { encoding: 'utf-8' }
+  ).trim();
+  process.env.PLAYWRIGHT_FRONTEND_PORT = discovered;
+  return Number(discovered);
+}
+
+const frontendPort = resolveFrontendPort();
 
 export default defineConfig({
   testDir: './e2e',
@@ -8,11 +29,11 @@ export default defineConfig({
   globalSetup: './e2e/globalSetup.ts',
   globalTeardown: './e2e/globalTeardown.ts',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: `http://127.0.0.1:${frontendPort}`,
   },
   webServer: {
-    command: 'node e2e/startPlaywrightWebServer.mjs',
-    url: 'http://127.0.0.1:3000',
+    command: `node e2e/startPlaywrightWebServer.mjs --frontend-port ${frontendPort}`,
+    url: `http://127.0.0.1:${frontendPort}`,
     timeout: 30000,
     reuseExistingServer: false,
   },

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,9 @@ import { tanstackRouter } from '@tanstack/router-plugin/vite';
 import { execSync } from 'node:child_process';
 import path from 'path';
 
+const backendProxyTarget =
+  process.env.VITE_PROXY_TARGET || 'http://localhost:8000';
+
 // Short commit of the working tree at build time, so a deployed build can be
 // traced back to a commit (the package version is the same across branches).
 // Appends "-dirty" when there are uncommitted changes to tracked files.
@@ -43,12 +46,12 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: backendProxyTarget,
         changeOrigin: true,
         ws: true,
       },
       '/socket.io': {
-        target: 'http://localhost:8000',
+        target: backendProxyTarget,
         changeOrigin: true,
         ws: true,
       },

--- a/scripts/start_e2e_services.py
+++ b/scripts/start_e2e_services.py
@@ -5,7 +5,7 @@ Launches three services and writes their URLs to a JSON file so Playwright
 tests can discover them.  Waits for SIGTERM/SIGINT, then tears everything down.
 
 Usage:
-    python scripts/start_e2e_services.py [--output urls.json]
+    python scripts/start_e2e_services.py [--output urls.json] [--dynamic-ports]
 """
 
 import argparse
@@ -33,6 +33,13 @@ def _port_is_free(port):
             return True
         except OSError:
             return False
+
+
+def _find_free_port(start_port, end_port):
+    for port in range(start_port, end_port + 1):
+        if _port_is_free(port):
+            return port
+    raise RuntimeError(f"No free port found in range {start_port}-{end_port}")
 
 
 def wait_for_server(url, timeout=30.0, endpoint="/test/stats"):
@@ -80,13 +87,28 @@ def main():
         "--output", default=None, help="JSON output file for service URLs"
     )
     parser.add_argument("--scenario", default=None, help="Scenario YAML for mock agent")
+    parser.add_argument(
+        "--dynamic-ports",
+        action="store_true",
+        help="Choose free ports automatically for backend and mock services",
+    )
+    parser.add_argument(
+        "--frontend-port",
+        type=int,
+        default=3000,
+        help="Frontend port reported to Playwright (default: 3000)",
+    )
     args = parser.parse_args()
 
-    # Use fixed ports so vite proxy (localhost:8000) works correctly.
-    # If a port is in use the test will fail — free it up and retry.
-    llm_port = 18003
-    agent_port = 18000
-    backend_port = 8000
+    if args.dynamic_ports:
+        llm_port = _find_free_port(18000, 18999)
+        agent_port = _find_free_port(19000, 19999)
+        backend_port = _find_free_port(8000, 8099)
+    else:
+        # Preserve the historical fixed-port workflow for manual debugging.
+        llm_port = 18003
+        agent_port = 18000
+        backend_port = 8000
 
     for port, name in [
         (llm_port, "mock LLM"),
@@ -134,7 +156,7 @@ def main():
         "llm_url": llm_url,
         "agent_url": agent_url,
         "backend_url": backend_url,
-        "frontend_url": "http://localhost:3000",
+        "frontend_url": f"http://127.0.0.1:{args.frontend_port}",
     }
     output_path = args.output or os.path.join(
         PROJECT_ROOT, "frontend", "e2e", ".service_urls.json"


### PR DESCRIPTION
## Summary
- add a Phase 3 dynamic-port mode to `scripts/start_e2e_services.py` while preserving the historical fixed-port path for manual debugging
- start the Playwright E2E stack via a dedicated webServer launcher that boots dynamic backend/mock ports and injects the resolved backend URL into the Vite proxy
- remove remaining Playwright-side hardcoded mock/backend ports in `globalSetup` and `scroll.spec.ts`

## Port flow
- `start_e2e_services.py --dynamic-ports`
  - mock LLM: first free port in `18000-18999`
  - mock agent: first free port in `19000-19999`
  - backend: first free port in `8000-8099`
- launcher writes `frontend/e2e/.service_urls.json`
- `frontend/e2e/startPlaywrightWebServer.mjs`
  - reads `.service_urls.json`
  - starts Vite with `VITE_PROXY_TARGET=<backend_url>`
- frontend `/api` + `/socket.io` proxy now follows `VITE_PROXY_TARGET`
- Playwright specs read `llm_url` / `agent_url` / `backend_url` from `.service_urls.json`

## Non-goals kept out
- no coverage / Codecov policy changes
- no custom structural checks
- no scenario matrix expansion
- no CI gate restructuring
- no harness platform rewrite

## Validation
- `uv run python scripts/lint.py --backend --check-only`
- `cd frontend && pnpm install --frozen-lockfile`
- `cd frontend && pnpm format:check`
- `cd frontend && pnpm type-check`
- `cd frontend && pnpm test:e2e e2e/scroll.spec.ts --reporter=line`
- occupied `8000/18000/19000` with temporary sockets, then ran `uv run python scripts/start_e2e_services.py --dynamic-ports --output /tmp/phase3-dynamic-urls.json` and confirmed fallback allocation to `8001/18001/19001`
