### PR TITLE
fix(frontend): persist device state across routes

### DIFF
--- a/frontend/e2e/device-state-routing.spec.ts
+++ b/frontend/e2e/device-state-routing.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression coverage for issue #376.
+ *
+ * The selected device should remain available immediately after navigating
+ * between chat and history, even if the next /api/devices refresh is slow.
+ */
+import { test, expect, type APIResponse } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+type ServiceUrls = {
+  llm_url: string;
+  agent_url: string;
+  backend_url: string;
+};
+
+type RemoteDeviceAddResponse = {
+  success: boolean;
+  serial: string | null;
+  message?: string;
+  error?: string;
+};
+
+function readServiceUrls(): ServiceUrls {
+  const urlsPath = path.resolve(__dirname, '.service_urls.json');
+  if (!fs.existsSync(urlsPath)) {
+    throw new Error(
+      `.service_urls.json not found - ensure start_e2e_services.py is running`
+    );
+  }
+  return JSON.parse(fs.readFileSync(urlsPath, 'utf-8')) as ServiceUrls;
+}
+
+async function assertOk(response: APIResponse, label: string): Promise<void> {
+  if (!response.ok()) {
+    throw new Error(
+      `${label} failed with ${response.status()}: ${await response.text()}`
+    );
+  }
+}
+
+test.describe('Device state routing', () => {
+  test('keeps the selected device while navigating to history and back', async ({
+    page,
+    request,
+  }) => {
+    const { backend_url, agent_url, llm_url } = readServiceUrls();
+    const testDeviceId = `mock_device_issue_376_${Date.now()}`;
+
+    await page.addInitScript(() => {
+      localStorage.setItem('locale', 'en');
+    });
+
+    const addDeviceResponse = await request.post(
+      `${backend_url}/api/devices/add_remote`,
+      {
+        data: { base_url: agent_url, device_id: testDeviceId },
+      }
+    );
+    await assertOk(addDeviceResponse, 'add remote device');
+    const addDeviceData =
+      (await addDeviceResponse.json()) as RemoteDeviceAddResponse;
+    expect(addDeviceData.success).toBe(true);
+    expect(addDeviceData.serial).toBeTruthy();
+    const deviceSerial = addDeviceData.serial as string;
+
+    await assertOk(
+      await request.delete(`${backend_url}/api/config`),
+      'clear config'
+    );
+    await assertOk(
+      await request.post(`${backend_url}/api/config`, {
+        data: {
+          base_url: `${llm_url}/v1`,
+          model_name: 'mock-glm-model',
+          api_key: 'mock-key',
+          agent_type: 'glm-async',
+        },
+      }),
+      'save config'
+    );
+
+    let delayDeviceRefresh = false;
+    await page.route('**/api/devices', async route => {
+      if (delayDeviceRefresh) {
+        await new Promise(resolve => setTimeout(resolve, 5000));
+      }
+      const response = await route.fetch();
+      await route.fulfill({ response });
+    });
+
+    await page.goto(
+      `/chat?serial=${encodeURIComponent(deviceSerial)}&mode=classic`
+    );
+
+    await expect(page.locator('textarea')).toBeVisible({ timeout: 15000 });
+
+    delayDeviceRefresh = true;
+
+    await page.locator('nav a[href="/history"]').click();
+    await expect(page).toHaveURL(/\/history/);
+    await expect(
+      page.getByRole('heading', { name: 'Conversation History' })
+    ).toBeVisible({ timeout: 1500 });
+    await expect(page.getByText(deviceSerial, { exact: true })).toBeVisible({
+      timeout: 500,
+    });
+
+    await page.locator('nav a[href="/chat"]:has(svg)').click();
+    await expect(page).toHaveURL(/\/chat/);
+
+    await expect(page.locator('textarea')).toBeVisible({ timeout: 500 });
+  });
+});

--- a/frontend/e2e/trace-events.spec.ts
+++ b/frontend/e2e/trace-events.spec.ts
@@ -232,7 +232,7 @@ test.describe('Trace debug surface', () => {
     await expect(page.getByText('Step 1').first()).toBeVisible({
       timeout: 30000,
     });
-    await expect(page.getByText(/^LLM /).first()).toBeVisible({
+    await expect(page.getByText(/^Model /).first()).toBeVisible({
       timeout: 30000,
     });
     await expect(page.getByText(/^Action /).first()).toBeVisible({

--- a/frontend/src/lib/device-context.tsx
+++ b/frontend/src/lib/device-context.tsx
@@ -1,0 +1,230 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { listDevices, type AgentStatus, type Device } from '../api';
+import { usePageVisibility } from '../hooks/usePageVisibility';
+
+interface DeviceContextValue {
+  devices: Device[];
+  currentDevice: Device | null;
+  currentDeviceId: string;
+  selectedSerial: string;
+  isLoadingDevices: boolean;
+  refreshDevices: () => Promise<void>;
+  selectDeviceById: (deviceId: string) => void;
+  selectDeviceBySerial: (serial: string | undefined) => void;
+}
+
+const DeviceContext = createContext<DeviceContextValue | undefined>(undefined);
+
+function areAgentStatesEqual(
+  left: AgentStatus | null,
+  right: AgentStatus | null
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+
+  return (
+    left.state === right.state &&
+    left.created_at === right.created_at &&
+    left.last_used === right.last_used &&
+    left.error_message === right.error_message &&
+    left.model_name === right.model_name
+  );
+}
+
+function areDevicesEqual(previous: Device[], next: Device[]): boolean {
+  if (previous === next) return true;
+  if (previous.length !== next.length) return false;
+
+  return previous.every((device, index) => {
+    const nextDevice = next[index];
+    if (!nextDevice) return false;
+
+    return (
+      device.id === nextDevice.id &&
+      device.serial === nextDevice.serial &&
+      device.model === nextDevice.model &&
+      device.status === nextDevice.status &&
+      device.connection_type === nextDevice.connection_type &&
+      device.state === nextDevice.state &&
+      device.is_available_only === nextDevice.is_available_only &&
+      device.display_name === nextDevice.display_name &&
+      device.group_id === nextDevice.group_id &&
+      areAgentStatesEqual(device.agent, nextDevice.agent)
+    );
+  });
+}
+
+function normalizeDevices(devices: Device[]): Device[] {
+  const connectedDevices = devices.filter(
+    device => device.state !== 'disconnected'
+  );
+
+  const deviceMap = new Map<string, Device>();
+  const serialMap = new Map<string, Device[]>();
+
+  for (const device of connectedDevices) {
+    if (device.serial) {
+      const group = serialMap.get(device.serial) || [];
+      group.push(device);
+      serialMap.set(device.serial, group);
+    } else {
+      deviceMap.set(device.id, device);
+    }
+  }
+
+  Array.from(serialMap.values()).forEach(devicesForSerial => {
+    const wifiDevice = devicesForSerial.find(
+      device => device.connection_type === 'wifi'
+    );
+    const selectedDevice = wifiDevice || devicesForSerial[0];
+    deviceMap.set(selectedDevice.id, selectedDevice);
+  });
+
+  return Array.from(deviceMap.values());
+}
+
+export function DeviceProvider({ children }: { children: ReactNode }) {
+  const isPageVisible = usePageVisibility();
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [selectedSerial, setSelectedSerial] = useState<string>('');
+  const [isLoadingDevices, setIsLoadingDevices] = useState(false);
+  const isLoadingDevicesRef = useRef(false);
+  const selectedSerialRef = useRef('');
+
+  useEffect(() => {
+    selectedSerialRef.current = selectedSerial;
+  }, [selectedSerial]);
+
+  const refreshDevices = useCallback(async () => {
+    if (isLoadingDevicesRef.current) {
+      return;
+    }
+
+    isLoadingDevicesRef.current = true;
+    setIsLoadingDevices(true);
+
+    try {
+      const response = await listDevices();
+      const filteredDevices = normalizeDevices(response.devices);
+
+      setDevices(previousDevices =>
+        areDevicesEqual(previousDevices, filteredDevices)
+          ? previousDevices
+          : filteredDevices
+      );
+
+      const currentSerial = selectedSerialRef.current;
+      if (filteredDevices.length === 0) {
+        if (currentSerial) {
+          setSelectedSerial('');
+        }
+        return;
+      }
+
+      if (
+        !currentSerial ||
+        !filteredDevices.some(device => device.serial === currentSerial)
+      ) {
+        setSelectedSerial(filteredDevices[0].serial);
+      }
+    } catch (error) {
+      console.error('Failed to load devices:', error);
+    } finally {
+      isLoadingDevicesRef.current = false;
+      setIsLoadingDevices(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isPageVisible) {
+      return;
+    }
+
+    let isCancelled = false;
+    let timeoutId: number | null = null;
+
+    const pollDevices = async () => {
+      await refreshDevices();
+
+      if (isCancelled) {
+        return;
+      }
+
+      timeoutId = window.setTimeout(() => {
+        void pollDevices();
+      }, 3000);
+    };
+
+    void pollDevices();
+
+    return () => {
+      isCancelled = true;
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [isPageVisible, refreshDevices]);
+
+  const selectDeviceById = useCallback(
+    (deviceId: string) => {
+      const device = devices.find(device => device.id === deviceId);
+      setSelectedSerial(device?.serial || '');
+    },
+    [devices]
+  );
+
+  const selectDeviceBySerial = useCallback((serial: string | undefined) => {
+    setSelectedSerial(serial || '');
+  }, []);
+
+  const currentDevice = useMemo(() => {
+    if (!selectedSerial) {
+      return null;
+    }
+    return devices.find(device => device.serial === selectedSerial) || null;
+  }, [devices, selectedSerial]);
+
+  const value = useMemo<DeviceContextValue>(
+    () => ({
+      devices,
+      currentDevice,
+      currentDeviceId: currentDevice?.id || '',
+      selectedSerial,
+      isLoadingDevices,
+      refreshDevices,
+      selectDeviceById,
+      selectDeviceBySerial,
+    }),
+    [
+      currentDevice,
+      devices,
+      isLoadingDevices,
+      refreshDevices,
+      selectDeviceById,
+      selectDeviceBySerial,
+      selectedSerial,
+    ]
+  );
+
+  return (
+    <DeviceContext.Provider value={value}>{children}</DeviceContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useDevices(): DeviceContextValue {
+  const context = useContext(DeviceContext);
+  if (!context) {
+    throw new Error('useDevices must be used within a DeviceProvider');
+  }
+  return context;
+}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import { useLocale, useTranslation } from '../lib/i18n-context';
 import { ThemeToggle } from '../components/ThemeToggle';
 import { NavigationSidebar } from '../components/NavigationSidebar';
 import { useFooterVersionInfo } from '../hooks/useFooterVersionInfo';
+import { DeviceProvider } from '../lib/device-context';
 
 export const Route = createRootRoute({
   component: RootComponent,
@@ -119,19 +120,21 @@ function Footer() {
 
 function RootComponent() {
   return (
-    <div className="h-screen flex flex-col overflow-hidden">
-      <div className="flex-1 flex overflow-hidden">
-        <NavigationSidebar />
-        <div className="flex-1 flex flex-col overflow-hidden">
-          <div className="flex-1 overflow-auto">
-            <Outlet />
+    <DeviceProvider>
+      <div className="h-screen flex flex-col overflow-hidden">
+        <div className="flex-1 flex overflow-hidden">
+          <NavigationSidebar />
+          <div className="flex-1 flex flex-col overflow-hidden">
+            <div className="flex-1 overflow-auto">
+              <Outlet />
+            </div>
+            <Footer />
           </div>
-          <Footer />
         </div>
+        {__DEVTOOLS_ENABLED__ && (
+          <TanStackRouterDevtools position="bottom-right" />
+        )}
       </div>
-      {__DEVTOOLS_ENABLED__ && (
-        <TanStackRouterDevtools position="bottom-right" />
-      )}
-    </div>
+    </DeviceProvider>
   );
 }

--- a/frontend/src/routes/chat.tsx
+++ b/frontend/src/routes/chat.tsx
@@ -1,15 +1,12 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import * as React from 'react';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import {
   connectWifi,
   disconnectWifi,
-  listDevices,
   getConfig,
   saveConfig,
   modelServiceConnection,
   getErrorMessage,
-  type Device,
   type ConfigSaveRequest,
 } from '../api';
 import { DeviceSidebar } from '../components/DeviceSidebar';
@@ -51,7 +48,7 @@ import {
   Loader2,
 } from 'lucide-react';
 import { useTranslation } from '../lib/i18n-context';
-import { usePageVisibility } from '../hooks/usePageVisibility';
+import { useDevices } from '../lib/device-context';
 
 // 视觉模型预设配置
 const VISION_PRESETS = [
@@ -180,50 +177,6 @@ type ChatSearchParams = {
   mode?: 'classic' | 'chatkit';
 };
 
-function areAgentStatesEqual(
-  left: Device['agent'] | null,
-  right: Device['agent'] | null
-): boolean {
-  if (left === right) {
-    return true;
-  }
-
-  if (!left || !right) {
-    return false;
-  }
-
-  return (
-    left.state === right.state &&
-    left.created_at === right.created_at &&
-    left.last_used === right.last_used &&
-    left.error_message === right.error_message &&
-    left.model_name === right.model_name
-  );
-}
-
-function areDevicesEqual(previous: Device[], next: Device[]): boolean {
-  if (previous.length !== next.length) {
-    return false;
-  }
-
-  return previous.every((device, index) => {
-    const nextDevice = next[index];
-
-    return (
-      device.id === nextDevice.id &&
-      device.serial === nextDevice.serial &&
-      device.model === nextDevice.model &&
-      device.status === nextDevice.status &&
-      device.connection_type === nextDevice.connection_type &&
-      device.state === nextDevice.state &&
-      device.is_available_only === nextDevice.is_available_only &&
-      device.display_name === nextDevice.display_name &&
-      device.group_id === nextDevice.group_id &&
-      areAgentStatesEqual(device.agent, nextDevice.agent)
-    );
-  });
-}
-
 export const Route = createFileRoute('/chat')({
   component: ChatComponent,
   validateSearch: (search: Record<string, unknown>): ChatSearchParams => {
@@ -239,17 +192,21 @@ function ChatComponent() {
   const t = useTranslation();
   const searchParams = Route.useSearch();
   const navigate = useNavigate();
-  const isPageVisible = usePageVisibility();
-  const [devices, setDevices] = useState<Device[]>([]);
-  const [currentDeviceId, setCurrentDeviceId] = useState<string>('');
+  const {
+    devices,
+    currentDevice,
+    currentDeviceId,
+    refreshDevices,
+    selectDeviceById,
+    selectDeviceBySerial,
+    selectedSerial,
+  } = useDevices();
   // Chat mode: 'classic' for DevicePanel (single model), 'chatkit' for ChatKitPanel (layered agent)
   // Initialize from URL search params if available
   const [chatMode, setChatMode] = useState<'classic' | 'chatkit'>(
     searchParams.mode || 'classic'
   );
 
-  // Track if we've done initial device selection from URL
-  const [initialDeviceSet, setInitialDeviceSet] = useState(false);
   const [toast, setToast] = useState<{
     message: string;
     type: ToastType;
@@ -275,7 +232,6 @@ function ChatComponent() {
     success: boolean;
     message: string;
   } | null>(null);
-  const isLoadingDevicesRef = React.useRef(false);
   const [tempConfig, setTempConfig] = useState({
     base_url: VISION_PRESETS[0].config.base_url as string,
     model_name: VISION_PRESETS[0].config.model_name as string,
@@ -340,118 +296,15 @@ function ChatComponent() {
     loadConfiguration();
   }, []);
 
-  const loadDevices = useCallback(async () => {
-    if (isLoadingDevicesRef.current) {
-      return;
-    }
-
-    isLoadingDevicesRef.current = true;
-    try {
-      const response = await listDevices();
-
-      // Filter out disconnected devices
-      const connectedDevices = response.devices.filter(
-        device => device.state !== 'disconnected'
-      );
-
-      const deviceMap = new Map<string, Device>();
-      const serialMap = new Map<string, Device[]>();
-
-      for (const device of connectedDevices) {
-        if (device.serial) {
-          const group = serialMap.get(device.serial) || [];
-          group.push(device);
-          serialMap.set(device.serial, group);
-        } else {
-          deviceMap.set(device.id, device);
-        }
-      }
-
-      Array.from(serialMap.values()).forEach(devices => {
-        const wifiDevice = devices.find(
-          (d: Device) => d.connection_type === 'wifi'
-        );
-        const selectedDevice = wifiDevice || devices[0];
-        deviceMap.set(selectedDevice.id, selectedDevice);
-      });
-
-      const filteredDevices = Array.from(deviceMap.values());
-      setDevices(previousDevices =>
-        areDevicesEqual(previousDevices, filteredDevices)
-          ? previousDevices
-          : filteredDevices
-      );
-
-      // On initial load, try to select device from URL serial param
-      if (filteredDevices.length > 0 && !initialDeviceSet) {
-        const urlSerial = searchParams.serial;
-        if (urlSerial) {
-          const deviceFromUrl = filteredDevices.find(
-            d => d.serial === urlSerial
-          );
-          if (deviceFromUrl) {
-            setCurrentDeviceId(deviceFromUrl.id);
-          } else {
-            // URL serial not found, fallback to first device
-            setCurrentDeviceId(filteredDevices[0].id);
-          }
-        } else if (!currentDeviceId) {
-          setCurrentDeviceId(filteredDevices[0].id);
-        }
-        setInitialDeviceSet(true);
-      }
-
-      if (
-        currentDeviceId &&
-        !filteredDevices.find(d => d.id === currentDeviceId)
-      ) {
-        setCurrentDeviceId(filteredDevices[0]?.id || '');
-      }
-    } catch (error) {
-      console.error('Failed to load devices:', error);
-    } finally {
-      isLoadingDevicesRef.current = false;
-    }
-  }, [currentDeviceId, initialDeviceSet, searchParams.serial]);
-
   useEffect(() => {
-    if (!isPageVisible) {
-      return;
+    if (searchParams.serial) {
+      selectDeviceBySerial(searchParams.serial);
     }
-
-    let isCancelled = false;
-    let timeoutId: number | null = null;
-
-    const pollDevices = async () => {
-      await loadDevices();
-
-      if (isCancelled) {
-        return;
-      }
-
-      timeoutId = window.setTimeout(() => {
-        void pollDevices();
-      }, 3000);
-    };
-
-    void pollDevices();
-
-    return () => {
-      isCancelled = true;
-      if (timeoutId !== null) {
-        window.clearTimeout(timeoutId);
-      }
-    };
-  }, [isPageVisible, loadDevices]);
+  }, [searchParams.serial, selectDeviceBySerial]);
 
   // Sync state changes to URL search params
   useEffect(() => {
-    // Get current device's serial
-    const currentDevice = devices.find(d => d.id === currentDeviceId);
-    const currentSerial = currentDevice?.serial;
-
-    // Only update URL after initial device selection is done
-    if (!initialDeviceSet) return;
+    const currentSerial = currentDevice?.serial || selectedSerial || undefined;
 
     // Check if URL needs updating
     const needsUpdate =
@@ -468,13 +321,12 @@ function ChatComponent() {
       });
     }
   }, [
-    currentDeviceId,
     chatMode,
-    devices,
-    initialDeviceSet,
+    currentDevice,
     navigate,
     searchParams.serial,
     searchParams.mode,
+    selectedSerial,
   ]);
 
   const handleSaveConfig = async () => {
@@ -576,7 +428,7 @@ function ChatComponent() {
     try {
       const res = await connectWifi({ device_id: deviceId });
       if (res.success && res.device_id) {
-        setCurrentDeviceId(res.device_id);
+        await refreshDevices();
         showToast(t.toasts.wifiConnected, 'success');
       } else if (!res.success) {
         showToast(
@@ -594,6 +446,7 @@ function ChatComponent() {
     try {
       const res = await disconnectWifi(deviceId);
       if (res.success) {
+        await refreshDevices();
         showToast(t.toasts.wifiDisconnected, 'success');
       } else {
         showToast(
@@ -1259,12 +1112,12 @@ function ChatComponent() {
       <DeviceSidebar
         devices={devices}
         currentDeviceId={currentDeviceId}
-        onSelectDevice={setCurrentDeviceId}
+        onSelectDevice={selectDeviceById}
         onOpenConfig={() => setShowConfig(true)}
         onOpenGroupManager={() => setShowGroupManager(true)}
         onConnectWifi={handleConnectWifi}
         onDisconnectWifi={handleDisconnectWifi}
-        onRefreshDevices={loadDevices}
+        onRefreshDevices={refreshDevices}
         showToast={showToast}
       />
 
@@ -1331,7 +1184,7 @@ function ChatComponent() {
 
         {/* Content area */}
         <div className="flex-1 flex items-stretch justify-center min-h-0 px-4 py-4 pt-16">
-          {devices.length === 0 ? (
+          {!currentDevice ? (
             <div className="flex-1 flex items-center justify-center bg-slate-50 dark:bg-slate-950">
               <div className="text-center">
                 <div className="flex h-20 w-20 items-center justify-center rounded-full bg-slate-100 dark:bg-slate-800 mx-auto mb-4">
@@ -1358,43 +1211,35 @@ function ChatComponent() {
               </div>
             </div>
           ) : (
-            devices
-              .filter(device => device.id === currentDeviceId)
-              .map(device => (
-                <div
-                  key={device.serial}
-                  className="w-full max-w-7xl flex items-stretch justify-center min-h-0"
-                >
-                  {chatMode === 'chatkit' ? (
-                    <div className="w-full flex items-stretch justify-center">
-                      <ChatKitPanel
-                        deviceId={device.id}
-                        deviceSerial={device.serial}
-                        deviceName={device.model}
-                        deviceConnectionType={device.connection_type}
-                        isVisible={device.id === currentDeviceId}
-                        unlimitedStepsEnabled={
-                          config?.default_max_steps === null
-                        }
-                      />
-                    </div>
-                  ) : (
-                    <div className="w-full flex items-stretch justify-center">
-                      <DevicePanel
-                        deviceId={device.id}
-                        deviceSerial={device.serial}
-                        deviceName={device.model}
-                        deviceConnectionType={device.connection_type}
-                        isConfigured={!!config?.base_url}
-                        isVisible={device.id === currentDeviceId} // ✅ 新增：传递可见性状态
-                        unlimitedStepsEnabled={
-                          config?.default_max_steps === null
-                        }
-                      />
-                    </div>
-                  )}
+            <div
+              key={currentDevice.serial}
+              className="w-full max-w-7xl flex items-stretch justify-center min-h-0"
+            >
+              {chatMode === 'chatkit' ? (
+                <div className="w-full flex items-stretch justify-center">
+                  <ChatKitPanel
+                    deviceId={currentDevice.id}
+                    deviceSerial={currentDevice.serial}
+                    deviceName={currentDevice.model}
+                    deviceConnectionType={currentDevice.connection_type}
+                    isVisible={currentDevice.id === currentDeviceId}
+                    unlimitedStepsEnabled={config?.default_max_steps === null}
+                  />
                 </div>
-              ))
+              ) : (
+                <div className="w-full flex items-stretch justify-center">
+                  <DevicePanel
+                    deviceId={currentDevice.id}
+                    deviceSerial={currentDevice.serial}
+                    deviceName={currentDevice.model}
+                    deviceConnectionType={currentDevice.connection_type}
+                    isConfigured={!!config?.base_url}
+                    isVisible={currentDevice.id === currentDeviceId}
+                    unlimitedStepsEnabled={config?.default_max_steps === null}
+                  />
+                </div>
+              )}
+            </div>
           )}
         </div>
       </div>
@@ -1403,7 +1248,7 @@ function ChatComponent() {
       <GroupManageDialog
         isOpen={showGroupManager}
         onClose={() => setShowGroupManager(false)}
-        onGroupsChanged={loadDevices}
+        onGroupsChanged={refreshDevices}
         showToast={showToast}
       />
     </div>

--- a/frontend/src/routes/history.tsx
+++ b/frontend/src/routes/history.tsx
@@ -4,9 +4,7 @@ import {
   listHistory,
   clearHistory,
   deleteHistoryRecord,
-  getDevices,
   type HistoryRecordResponse,
-  type Device,
   type StepTimingSummary,
 } from '../api';
 import { Button } from '@/components/ui/button';
@@ -48,6 +46,7 @@ import {
   Eye,
 } from 'lucide-react';
 import { useTranslation } from '../lib/i18n-context';
+import { useDevices } from '../lib/device-context';
 
 export const Route = createFileRoute('/history')({
   component: HistoryComponent,
@@ -55,8 +54,7 @@ export const Route = createFileRoute('/history')({
 
 function HistoryComponent() {
   const t = useTranslation();
-  const [devices, setDevices] = useState<Device[]>([]);
-  const [selectedSerial, setSelectedSerial] = useState<string>('');
+  const { devices, selectedSerial, selectDeviceBySerial } = useDevices();
   const [records, setRecords] = useState<HistoryRecordResponse[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -70,23 +68,6 @@ function HistoryComponent() {
     useState<HistoryRecordResponse | null>(null);
   const [expandedSteps, setExpandedSteps] = useState<Set<number>>(new Set());
   const limit = 20;
-
-  // Load devices
-  useEffect(() => {
-    const loadDevices = async () => {
-      try {
-        const deviceList = await getDevices();
-        setDevices(deviceList);
-        // Auto-select first device if available
-        if (deviceList.length > 0 && !selectedSerial) {
-          setSelectedSerial(deviceList[0].serial);
-        }
-      } catch (error) {
-        console.error('Failed to load devices:', error);
-      }
-    };
-    loadDevices();
-  }, [selectedSerial]);
 
   // Load history when device changes
   const loadHistory = useCallback(
@@ -124,6 +105,10 @@ function HistoryComponent() {
   useEffect(() => {
     if (selectedSerial) {
       loadHistory(selectedSerial, true);
+    } else {
+      setRecords([]);
+      setTotal(0);
+      setOffset(0);
     }
   }, [selectedSerial]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -290,7 +275,7 @@ function HistoryComponent() {
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-bold">{t.historyPage.title}</h1>
         <div className="flex items-center gap-4">
-          <Select value={selectedSerial} onValueChange={setSelectedSerial}>
+          <Select value={selectedSerial} onValueChange={selectDeviceBySerial}>
             <SelectTrigger className="w-[200px]">
               <SelectValue placeholder={t.historyPage.selectDevice} />
             </SelectTrigger>


### PR DESCRIPTION
## Summary
- Move device list polling and selected device serial into a root-level DeviceProvider.
- Update chat and history routes to share the same device state instead of owning separate page-local device state.
- Add Playwright regression coverage for issue #376: navigating chat -> history -> chat while the next /api/devices refresh is delayed.

Fixes #376.

## E2E evidence
Before the fix, the new regression test reproduced the issue:

```text
pnpm test:e2e e2e/device-state-routing.spec.ts
1 failed
expect(page.getByText(deviceSerial, { exact: true })).toBeVisible({ timeout: 500 })
Error: element(s) not found / hidden after navigating to /history while /api/devices was delayed
```

After the fix, the same E2E passes:

```text
pnpm test:e2e e2e/device-state-routing.spec.ts
1 passed (11.9s)
```

## Verification
```text
uv run python scripts/lint.py --frontend --check-only
✅ pnpm lint
✅ pnpm format:check
✅ pnpm type-check
Result: 3/3 checks passed

pnpm type-check
✅ passed

pnpm test:e2e e2e/device-state-routing.spec.ts
✅ 1 passed (11.9s)
```

Manual browser check with local E2E services also confirmed `/history` immediately shows the selected remote serial and returning to `/chat` immediately shows the chat textarea.
