### PR TITLE
Improve model error diagnostics

### DIFF
--- a/AutoGLM_GUI/agents/gemini/async_agent.py
+++ b/AutoGLM_GUI/agents/gemini/async_agent.py
@@ -14,6 +14,11 @@ from AutoGLM_GUI.actions import ActionResult
 from AutoGLM_GUI.agents.base import AsyncAgentBase
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.model import MessageBuilder
+from AutoGLM_GUI.model.error_details import (
+    model_error_message,
+    serialize_model_error,
+    trace_error_attrs,
+)
 from AutoGLM_GUI.trace import summarize_text, trace_span
 
 from .action_mapper import InvalidToolCallError, tool_call_to_action
@@ -124,25 +129,45 @@ class AsyncGeminiAgent(AsyncAgentBase):
                     "message_count": len(self._context),
                 },
             ) as span:
-                (
-                    thinking,
-                    reasoning_content,
-                    tool_name,
-                    tool_args,
-                ) = await self._call_llm_with_tools()
-                span.set_attributes(
-                    {
-                        "thinking_chars": len(thinking),
-                        "reasoning_content_present": bool(reasoning_content),
-                    }
-                )
+                try:
+                    (
+                        thinking,
+                        reasoning_content,
+                        tool_name,
+                        tool_args,
+                    ) = await self._call_llm_with_tools()
+                    span.set_attributes(
+                        {
+                            "thinking_chars": len(thinking),
+                            "reasoning_content_present": bool(reasoning_content),
+                        }
+                    )
+                except Exception as exc:
+                    error_details = serialize_model_error(
+                        exc,
+                        model_config=self.model_config,
+                        call_site="AutoGLM_GUI.agents.gemini.async_agent.AsyncGeminiAgent._call_llm_with_tools",
+                        include_traceback=self.agent_config.verbose,
+                    )
+                    span.set_attributes(trace_error_attrs(error_details))
+                    raise
         except asyncio.CancelledError:
             raise
         except Exception as e:
             logger.error(f"LLM error: {e}")
             if self.agent_config.verbose:
                 logger.debug(traceback.format_exc())
-            yield {"type": "error", "data": {"message": f"Model error: {e}"}}
+            error_details = serialize_model_error(
+                e,
+                model_config=self.model_config,
+                call_site="AutoGLM_GUI.agents.gemini.async_agent.AsyncGeminiAgent._call_llm_with_tools",
+                include_traceback=self.agent_config.verbose,
+            )
+            message = model_error_message(e)
+            yield {
+                "type": "error",
+                "data": {"message": message, "error_details": error_details},
+            }
             yield {
                 "type": "step",
                 "data": {
@@ -151,7 +176,8 @@ class AsyncGeminiAgent(AsyncAgentBase):
                     "action": None,
                     "success": False,
                     "finished": True,
-                    "message": f"Model error: {e}",
+                    "message": message,
+                    "error_details": error_details,
                 },
             }
             return

--- a/AutoGLM_GUI/agents/gemini/async_agent.py
+++ b/AutoGLM_GUI/agents/gemini/async_agent.py
@@ -147,7 +147,6 @@ class AsyncGeminiAgent(AsyncAgentBase):
                         exc,
                         model_config=self.model_config,
                         call_site="AutoGLM_GUI.agents.gemini.async_agent.AsyncGeminiAgent._call_llm_with_tools",
-                        include_traceback=self.agent_config.verbose,
                     )
                     span.set_attributes(trace_error_attrs(error_details))
                     raise
@@ -161,7 +160,6 @@ class AsyncGeminiAgent(AsyncAgentBase):
                 e,
                 model_config=self.model_config,
                 call_site="AutoGLM_GUI.agents.gemini.async_agent.AsyncGeminiAgent._call_llm_with_tools",
-                include_traceback=self.agent_config.verbose,
             )
             message = model_error_message(e)
             yield {

--- a/AutoGLM_GUI/agents/gemini/async_agent.py
+++ b/AutoGLM_GUI/agents/gemini/async_agent.py
@@ -16,7 +16,7 @@ from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.model import MessageBuilder
 from AutoGLM_GUI.model.error_details import (
     model_error_message,
-    serialize_model_error,
+    serialize_model_error_async,
     trace_error_attrs,
 )
 from AutoGLM_GUI.trace import summarize_text, trace_span
@@ -143,7 +143,7 @@ class AsyncGeminiAgent(AsyncAgentBase):
                         }
                     )
                 except Exception as exc:
-                    error_details = serialize_model_error(
+                    error_details = await serialize_model_error_async(
                         exc,
                         model_config=self.model_config,
                         call_site="AutoGLM_GUI.agents.gemini.async_agent.AsyncGeminiAgent._call_llm_with_tools",
@@ -156,7 +156,7 @@ class AsyncGeminiAgent(AsyncAgentBase):
             logger.error(f"LLM error: {e}")
             if self.agent_config.verbose:
                 logger.debug(traceback.format_exc())
-            error_details = serialize_model_error(
+            error_details = await serialize_model_error_async(
                 e,
                 model_config=self.model_config,
                 call_site="AutoGLM_GUI.agents.gemini.async_agent.AsyncGeminiAgent._call_llm_with_tools",

--- a/AutoGLM_GUI/agents/glm/async_agent.py
+++ b/AutoGLM_GUI/agents/glm/async_agent.py
@@ -15,7 +15,7 @@ from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.model import MessageBuilder
 from AutoGLM_GUI.model.error_details import (
     model_error_message,
-    serialize_model_error,
+    serialize_model_error_async,
     trace_error_attrs,
 )
 from AutoGLM_GUI.prompt_config import get_messages, get_system_prompt
@@ -196,7 +196,7 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
                 except Exception as exc:
                     if isinstance(exc, asyncio.CancelledError):
                         raise
-                    error_details = serialize_model_error(
+                    error_details = await serialize_model_error_async(
                         exc,
                         model_config=self.model_config,
                         call_site="AutoGLM_GUI.agents.glm.async_agent.AsyncGLMAgent._stream_openai",
@@ -214,7 +214,7 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
             logger.error(f"LLM error: {e}")
             if self.agent_config.verbose:
                 logger.debug(traceback.format_exc())
-            error_details = serialize_model_error(
+            error_details = await serialize_model_error_async(
                 e,
                 model_config=self.model_config,
                 call_site="AutoGLM_GUI.agents.glm.async_agent.AsyncGLMAgent._stream_openai",

--- a/AutoGLM_GUI/agents/glm/async_agent.py
+++ b/AutoGLM_GUI/agents/glm/async_agent.py
@@ -200,7 +200,6 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
                         exc,
                         model_config=self.model_config,
                         call_site="AutoGLM_GUI.agents.glm.async_agent.AsyncGLMAgent._stream_openai",
-                        include_traceback=self.agent_config.verbose,
                     )
                     span.set_attributes(trace_error_attrs(error_details))
                     raise
@@ -219,7 +218,6 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
                 e,
                 model_config=self.model_config,
                 call_site="AutoGLM_GUI.agents.glm.async_agent.AsyncGLMAgent._stream_openai",
-                include_traceback=self.agent_config.verbose,
             )
             message = model_error_message(e)
             yield {

--- a/AutoGLM_GUI/agents/glm/async_agent.py
+++ b/AutoGLM_GUI/agents/glm/async_agent.py
@@ -13,6 +13,11 @@ from AutoGLM_GUI.config import AgentConfig, ModelConfig
 from AutoGLM_GUI.device_protocol import DeviceProtocol
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.model import MessageBuilder
+from AutoGLM_GUI.model.error_details import (
+    model_error_message,
+    serialize_model_error,
+    trace_error_attrs,
+)
 from AutoGLM_GUI.prompt_config import get_messages, get_system_prompt
 from AutoGLM_GUI.trace import trace_span
 
@@ -171,22 +176,34 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
                     "model_name": self.model_config.model_name,
                     "message_count": len(self._context),
                 },
-            ):
-                async for chunk_data in self._stream_openai(self._context):
-                    if self._cancel_event.is_set():
-                        raise asyncio.CancelledError()
+            ) as span:
+                try:
+                    async for chunk_data in self._stream_openai(self._context):
+                        if self._cancel_event.is_set():
+                            raise asyncio.CancelledError()
 
-                    if chunk_data["type"] == "thinking":
-                        thinking_parts.append(chunk_data["content"])
-                        yield {
-                            "type": "thinking",
-                            "data": {"chunk": chunk_data["content"]},
-                        }
-                        if self.agent_config.verbose:
-                            logger.debug(chunk_data["content"])
+                        if chunk_data["type"] == "thinking":
+                            thinking_parts.append(chunk_data["content"])
+                            yield {
+                                "type": "thinking",
+                                "data": {"chunk": chunk_data["content"]},
+                            }
+                            if self.agent_config.verbose:
+                                logger.debug(chunk_data["content"])
 
-                    elif chunk_data["type"] == "raw":
-                        raw_content += chunk_data["content"]
+                        elif chunk_data["type"] == "raw":
+                            raw_content += chunk_data["content"]
+                except Exception as exc:
+                    if isinstance(exc, asyncio.CancelledError):
+                        raise
+                    error_details = serialize_model_error(
+                        exc,
+                        model_config=self.model_config,
+                        call_site="AutoGLM_GUI.agents.glm.async_agent.AsyncGLMAgent._stream_openai",
+                        include_traceback=self.agent_config.verbose,
+                    )
+                    span.set_attributes(trace_error_attrs(error_details))
+                    raise
 
             thinking = "".join(thinking_parts)
 
@@ -198,7 +215,17 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
             logger.error(f"LLM error: {e}")
             if self.agent_config.verbose:
                 logger.debug(traceback.format_exc())
-            yield {"type": "error", "data": {"message": f"Model error: {e}"}}
+            error_details = serialize_model_error(
+                e,
+                model_config=self.model_config,
+                call_site="AutoGLM_GUI.agents.glm.async_agent.AsyncGLMAgent._stream_openai",
+                include_traceback=self.agent_config.verbose,
+            )
+            message = model_error_message(e)
+            yield {
+                "type": "error",
+                "data": {"message": message, "error_details": error_details},
+            }
             yield {
                 "type": "step",
                 "data": {
@@ -207,7 +234,8 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
                     "action": None,
                     "success": False,
                     "finished": True,
-                    "message": f"Model error: {e}",
+                    "message": message,
+                    "error_details": error_details,
                 },
             }
             return

--- a/AutoGLM_GUI/layered_agent_service.py
+++ b/AutoGLM_GUI/layered_agent_service.py
@@ -18,7 +18,10 @@ from openai import AsyncOpenAI
 from AutoGLM_GUI.config import ModelConfig
 from AutoGLM_GUI.config_manager import config_manager
 from AutoGLM_GUI.logger import logger
-from AutoGLM_GUI.model.error_details import serialize_model_error, trace_error_attrs
+from AutoGLM_GUI.model.error_details import (
+    serialize_model_error_async,
+    trace_error_attrs,
+)
 from AutoGLM_GUI.trace import TraceSpan, summarize_text, trace_span
 
 if TYPE_CHECKING:
@@ -680,7 +683,7 @@ class LayeredTaskRun:
                     "payload": {"message": self.final_output},
                 }
             else:
-                error_details = serialize_model_error(
+                error_details = await serialize_model_error_async(
                     exc,
                     model_config=_planner_model_config(),
                     call_site="AutoGLM_GUI.layered_agent_service.LayeredTaskRun.stream_events",

--- a/AutoGLM_GUI/layered_agent_service.py
+++ b/AutoGLM_GUI/layered_agent_service.py
@@ -684,7 +684,6 @@ class LayeredTaskRun:
                     exc,
                     model_config=_planner_model_config(),
                     call_site="AutoGLM_GUI.layered_agent_service.LayeredTaskRun.stream_events",
-                    include_traceback=True,
                 )
                 if model_span is not None:
                     model_span.set_attributes(trace_error_attrs(error_details))

--- a/AutoGLM_GUI/layered_agent_service.py
+++ b/AutoGLM_GUI/layered_agent_service.py
@@ -15,8 +15,10 @@ from agents import Agent, Runner, SQLiteSession, function_tool
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from openai import AsyncOpenAI
 
+from AutoGLM_GUI.config import ModelConfig
 from AutoGLM_GUI.config_manager import config_manager
 from AutoGLM_GUI.logger import logger
+from AutoGLM_GUI.model.error_details import serialize_model_error, trace_error_attrs
 from AutoGLM_GUI.trace import TraceSpan, summarize_text, trace_span
 
 if TYPE_CHECKING:
@@ -202,6 +204,16 @@ def _setup_openai_client() -> AsyncOpenAI:
     return AsyncOpenAI(
         base_url=decision_base_url,
         api_key=decision_api_key or "EMPTY",
+    )
+
+
+def _planner_model_config() -> ModelConfig:
+    config_manager.load_file_config()
+    effective_config = config_manager.get_effective_config()
+    return ModelConfig(
+        base_url=effective_config.decision_base_url or "",
+        api_key=effective_config.decision_api_key or "EMPTY",
+        model_name=effective_config.decision_model_name or "",
     )
 
 
@@ -659,8 +671,8 @@ class LayeredTaskRun:
             self.cancelled = True
             raise
         except Exception as exc:
-            close_model_span()
             if self.cancelled:
+                close_model_span()
                 self.final_output = "Task cancelled by user"
                 self.success = False
                 yield {
@@ -668,12 +680,24 @@ class LayeredTaskRun:
                     "payload": {"message": self.final_output},
                 }
             else:
+                error_details = serialize_model_error(
+                    exc,
+                    model_config=_planner_model_config(),
+                    call_site="AutoGLM_GUI.layered_agent_service.LayeredTaskRun.stream_events",
+                    include_traceback=True,
+                )
+                if model_span is not None:
+                    model_span.set_attributes(trace_error_attrs(error_details))
+                close_model_span()
                 logger.exception(f"[LayeredAgent] Error: {exc}")
                 self.final_output = str(exc)
                 self.success = False
                 yield {
                     "type": "error",
-                    "payload": {"message": str(exc)},
+                    "payload": {
+                        "message": str(exc),
+                        "error_details": error_details,
+                    },
                 }
         finally:
             for task in (next_task, cancel_task):

--- a/AutoGLM_GUI/model/error_details.py
+++ b/AutoGLM_GUI/model/error_details.py
@@ -1,0 +1,129 @@
+"""Structured model error details for UI and trace diagnostics."""
+
+from __future__ import annotations
+
+import traceback
+from collections.abc import Mapping
+from typing import Any
+
+from openai import APIConnectionError, APIStatusError, APITimeoutError
+
+from AutoGLM_GUI.config import ModelConfig
+from AutoGLM_GUI.trace import summarize_text
+
+_REDACTED_HEADER_NAMES = {
+    "authorization",
+    "api-key",
+    "x-api-key",
+    "x-goog-api-key",
+    "cookie",
+    "set-cookie",
+}
+_MAX_BODY_CHARS = 20000
+
+
+def _redact_header_value(name: str, value: str) -> str:
+    if name.lower() in _REDACTED_HEADER_NAMES:
+        return "[REDACTED]"
+    return value
+
+
+def _headers_to_dict(headers: Any) -> dict[str, str]:
+    if headers is None:
+        return {}
+    if isinstance(headers, Mapping):
+        items = headers.items()
+    else:
+        try:
+            items = headers.items()
+        except AttributeError:
+            return {}
+    return {
+        str(key): _redact_header_value(str(key), str(value)) for key, value in items
+    }
+
+
+def _response_body_text(exc: APIStatusError) -> str | None:
+    body = getattr(exc, "body", None)
+    if body is not None:
+        return summarize_text(str(body), limit=_MAX_BODY_CHARS)
+
+    response = getattr(exc, "response", None)
+    if response is None:
+        return None
+    text = getattr(response, "text", None)
+    if text is None:
+        return None
+    return summarize_text(str(text), limit=_MAX_BODY_CHARS)
+
+
+def serialize_model_error(
+    exc: BaseException,
+    *,
+    model_config: ModelConfig,
+    call_site: str,
+    include_traceback: bool = False,
+) -> dict[str, Any]:
+    """Return UI/trace-safe structured details for model call failures."""
+    details: dict[str, Any] = {
+        "kind": "model_error",
+        "exception_type": exc.__class__.__name__,
+        "message": str(exc),
+        "model_name": model_config.model_name,
+        "base_url": model_config.base_url,
+        "call_site": call_site,
+    }
+
+    if isinstance(exc, APIStatusError):
+        response = getattr(exc, "response", None)
+        request_id = getattr(exc, "request_id", None)
+        if request_id is None and response is not None:
+            request_id = getattr(response, "headers", {}).get("x-request-id")
+        details.update(
+            {
+                "kind": "model_http_error",
+                "status_code": getattr(response, "status_code", None),
+                "request_id": request_id,
+                "response_headers": _headers_to_dict(
+                    getattr(response, "headers", None)
+                ),
+                "response_body": _response_body_text(exc),
+            }
+        )
+    elif isinstance(exc, APITimeoutError):
+        details["kind"] = "model_timeout"
+    elif isinstance(exc, APIConnectionError):
+        details["kind"] = "model_connection_error"
+
+    if include_traceback:
+        details["traceback"] = "".join(
+            traceback.format_exception(type(exc), exc, exc.__traceback__)
+        )
+
+    return {key: value for key, value in details.items() if value is not None}
+
+
+def model_error_message(exc: BaseException) -> str:
+    """Return the short message shown in existing compact task surfaces."""
+    return f"Model error: {exc}"
+
+
+def trace_error_attrs(details: dict[str, Any]) -> dict[str, Any]:
+    """Convert structured details into namespaced span attributes."""
+    attrs: dict[str, Any] = {
+        "error_kind": details.get("kind"),
+        "error_type": details.get("exception_type"),
+        "error_message": details.get("message"),
+        "model_name": details.get("model_name"),
+        "base_url": details.get("base_url"),
+        "call_site": details.get("call_site"),
+    }
+    if "status_code" in details:
+        attrs["http.status_code"] = details["status_code"]
+    if "request_id" in details:
+        attrs["http.request_id"] = details["request_id"]
+    if "response_headers" in details:
+        attrs["http.response_headers"] = details["response_headers"]
+    if "response_body" in details:
+        attrs["http.response_body"] = details["response_body"]
+    return {key: value for key, value in attrs.items() if value is not None}

--- a/AutoGLM_GUI/model/error_details.py
+++ b/AutoGLM_GUI/model/error_details.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
+import httpx
 from openai import APIConnectionError, APIStatusError, APITimeoutError
 
 from AutoGLM_GUI.config import ModelConfig
@@ -71,7 +72,16 @@ def _response_body_text(exc: APIStatusError) -> str | None:
     response = getattr(exc, "response", None)
     if response is None:
         return None
-    text = getattr(response, "text", None)
+    try:
+        text = getattr(response, "text", None)
+    except httpx.ResponseNotRead:
+        try:
+            response.read()
+            text = getattr(response, "text", None)
+        except (httpx.HTTPError, httpx.StreamError, RuntimeError):
+            return None
+    except (httpx.HTTPError, httpx.StreamError, RuntimeError):
+        return None
     if text is None:
         return None
     return summarize_text(str(text), limit=_MAX_BODY_CHARS)

--- a/AutoGLM_GUI/model/error_details.py
+++ b/AutoGLM_GUI/model/error_details.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import traceback
 from collections.abc import Mapping
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from openai import APIConnectionError, APIStatusError, APITimeoutError
 
@@ -20,6 +21,25 @@ _REDACTED_HEADER_NAMES = {
     "set-cookie",
 }
 _MAX_BODY_CHARS = 20000
+
+
+def _sanitize_base_url(base_url: str) -> str:
+    if not base_url:
+        return base_url
+    try:
+        parts = urlsplit(base_url)
+        port = parts.port
+    except ValueError:
+        return "[invalid-url]"
+
+    netloc = parts.netloc
+    if parts.hostname:
+        hostname = parts.hostname
+        if ":" in hostname and not hostname.startswith("["):
+            hostname = f"[{hostname}]"
+        netloc = f"{hostname}:{port}" if port is not None else hostname
+
+    return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
 
 
 def _redact_header_value(name: str, value: str) -> str:
@@ -70,7 +90,7 @@ def serialize_model_error(
         "exception_type": exc.__class__.__name__,
         "message": str(exc),
         "model_name": model_config.model_name,
-        "base_url": model_config.base_url,
+        "base_url": _sanitize_base_url(model_config.base_url),
         "call_site": call_site,
     }
 

--- a/AutoGLM_GUI/model/error_details.py
+++ b/AutoGLM_GUI/model/error_details.py
@@ -87,15 +87,44 @@ def _response_body_text(exc: APIStatusError) -> str | None:
     return summarize_text(str(text), limit=_MAX_BODY_CHARS)
 
 
-def serialize_model_error(
+async def _response_body_text_async(exc: APIStatusError) -> str | None:
+    body = getattr(exc, "body", None)
+    if body is not None:
+        return summarize_text(str(body), limit=_MAX_BODY_CHARS)
+
+    response = getattr(exc, "response", None)
+    if response is None:
+        return None
+    try:
+        text = getattr(response, "text", None)
+    except httpx.ResponseNotRead:
+        try:
+            await response.aread()
+        except RuntimeError:
+            try:
+                response.read()
+            except (httpx.HTTPError, httpx.StreamError, RuntimeError):
+                return None
+        except (httpx.HTTPError, httpx.StreamError):
+            return None
+        try:
+            text = getattr(response, "text", None)
+        except (httpx.HTTPError, httpx.StreamError, RuntimeError):
+            return None
+    except (httpx.HTTPError, httpx.StreamError, RuntimeError):
+        return None
+    if text is None:
+        return None
+    return summarize_text(str(text), limit=_MAX_BODY_CHARS)
+
+
+def _base_model_error_details(
     exc: BaseException,
     *,
     model_config: ModelConfig,
     call_site: str,
-    include_traceback: bool = False,
 ) -> dict[str, Any]:
-    """Return UI/trace-safe structured details for model call failures."""
-    details: dict[str, Any] = {
+    return {
         "kind": "model_error",
         "exception_type": exc.__class__.__name__,
         "message": str(exc),
@@ -104,33 +133,94 @@ def serialize_model_error(
         "call_site": call_site,
     }
 
-    if isinstance(exc, APIStatusError):
-        response = getattr(exc, "response", None)
-        request_id = getattr(exc, "request_id", None)
-        if request_id is None and response is not None:
-            request_id = getattr(response, "headers", {}).get("x-request-id")
-        details.update(
-            {
-                "kind": "model_http_error",
-                "status_code": getattr(response, "status_code", None),
-                "request_id": request_id,
-                "response_headers": _headers_to_dict(
-                    getattr(response, "headers", None)
-                ),
-                "response_body": _response_body_text(exc),
-            }
-        )
-    elif isinstance(exc, APITimeoutError):
-        details["kind"] = "model_timeout"
-    elif isinstance(exc, APIConnectionError):
-        details["kind"] = "model_connection_error"
 
+def _api_status_error_details(
+    exc: APIStatusError,
+    response_body: str | None,
+) -> dict[str, Any]:
+    response = getattr(exc, "response", None)
+    request_id = getattr(exc, "request_id", None)
+    if request_id is None and response is not None:
+        request_id = getattr(response, "headers", {}).get("x-request-id")
+    return {
+        "kind": "model_http_error",
+        "status_code": getattr(response, "status_code", None),
+        "request_id": request_id,
+        "response_headers": _headers_to_dict(getattr(response, "headers", None)),
+        "response_body": response_body,
+    }
+
+
+def _finalize_model_error_details(
+    details: dict[str, Any],
+    exc: BaseException,
+    *,
+    include_traceback: bool,
+) -> dict[str, Any]:
     if include_traceback:
         details["traceback"] = "".join(
             traceback.format_exception(type(exc), exc, exc.__traceback__)
         )
 
     return {key: value for key, value in details.items() if value is not None}
+
+
+def serialize_model_error(
+    exc: BaseException,
+    *,
+    model_config: ModelConfig,
+    call_site: str,
+    include_traceback: bool = False,
+) -> dict[str, Any]:
+    """Return UI/trace-safe structured details for model call failures."""
+    details = _base_model_error_details(
+        exc,
+        model_config=model_config,
+        call_site=call_site,
+    )
+
+    if isinstance(exc, APIStatusError):
+        details.update(_api_status_error_details(exc, _response_body_text(exc)))
+    elif isinstance(exc, APITimeoutError):
+        details["kind"] = "model_timeout"
+    elif isinstance(exc, APIConnectionError):
+        details["kind"] = "model_connection_error"
+
+    return _finalize_model_error_details(
+        details,
+        exc,
+        include_traceback=include_traceback,
+    )
+
+
+async def serialize_model_error_async(
+    exc: BaseException,
+    *,
+    model_config: ModelConfig,
+    call_site: str,
+    include_traceback: bool = False,
+) -> dict[str, Any]:
+    """Return structured model error details, reading async response streams."""
+    details = _base_model_error_details(
+        exc,
+        model_config=model_config,
+        call_site=call_site,
+    )
+
+    if isinstance(exc, APIStatusError):
+        details.update(
+            _api_status_error_details(exc, await _response_body_text_async(exc))
+        )
+    elif isinstance(exc, APITimeoutError):
+        details["kind"] = "model_timeout"
+    elif isinstance(exc, APIConnectionError):
+        details["kind"] = "model_connection_error"
+
+    return _finalize_model_error_details(
+        details,
+        exc,
+        include_traceback=include_traceback,
+    )
 
 
 def model_error_message(exc: BaseException) -> str:

--- a/AutoGLM_GUI/trace.py
+++ b/AutoGLM_GUI/trace.py
@@ -340,6 +340,8 @@ def _normalize_step_payload(
         "finished": _json_safe_value(payload.get("finished")),
         "message": _json_safe_value(payload.get("message")),
     }
+    if isinstance(payload.get("error_details"), dict):
+        result["error_details"] = _json_safe_value(payload.get("error_details"))
     return {
         "index": step_index,
         "agent_type": _json_safe_value(payload.get("agent_type")),

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -108,6 +108,21 @@ export interface StepTimingSummary {
   other_duration_ms: number;
 }
 
+export interface ModelErrorDetails {
+  kind?: string;
+  exception_type?: string;
+  message?: string;
+  model_name?: string;
+  base_url?: string;
+  call_site?: string;
+  status_code?: number;
+  request_id?: string;
+  response_headers?: Record<string, string>;
+  response_body?: string;
+  traceback?: string;
+  [key: string]: unknown;
+}
+
 export interface TraceTimingSummary {
   trace_id: string;
   steps: number;
@@ -133,6 +148,7 @@ export interface StepEvent {
   finished: boolean;
   screenshot?: string;
   timings?: StepTimingSummary;
+  error_details?: ModelErrorDetails;
 }
 
 export interface DoneEvent {
@@ -147,6 +163,7 @@ export interface ErrorEvent {
   type: 'error';
   role: 'assistant';
   message: string;
+  error_details?: ModelErrorDetails;
 }
 
 export interface CancelledEvent {

--- a/frontend/src/components/DevicePanel.tsx
+++ b/frontend/src/components/DevicePanel.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { DeviceMonitor } from './DeviceMonitor';
 import type {
+  ModelErrorDetails,
   StepTimingSummary,
   TaskImageAttachment,
   Workflow,
@@ -142,7 +143,7 @@ function getTimingChips(
 
   const chips = [
     { label: 'Total', value: formatDuration(timings.total_duration_ms) },
-    { label: 'Model', value: formatDuration(timings.llm_duration_ms) },
+    { label: 'LLM', value: formatDuration(timings.llm_duration_ms) },
   ];
 
   if (timings.screenshot_duration_ms > 0) {
@@ -174,6 +175,35 @@ function getTimingChips(
   }
 
   return chips;
+}
+
+function formatModelErrorDetails(details: ModelErrorDetails): string {
+  const ordered: Record<string, unknown> = {};
+  [
+    'kind',
+    'exception_type',
+    'message',
+    'status_code',
+    'request_id',
+    'model_name',
+    'base_url',
+    'call_site',
+    'response_headers',
+    'response_body',
+    'traceback',
+  ].forEach(key => {
+    if (details[key] !== undefined && details[key] !== null) {
+      ordered[key] = details[key];
+    }
+  });
+
+  Object.entries(details).forEach(([key, value]) => {
+    if (!(key in ordered) && value !== undefined && value !== null) {
+      ordered[key] = value;
+    }
+  });
+
+  return JSON.stringify(ordered, null, 2);
 }
 
 export function DevicePanel({
@@ -999,6 +1029,18 @@ export function DevicePanel({
                                 <p className="text-xs mt-2 opacity-60 text-slate-500 dark:text-slate-400">
                                   {message.steps} steps completed
                                 </p>
+                              )}
+                              {message.errorDetails && (
+                                <details className="mt-3 text-xs">
+                                  <summary className="cursor-pointer font-medium text-red-700 hover:text-red-800 dark:text-red-300 dark:hover:text-red-200 transition-colors">
+                                    Model error details
+                                  </summary>
+                                  <pre className="mt-2 max-h-80 overflow-auto rounded-lg border border-red-200 bg-white/80 p-3 text-left font-mono text-[11px] leading-relaxed text-slate-800 dark:border-red-900/60 dark:bg-slate-950/70 dark:text-slate-200">
+                                    {formatModelErrorDetails(
+                                      message.errorDetails
+                                    )}
+                                  </pre>
+                                </details>
                               )}
                             </div>
                           </div>

--- a/frontend/src/components/DevicePanel.tsx
+++ b/frontend/src/components/DevicePanel.tsx
@@ -143,7 +143,7 @@ function getTimingChips(
 
   const chips = [
     { label: 'Total', value: formatDuration(timings.total_duration_ms) },
-    { label: 'LLM', value: formatDuration(timings.llm_duration_ms) },
+    { label: 'Model', value: formatDuration(timings.llm_duration_ms) },
   ];
 
   if (timings.screenshot_duration_ms > 0) {

--- a/frontend/src/hooks/useTaskSessionConversation.ts
+++ b/frontend/src/hooks/useTaskSessionConversation.ts
@@ -7,6 +7,7 @@ import {
   type SetStateAction,
 } from 'react';
 import type {
+  ModelErrorDetails,
   StepTimingSummary,
   TaskEventRecordResponse,
   TaskImageAttachment,
@@ -34,6 +35,7 @@ export interface TaskConversationMessage {
   actions?: Record<string, unknown>[];
   screenshots?: (string | undefined)[];
   stepTimings?: (StepTimingSummary | undefined)[];
+  errorDetails?: ModelErrorDetails;
   isStreaming?: boolean;
   currentThinking?: string;
   attachments?: TaskImageAttachment[];
@@ -131,6 +133,7 @@ function buildAssistantMessage(
   const actions: Record<string, unknown>[] = [];
   const screenshots: (string | undefined)[] = [];
   const stepTimings: (StepTimingSummary | undefined)[] = [];
+  let errorDetails: ModelErrorDetails | undefined;
   let currentThinking = '';
   let content = task.final_message || task.error_message || '';
   let steps = task.step_count;
@@ -168,6 +171,12 @@ function buildAssistantMessage(
         stepTimings.push(
           (payload.timings as StepTimingSummary | undefined) || undefined
         );
+        if (
+          payload.error_details &&
+          typeof payload.error_details === 'object'
+        ) {
+          errorDetails = payload.error_details as ModelErrorDetails;
+        }
         currentThinking = '';
         if (typeof payload.step === 'number') {
           steps = payload.step;
@@ -188,6 +197,12 @@ function buildAssistantMessage(
       case 'error': {
         if (typeof payload.message === 'string') {
           content = payload.message;
+        }
+        if (
+          payload.error_details &&
+          typeof payload.error_details === 'object'
+        ) {
+          errorDetails = payload.error_details as ModelErrorDetails;
         }
         success = false;
         currentThinking = '';
@@ -213,6 +228,7 @@ function buildAssistantMessage(
     actions,
     screenshots,
     stepTimings,
+    errorDetails,
     steps,
     success,
     isStreaming: isTaskActive(task.status),

--- a/tests/test_model_error_details.py
+++ b/tests/test_model_error_details.py
@@ -1,0 +1,125 @@
+"""Tests for structured model error diagnostics."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+from openai import BadRequestError
+
+from AutoGLM_GUI.agents.gemini.async_agent import AsyncGeminiAgent
+from AutoGLM_GUI.config import AgentConfig, ModelConfig
+from AutoGLM_GUI.device_protocol import Screenshot
+from AutoGLM_GUI.model.error_details import serialize_model_error
+
+
+class _FakeDevice:
+    device_id = "fake-001"
+
+    def get_screenshot(self, timeout: int = 10) -> Screenshot:
+        return Screenshot(base64_data="screen", width=1080, height=2400)
+
+    def get_current_app(self) -> str:
+        return "com.example.app"
+
+
+class _FailingGeminiAgent(AsyncGeminiAgent):
+    async def _call_llm_with_tools(
+        self,
+    ) -> tuple[str, str | None, str, dict[str, Any]]:
+        request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+        response = httpx.Response(
+            400,
+            request=request,
+            headers={
+                "authorization": "Bearer secret",
+                "x-request-id": "req-123",
+                "content-type": "application/json",
+            },
+            json={"error": {"message": "bad request", "code": "invalid_request"}},
+        )
+        raise BadRequestError(
+            "bad request",
+            response=response,
+            body=response.json(),
+        )
+
+
+def test_serialize_model_error_redacts_sensitive_headers() -> None:
+    request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+    response = httpx.Response(
+        401,
+        request=request,
+        headers={
+            "authorization": "Bearer secret",
+            "x-api-key": "secret-key",
+            "x-request-id": "req-unauthorized",
+        },
+        text="Unauthorized",
+    )
+    exc = BadRequestError("Unauthorized", response=response, body=response.text)
+
+    details = serialize_model_error(
+        exc,
+        model_config=ModelConfig(
+            base_url="https://example.test/v1",
+            api_key="secret",
+            model_name="demo-model",
+        ),
+        call_site="tests.call_site",
+    )
+
+    assert details["kind"] == "model_http_error"
+    assert details["status_code"] == 401
+    assert details["request_id"] == "req-unauthorized"
+    assert details["response_body"] == "Unauthorized"
+    assert details["response_headers"]["authorization"] == "[REDACTED]"
+    assert details["response_headers"]["x-api-key"] == "[REDACTED]"
+    assert details["model_name"] == "demo-model"
+    assert details["base_url"] == "https://example.test/v1"
+    assert details["call_site"] == "tests.call_site"
+
+
+def test_gemini_model_error_events_include_structured_details(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    trace_file = tmp_path / "trace.jsonl"
+    monkeypatch.setenv("AUTOGLM_TRACE_FILE", str(trace_file))
+
+    agent = _FailingGeminiAgent(
+        model_config=ModelConfig(
+            base_url="https://example.test/v1",
+            api_key="secret",
+            model_name="demo-model",
+        ),
+        agent_config=AgentConfig(max_steps=1, verbose=False),
+        device=_FakeDevice(),
+    )
+
+    async def run() -> list[dict[str, Any]]:
+        agent._prepare_initial_context("task", "screen", "com.example.app")
+        return [event async for event in agent._execute_step()]
+
+    events = asyncio.run(run())
+    error_event = next(event for event in events if event["type"] == "error")
+    step_event = next(event for event in events if event["type"] == "step")
+
+    error_details = error_event["data"]["error_details"]
+    assert error_event["data"]["message"] == "Model error: bad request"
+    assert step_event["data"]["error_details"] == error_details
+    assert error_details["kind"] == "model_http_error"
+    assert error_details["status_code"] == 400
+    assert error_details["request_id"] == "req-123"
+    assert error_details["response_headers"]["authorization"] == "[REDACTED]"
+    assert "bad request" in error_details["response_body"]
+
+    trace_records = [
+        json.loads(line) for line in trace_file.read_text(encoding="utf-8").splitlines()
+    ]
+    llm_span = next(record for record in trace_records if record["name"] == "step.llm")
+    assert llm_span["status"] == "error"
+    assert llm_span["attrs"]["http.status_code"] == 400
+    assert llm_span["attrs"]["http.response_headers"]["authorization"] == "[REDACTED]"

--- a/tests/test_model_error_details.py
+++ b/tests/test_model_error_details.py
@@ -61,7 +61,9 @@ class _FailingPlannerResult:
 
 
 def test_serialize_model_error_redacts_sensitive_headers() -> None:
-    request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+    request = httpx.Request(
+        "POST", "https://user:pass@example.test/v1/chat/completions?token=secret"
+    )
     response = httpx.Response(
         401,
         request=request,
@@ -77,7 +79,7 @@ def test_serialize_model_error_redacts_sensitive_headers() -> None:
     details = serialize_model_error(
         exc,
         model_config=ModelConfig(
-            base_url="https://example.test/v1",
+            base_url="https://user:pass@example.test/v1?token=secret#fragment",
             api_key="secret",
             model_name="demo-model",
         ),
@@ -104,11 +106,11 @@ def test_gemini_model_error_events_include_structured_details(
 
     agent = _FailingGeminiAgent(
         model_config=ModelConfig(
-            base_url="https://example.test/v1",
+            base_url="https://user:pass@example.test/v1?token=secret",
             api_key="secret",
             model_name="demo-model",
         ),
-        agent_config=AgentConfig(max_steps=1, verbose=False),
+        agent_config=AgentConfig(max_steps=1, verbose=True),
         device=_FakeDevice(),
     )
 
@@ -127,6 +129,8 @@ def test_gemini_model_error_events_include_structured_details(
     assert error_details["status_code"] == 400
     assert error_details["request_id"] == "req-123"
     assert error_details["response_headers"]["authorization"] == "[REDACTED]"
+    assert error_details["base_url"] == "https://example.test/v1"
+    assert "traceback" not in error_details
     assert "bad request" in error_details["response_body"]
 
     trace_records = [

--- a/tests/test_model_error_details.py
+++ b/tests/test_model_error_details.py
@@ -97,6 +97,29 @@ def test_serialize_model_error_redacts_sensitive_headers() -> None:
     assert details["call_site"] == "tests.call_site"
 
 
+def test_serialize_model_error_reads_unread_streaming_response_body() -> None:
+    request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+    response = httpx.Response(
+        400,
+        request=request,
+        stream=httpx.ByteStream(b"streamed model failure"),
+    )
+    exc = BadRequestError("bad request", response=response, body=None)
+
+    details = serialize_model_error(
+        exc,
+        model_config=ModelConfig(
+            base_url="https://example.test/v1",
+            api_key="secret",
+            model_name="demo-model",
+        ),
+        call_site="tests.call_site",
+    )
+
+    assert details["kind"] == "model_http_error"
+    assert details["response_body"] == "streamed model failure"
+
+
 def test_gemini_model_error_events_include_structured_details(
     tmp_path,
     monkeypatch,

--- a/tests/test_model_error_details.py
+++ b/tests/test_model_error_details.py
@@ -10,6 +10,7 @@ import httpx
 from openai import BadRequestError
 
 from AutoGLM_GUI.agents.gemini.async_agent import AsyncGeminiAgent
+import AutoGLM_GUI.layered_agent_service as layered_agent_service
 from AutoGLM_GUI.config import AgentConfig, ModelConfig
 from AutoGLM_GUI.device_protocol import Screenshot
 from AutoGLM_GUI.model.error_details import serialize_model_error
@@ -45,6 +46,18 @@ class _FailingGeminiAgent(AsyncGeminiAgent):
             response=response,
             body=response.json(),
         )
+
+
+class _FailingPlannerResult:
+    final_output = ""
+
+    async def stream_events(self):
+        if False:
+            yield None
+        raise RuntimeError("planner boom")
+
+    def cancel(self, mode: str = "immediate") -> None:
+        pass
 
 
 def test_serialize_model_error_redacts_sensitive_headers() -> None:
@@ -123,3 +136,32 @@ def test_gemini_model_error_events_include_structured_details(
     assert llm_span["status"] == "error"
     assert llm_span["attrs"]["http.status_code"] == 400
     assert llm_span["attrs"]["http.response_headers"]["authorization"] == "[REDACTED]"
+
+
+def test_layered_planner_error_event_does_not_expose_traceback(monkeypatch) -> None:
+    monkeypatch.setattr(
+        layered_agent_service,
+        "_planner_model_config",
+        lambda: ModelConfig(
+            base_url="https://example.test/v1",
+            api_key="secret",
+            model_name="planner-model",
+        ),
+    )
+    run = layered_agent_service.LayeredTaskRun(
+        task_id="task-1",
+        session_id="session-1",
+        result=_FailingPlannerResult(),
+    )
+
+    async def collect_events() -> list[dict[str, Any]]:
+        return [event async for event in run.stream_events()]
+
+    events = asyncio.run(collect_events())
+    error_event = next(event for event in events if event["type"] == "error")
+    details = error_event["payload"]["error_details"]
+
+    assert details["exception_type"] == "RuntimeError"
+    assert details["message"] == "planner boom"
+    assert details["model_name"] == "planner-model"
+    assert "traceback" not in details

--- a/tests/test_model_error_details.py
+++ b/tests/test_model_error_details.py
@@ -13,7 +13,10 @@ from AutoGLM_GUI.agents.gemini.async_agent import AsyncGeminiAgent
 import AutoGLM_GUI.layered_agent_service as layered_agent_service
 from AutoGLM_GUI.config import AgentConfig, ModelConfig
 from AutoGLM_GUI.device_protocol import Screenshot
-from AutoGLM_GUI.model.error_details import serialize_model_error
+from AutoGLM_GUI.model.error_details import (
+    serialize_model_error,
+    serialize_model_error_async,
+)
 
 
 class _FakeDevice:
@@ -58,6 +61,14 @@ class _FailingPlannerResult:
 
     def cancel(self, mode: str = "immediate") -> None:
         pass
+
+
+class _AsyncBodyStream(httpx.AsyncByteStream):
+    def __init__(self, body: bytes):
+        self.body = body
+
+    async def __aiter__(self):
+        yield self.body
 
 
 def test_serialize_model_error_redacts_sensitive_headers() -> None:
@@ -118,6 +129,32 @@ def test_serialize_model_error_reads_unread_streaming_response_body() -> None:
 
     assert details["kind"] == "model_http_error"
     assert details["response_body"] == "streamed model failure"
+
+
+def test_serialize_model_error_async_reads_async_streaming_body() -> None:
+    request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+    response = httpx.Response(
+        400,
+        request=request,
+        stream=_AsyncBodyStream(b"async streamed model failure"),
+    )
+    exc = BadRequestError("bad request", response=response, body=None)
+
+    async def run() -> dict[str, Any]:
+        return await serialize_model_error_async(
+            exc,
+            model_config=ModelConfig(
+                base_url="https://example.test/v1",
+                api_key="secret",
+                model_name="demo-model",
+            ),
+            call_site="tests.call_site",
+        )
+
+    details = asyncio.run(run())
+
+    assert details["kind"] == "model_http_error"
+    assert details["response_body"] == "async streamed model failure"
 
 
 def test_gemini_model_error_events_include_structured_details(


### PR DESCRIPTION
## Summary
- add structured model error details with redacted response headers and HTTP response body capture
- include model error details in task events, failed step payloads, trace spans, and replay step results
- show expandable model error details in the chat UI

## Validation
- uv run pytest tests/test_model_error_details.py tests/test_gemini_agent.py -q
- uv run python scripts/lint.py --backend --check-only
- cd frontend && pnpm type-check
- uv run python scripts/lint.py --frontend --check-only

Closes #360