### PR TITLE
fix(frontend): fix layered mode cancel task

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   review:
+    # Forked pull_request runs are read-only and cannot access OIDC/secrets.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/AutoGLM_GUI/layered_agent_service.py
+++ b/AutoGLM_GUI/layered_agent_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import threading
 from collections.abc import AsyncIterator
@@ -462,6 +463,9 @@ class LayeredTaskRun:
             except StopAsyncIteration:
                 return None
 
+        next_task: asyncio.Task[Any] | None = None
+        cancel_task: asyncio.Task[None] | None = None
+
         try:
             with trace_span(
                 "layered.planner.stream",
@@ -668,6 +672,11 @@ class LayeredTaskRun:
                     "payload": {"message": str(exc)},
                 }
         finally:
+            for task in (next_task, cancel_task):
+                if task is not None and not task.done():
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
             with _active_runs_lock:
                 _active_runs.pop(self.task_id, None)
             self.finished = True

--- a/AutoGLM_GUI/layered_agent_service.py
+++ b/AutoGLM_GUI/layered_agent_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import json
 import threading
 from collections.abc import AsyncIterator
@@ -465,6 +466,7 @@ class LayeredTaskRun:
 
         next_task: asyncio.Task[Any] | None = None
         cancel_task: asyncio.Task[bool] | None = None
+        iterator: Any | None = None
 
         try:
             with trace_span(
@@ -679,6 +681,13 @@ class LayeredTaskRun:
                     task.cancel()
                     with contextlib.suppress(asyncio.CancelledError):
                         await task
+            if iterator is not None:
+                aclose = getattr(iterator, "aclose", None)
+                if callable(aclose):
+                    with contextlib.suppress(Exception):
+                        close_result = aclose()
+                        if inspect.isawaitable(close_result):
+                            await close_result
             with _active_runs_lock:
                 _active_runs.pop(self.task_id, None)
             self.finished = True

--- a/AutoGLM_GUI/layered_agent_service.py
+++ b/AutoGLM_GUI/layered_agent_service.py
@@ -464,7 +464,7 @@ class LayeredTaskRun:
                 return None
 
         next_task: asyncio.Task[Any] | None = None
-        cancel_task: asyncio.Task[None] | None = None
+        cancel_task: asyncio.Task[bool] | None = None
 
         try:
             with trace_span(
@@ -482,6 +482,8 @@ class LayeredTaskRun:
                     next_task = asyncio.create_task(get_next(iterator))
                     cancel_task = asyncio.create_task(self._cancel_event.wait())
 
+                    assert next_task is not None
+                    assert cancel_task is not None
                     done, pending = await asyncio.wait(
                         [next_task, cancel_task], return_when=asyncio.FIRST_COMPLETED
                     )

--- a/AutoGLM_GUI/layered_agent_service.py
+++ b/AutoGLM_GUI/layered_agent_service.py
@@ -412,18 +412,39 @@ class LayeredTaskRun:
     task_id: str
     session_id: str
     result: "RunResultStreaming"
+    device_id: str | None = None
     final_output: str = ""
     success: bool = False
     cancelled: bool = False
     finished: bool = False
     _current_tool_call: dict[str, Any] | None = field(default=None, init=False)
+    _cancel_event: asyncio.Event | None = field(default=None, init=False)
 
-    def cancel(self) -> None:
+    async def cancel(self) -> None:
         self.cancelled = True
-        self.result.cancel(mode="immediate")
+        if self._cancel_event is not None:
+            self._cancel_event.set()
+        if hasattr(self.result, "cancel"):
+            self.result.cancel(mode="immediate")
+        if self.device_id:
+            try:
+                from AutoGLM_GUI.phone_agent_manager import PhoneAgentManager
+
+                # 尝试中止可能正在运行的下层 Phone Agent
+                await PhoneAgentManager.get_instance().abort_streaming_chat_async(
+                    self.device_id
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[LayeredAgent] Failed to abort phone agent for device {self.device_id}: {e}"
+                )
 
     async def stream_events(self) -> AsyncIterator[dict[str, Any]]:
         from agents.stream_events import RawResponsesStreamEvent, RunItemStreamEvent
+
+        self._cancel_event = asyncio.Event()
+        if self.cancelled:
+            self._cancel_event.set()
 
         model_span: TraceSpan | None = None
         raw_event_count = 0
@@ -435,6 +456,12 @@ class LayeredTaskRun:
                 model_span = None
                 raw_event_count = 0
 
+        async def get_next(aiter: Any) -> Any:
+            try:
+                return await aiter.__anext__()
+            except StopAsyncIteration:
+                return None
+
         try:
             with trace_span(
                 "layered.planner.stream",
@@ -443,7 +470,28 @@ class LayeredTaskRun:
                     "session_id": self.session_id,
                 },
             ) as stream_span:
-                async for event in self.result.stream_events():
+                iterator = self.result.stream_events().__aiter__()
+                while True:
+                    if self.cancelled:
+                        break
+
+                    next_task = asyncio.create_task(get_next(iterator))
+                    cancel_task = asyncio.create_task(self._cancel_event.wait())
+
+                    done, pending = await asyncio.wait(
+                        [next_task, cancel_task],
+                        return_when=asyncio.FIRST_COMPLETED
+                    )
+
+                    if cancel_task in done:
+                        next_task.cancel()
+                        break
+
+                    cancel_task.cancel()
+                    event = next_task.result()
+                    if event is None:
+                        break
+
                     if isinstance(event, RawResponsesStreamEvent):
                         if model_span is None:
                             model_span = trace_span(
@@ -568,6 +616,15 @@ class LayeredTaskRun:
                             }
 
                 close_model_span()
+                if self.cancelled:
+                    self.final_output = "Task cancelled by user"
+                    self.success = False
+                    yield {
+                        "type": "cancelled",
+                        "payload": {"message": self.final_output},
+                    }
+                    return
+
                 self.final_output = (
                     self.result.final_output
                     if hasattr(self.result, "final_output")
@@ -718,6 +775,7 @@ def start_run(
     task_id: str,
     session_id: str,
     message: str,
+    device_id: str | None = None,
 ) -> LayeredTaskRun:
     agent = _ensure_agent()
     session = _get_or_create_session(session_id)
@@ -729,6 +787,7 @@ def start_run(
         attrs={
             "task_id": task_id,
             "session_id": session_id,
+            "device_id": device_id,
             "max_turns": resolved_max_turns,
             "message_preview": summarize_text(message, 512),
         },
@@ -747,14 +806,21 @@ def start_run(
         task_id=task_id,
         session_id=session_id,
         result=result,
+        device_id=device_id,
     )
 
 
-def cancel_task(task_id: str) -> bool:
+async def cancel_task(task_id: str) -> bool:
     with _active_runs_lock:
         result = _active_runs.get(task_id)
     if result is None:
         return False
-    result.cancel(mode="immediate")
+    
+    if hasattr(result, "cancel"):
+        if asyncio.iscoroutinefunction(result.cancel):
+            await result.cancel()
+        else:
+            result.cancel(mode="immediate")
+            
     logger.info(f"[LayeredAgent] Aborted task: {task_id}")
     return True

--- a/AutoGLM_GUI/layered_agent_service.py
+++ b/AutoGLM_GUI/layered_agent_service.py
@@ -479,8 +479,7 @@ class LayeredTaskRun:
                     cancel_task = asyncio.create_task(self._cancel_event.wait())
 
                     done, pending = await asyncio.wait(
-                        [next_task, cancel_task],
-                        return_when=asyncio.FIRST_COMPLETED
+                        [next_task, cancel_task], return_when=asyncio.FIRST_COMPLETED
                     )
 
                     if cancel_task in done:
@@ -815,12 +814,12 @@ async def cancel_task(task_id: str) -> bool:
         result = _active_runs.get(task_id)
     if result is None:
         return False
-    
+
     if hasattr(result, "cancel"):
         if asyncio.iscoroutinefunction(result.cancel):
             await result.cancel()
         else:
             result.cancel(mode="immediate")
-            
+
     logger.info(f"[LayeredAgent] Aborted task: {task_id}")
     return True

--- a/AutoGLM_GUI/task_manager.py
+++ b/AutoGLM_GUI/task_manager.py
@@ -764,6 +764,8 @@ class TaskManager:
                 final_message = "Task cancelled by user"
                 final_status = TaskStatus.CANCELLED.value
                 stop_reason = "user_stopped"
+            else:
+                raise
         except Exception as exc:
             if task_id in self._cancel_requested:
                 final_message = "Task cancelled by user"

--- a/AutoGLM_GUI/task_manager.py
+++ b/AutoGLM_GUI/task_manager.py
@@ -698,6 +698,7 @@ class TaskManager:
                     task_id=task_id,
                     session_id=session_id,
                     message=str(task["input_text"]),
+                    device_id=str(task["device_id"]),
                 )
                 self._abort_handlers[task_id] = run.cancel
 
@@ -746,12 +747,23 @@ class TaskManager:
                             event_payload.get("stop_reason", "user_stopped")
                         )
 
-            if not final_message:
+                if task_id in self._cancel_requested:
+                    final_message = "Task cancelled by user"
+                    final_status = TaskStatus.CANCELLED.value
+                    stop_reason = "user_stopped"
+
+            if not final_message and run:
                 final_message = run.final_output
+
             if not final_message:
                 final_message = "Task finished without a final response"
                 final_status = TaskStatus.FAILED.value
                 stop_reason = "error"
+        except asyncio.CancelledError:
+            if task_id in self._cancel_requested:
+                final_message = "Task cancelled by user"
+                final_status = TaskStatus.CANCELLED.value
+                stop_reason = "user_stopped"
         except Exception as exc:
             if task_id in self._cancel_requested:
                 final_message = "Task cancelled by user"

--- a/frontend/src/components/ChatKitPanel.tsx
+++ b/frontend/src/components/ChatKitPanel.tsx
@@ -216,6 +216,15 @@ function buildAssistantMessage(
     }
   }
 
+  // Override with task-level message if task is in terminal state to ensure
+  // cancellation/error messages are shown even if overridden by previous events
+  if (
+    (task.status === 'CANCELLED' || task.status === 'FAILED') &&
+    (task.final_message || task.error_message)
+  ) {
+    content = task.final_message || task.error_message || content;
+  }
+
   return {
     id: `${task.id}-agent`,
     role: 'assistant',
@@ -629,7 +638,6 @@ export function ChatKitPanel({
       console.error('Failed to submit layered task:', err);
       const errorMessage = getErrorMessage(err);
       setError(errorMessage);
-    } finally {
       setLoading(false);
       setAborting(false);
     }
@@ -644,6 +652,10 @@ export function ChatKitPanel({
     void (async () => {
       try {
         const response = await cancelTaskRun(taskId);
+        // Even if the backend still says RUNNING, we've sent the abort signal.
+        // To prevent the UI from flickering or showing the stop button again,
+        // we clear the current task ID immediately on successful request.
+        currentTaskIdRef.current = null;
         if (response.task) {
           taskRunsRef.current[taskId] = response.task;
           replaceTaskMessages();

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -269,7 +269,7 @@ def test_execute_layered_chat_counts_inner_steps_and_skips_legacy_history(
                 "payload": {"content": "已完成整理", "success": True},
             }
 
-    def fake_start_run(*, task_id: str, session_id: str, message: str) -> FakeRun:
+    def fake_start_run(*, task_id: str, session_id: str, message: str, device_id: str = "") -> FakeRun:
         return FakeRun()
 
     monkeypatch.setattr(layered_service, "start_run", fake_start_run)

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -269,7 +269,9 @@ def test_execute_layered_chat_counts_inner_steps_and_skips_legacy_history(
                 "payload": {"content": "已完成整理", "success": True},
             }
 
-    def fake_start_run(*, task_id: str, session_id: str, message: str, device_id: str = "") -> FakeRun:
+    def fake_start_run(
+        *, task_id: str, session_id: str, message: str, device_id: str = ""
+    ) -> FakeRun:
         return FakeRun()
 
     monkeypatch.setattr(layered_service, "start_run", fake_start_run)

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -324,6 +324,106 @@ def test_execute_layered_chat_counts_inner_steps_and_skips_legacy_history(
     assert legacy_history_calls == []
 
 
+def test_execute_layered_task_reraises_non_user_cancellation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import AutoGLM_GUI.layered_agent_service as layered_service
+
+    class FakeRun:
+        final_output = ""
+
+        async def cancel(self) -> None:
+            pass
+
+        async def stream_events(self):
+            raise asyncio.CancelledError
+            yield
+
+    def fake_start_run(
+        *, task_id: str, session_id: str, message: str, device_id: str = ""
+    ) -> FakeRun:
+        return FakeRun()
+
+    monkeypatch.setattr(layered_service, "start_run", fake_start_run)
+
+    async def scenario() -> None:
+        store = TaskStore(tmp_path / "tasks.db")
+        manager = TaskManager(store)
+        task = store.create_task_run(
+            source="chat",
+            executor_key="layered_chat",
+            device_id="device-a",
+            device_serial="serial-a",
+            input_text="cancelled by shutdown",
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await manager._execute_layered_task(
+                task,
+                session_id="session-a",
+                clear_session_after_run=False,
+                metrics_source="layered",
+            )
+
+        store.close()
+
+    asyncio.run(scenario())
+
+
+def test_layered_task_run_closes_stream_iterator_on_cancel() -> None:
+    import AutoGLM_GUI.layered_agent_service as layered_service
+
+    async def scenario() -> None:
+        closed = asyncio.Event()
+        started = asyncio.Event()
+
+        class BlockingIterator:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                started.set()
+                await asyncio.Event().wait()
+
+            async def aclose(self) -> None:
+                closed.set()
+
+        class FakeResult:
+            final_output = ""
+
+            def __init__(self) -> None:
+                self.iterator = BlockingIterator()
+
+            def cancel(self, mode: str = "immediate") -> None:
+                pass
+
+            def stream_events(self):
+                return self.iterator
+
+        run = layered_service.LayeredTaskRun(
+            task_id="task-close-stream",
+            session_id="session-a",
+            result=FakeResult(),
+        )
+        events: list[dict[str, object]] = []
+
+        async def consume_events() -> None:
+            async for event in run.stream_events():
+                events.append(event)
+
+        consumer = asyncio.create_task(consume_events())
+        await asyncio.wait_for(started.wait(), timeout=1)
+        await run.cancel()
+        await asyncio.wait_for(consumer, timeout=1)
+
+        assert closed.is_set()
+        assert events == [
+            {"type": "cancelled", "payload": {"message": "Task cancelled by user"}}
+        ]
+
+    asyncio.run(scenario())
+
+
 def test_submit_chat_task_uses_layered_executor_for_layered_sessions(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_trace_observability_integration.py
+++ b/tests/test_trace_observability_integration.py
@@ -195,6 +195,7 @@ def test_layered_task_trace_observability_covers_debug_surface(
         task_id: str,
         session_id: str,
         message: str,
+        device_id: str | None = None,
     ) -> layered_service.LayeredTaskRun:
         assert message == "打开微信，搜索张三，发送你好"
         with trace_span(
@@ -202,6 +203,7 @@ def test_layered_task_trace_observability_covers_debug_surface(
             attrs={
                 "task_id": task_id,
                 "session_id": session_id,
+                "device_id": device_id,
                 "max_turns": 100000,
             },
         ):
@@ -209,6 +211,7 @@ def test_layered_task_trace_observability_covers_debug_surface(
                 task_id=task_id,
                 session_id=session_id,
                 result=_FakePlannerStreamingResult("adb-debug-device"),
+                device_id=device_id,
             )
 
     monkeypatch.setattr(layered_service, "start_run", fake_start_run)


### PR DESCRIPTION
## 改动说明

在【分层代理】模式下，用户点击中止按钮后存在以下问题：
1. 任务并没有真正终止，后端网络 I/O (大模型调用或设备执行) 依然在阻塞等待中。
2. 由于阻塞，任务在数据库中的状态始终保持 RUNNING 。
3. 页面没有输出 “Task cancelled by user” 提示。
4. 切换到经典模式会提示“Waiting for device...”；再切回分层代理时，中止按钮会再次出现（幽灵按钮）。

修改点总结 (Changes) 
1. 后端底层阻塞强中断 (Backend Async Interruption)
- 引入 asyncio.Event 打断阻塞 : 重构了 layered_agent_service.py 中的 LayeredTaskRun.stream_events 逻辑。利用 asyncio.wait 配合 FIRST_COMPLETED 策略，让事件流在等待下一次响应时，也能同时监听中止信号 ( _cancel_event )，实现对网络/设备阻塞的瞬间打断。
- 底层设备释放 : 将 LayeredTaskRun.cancel() 升级为异步方法，确保在中止分层代理时，能正确 await 到底层 PhoneAgentManager 的 abort 逻辑，及时释放设备锁。

2. 后端状态及事件传播 (Backend State Propagation)
- 取消事件抛出 : 阻塞被打断后，立即主动向流中 yield 出 {"type": "cancelled", "payload": {"message": "Task cancelled by user"}} 事件。
- 取消异常捕获 : 在 task_manager.py 的 _execute_layered_task 中，增加了对 asyncio.CancelledError 的显式捕获，确保因中止引发的异常能被正确收尾，任务状态能被硬性标记为 CANCELLED 并落库。

3. 前端 UI 交互与渲染修复 (Frontend State Synchronization)
- 去除过早的 Loading 重置 : 移除了 ChatKitPanel.tsx 发送消息 handleSend 中不恰当的 finally 块（该块曾导致中止按钮还未显示就消失）。
- 立即清理活跃任务 : 在 handleAbort 请求成功后，立即清理 currentTaskIdRef.current = null ，避免因后端状态同步延迟导致的 UI 闪烁和幽灵按钮。
- 强化终端消息显示 : 优化了消息构建逻辑，当检测到任务处于 CANCELLED 状态时，强制渲染 Task 级别的 final_message ，确保 “Task cancelled by user” 稳定输出，不被历史事件覆盖。


## 相关 Issue
#351 

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 代码重构
- [ ] 性能优化
- [ ] 其他（请说明）

## 测试说明
1. 进入【分层代理】模式，发送一条需要较长时间执行的任务。
2. 在任务执行期间点击“中止”按钮。
3. 预期结果1 : 任务瞬间停止，对话气泡中立即输出 “Task cancelled by user.”。
4. 预期结果2 : 发送框的停止按钮立即变回发送按钮，且不再出现。
5. 预期结果3 : 切换到【经典模式】Tag，输入框可用，不会出现“Waiting for device...”；再切回【分层代理】Tag，状态依然保持正常，不出现幽灵停止按钮。

## 截图/录屏

<img width="1059" height="1182" alt="image" src="https://github.com/user-attachments/assets/8a5793e1-79e0-4bbd-a87a-41cfcc691975" />

## 其他说明
- None