### PR TITLE
fix: Take_over/Interact pause-resume flow

### DIFF
--- a/AutoGLM_GUI/actions/handler.py
+++ b/AutoGLM_GUI/actions/handler.py
@@ -288,7 +288,7 @@ class ActionHandler:
     ) -> ActionResult:
         message = action.get("message", "User intervention required")
         self.takeover_callback(message)
-        return ActionResult(True, False)
+        return ActionResult(True, False, message=f"TAKEOVER_REQUIRED:\n {message}")
 
     def _handle_note(
         self, action: dict[str, Any], width: int, height: int
@@ -307,8 +307,9 @@ class ActionHandler:
         self, action: dict[str, Any], width: int, height: int
     ) -> ActionResult:
         """Handle interaction request (user choice needed)."""
-        # This action signals that user input is needed
-        return ActionResult(True, False, message="User interaction required")
+        return ActionResult(
+            True, False, message="INTERACT_REQUIRED: User interaction required"
+        )
 
     @staticmethod
     def _default_confirmation(message: str) -> bool:

--- a/AutoGLM_GUI/agents/base/async_agent_base.py
+++ b/AutoGLM_GUI/agents/base/async_agent_base.py
@@ -110,11 +110,31 @@ class AsyncAgentBase(ABC):
 
     # ==================== 共享逻辑 ====================
 
-    async def stream(self, task: str) -> AsyncIterator[dict[str, Any]]:
-        """流式执行任务，支持取消。"""
+    async def stream(
+        self, task: str, *, continue_with: str | None = None
+    ) -> AsyncIterator[dict[str, Any]]:
+        """流式执行任务，支持取消和继续执行。
+
+        Args:
+            task: 任务文本或用户输入
+            continue_with: 如果设置，表示在 Take_over/Interact 后继续执行。
+                           不重置 step_count，将用户输入添加到上下文后继续循环。
+        """
+        INTERACTION_ACTIONS = ("Take_over", "Interact")
+
         self._is_running = True
-        self._step_count = 0
+        if continue_with is None:
+            self._step_count = 0
+        else:
+            logger.info(
+                "Continuing agent stream from step %d with user input: %s",
+                self._step_count,
+                summarize_text(continue_with) or "",
+            )
         self._cancel_event.clear()
+
+        if continue_with is not None:
+            self._context.append(MessageBuilder.create_user_message(continue_with))
 
         with trace_span(
             "agent.stream",
@@ -127,44 +147,50 @@ class AsyncAgentBase(ABC):
             },
         ) as stream_span:
             try:
-                try:
-                    with trace_span(
-                        "agent.prepare_initial_state",
-                        attrs={
-                            "agent_type": self.__class__.__name__,
-                            "device_id": self.device.device_id,
-                        },
-                    ):
-                        screenshot = await asyncio.to_thread(self.device.get_screenshot)
-                        current_app = await asyncio.to_thread(
-                            self.device.get_current_app
+                if continue_with is None:
+                    try:
+                        with trace_span(
+                            "agent.prepare_initial_state",
+                            attrs={
+                                "agent_type": self.__class__.__name__,
+                                "device_id": self.device.device_id,
+                            },
+                        ):
+                            screenshot = await asyncio.to_thread(
+                                self.device.get_screenshot
+                            )
+                            current_app = await asyncio.to_thread(
+                                self.device.get_current_app
+                            )
+                    except Exception as e:
+                        logger.error(f"Failed to get device info: {e}")
+                        stream_span.set_attributes(
+                            {"success": False, "error_kind": "initial_device_state"}
                         )
-                except Exception as e:
-                    logger.error(f"Failed to get device info: {e}")
-                    stream_span.set_attributes(
-                        {"success": False, "error_kind": "initial_device_state"}
-                    )
-                    yield {"type": "error", "data": {"message": f"Device error: {e}"}}
-                    yield {
-                        "type": "done",
-                        "data": {
-                            "message": f"Device error: {e}",
-                            "steps": 0,
-                            "success": False,
-                        },
-                    }
-                    return
+                        yield {
+                            "type": "error",
+                            "data": {"message": f"Device error: {e}"},
+                        }
+                        yield {
+                            "type": "done",
+                            "data": {
+                                "message": f"Device error: {e}",
+                                "steps": 0,
+                                "success": False,
+                            },
+                        }
+                        return
 
-                with trace_span(
-                    "agent.prepare_initial_context",
-                    attrs={"agent_type": self.__class__.__name__},
-                ):
-                    self._prepare_initial_context(
-                        task,
-                        screenshot.base64_data,
-                        current_app,
-                        self._user_image_attachments,
-                    )
+                    with trace_span(
+                        "agent.prepare_initial_context",
+                        attrs={"agent_type": self.__class__.__name__},
+                    ):
+                        self._prepare_initial_context(
+                            task,
+                            screenshot.base64_data,
+                            current_app,
+                            self._user_image_attachments,
+                        )
 
                 started_at = time.monotonic()
                 repeated_action_count = 0
@@ -215,6 +241,24 @@ class AsyncAgentBase(ABC):
                                     no_progress_count += 1
 
                             yield event
+
+                            if event["type"] == "step":
+                                step_data = event["data"]
+                                action = step_data.get("action") or {}
+                                if (
+                                    step_data.get("waiting_for_input")
+                                    or action.get("action") in INTERACTION_ACTIONS
+                                ):
+                                    yield {
+                                        "type": "takeover",
+                                        "data": {
+                                            "message": step_data.get("message", ""),
+                                            "steps": self._step_count,
+                                            "success": True,
+                                            "stop_reason": "takeover",
+                                        },
+                                    }
+                                    return
 
                             if event["type"] == "step" and event["data"].get(
                                 "finished"

--- a/AutoGLM_GUI/agents/glm/async_agent.py
+++ b/AutoGLM_GUI/agents/glm/async_agent.py
@@ -295,6 +295,26 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
                 )
             )
 
+        # 6.5. 检测需要用户交互的 action (Take_over / Interact)
+        interaction_actions = ("Take_over", "Interact")
+        if action.get("action") in interaction_actions:
+            if self.agent_config.verbose:
+                logger.debug(f"Waiting for user input after {action.get('action')}")
+            yield {
+                "type": "step",
+                "data": {
+                    "step": self._step_count,
+                    "thinking": thinking,
+                    "action": action,
+                    "success": result.success,
+                    "finished": False,
+                    "waiting_for_input": True,
+                    "message": result.message or action.get("message"),
+                    "screenshot": screenshot.base64_data if screenshot else None,
+                },
+            }
+            return
+
         # 7. 检查完成
         finished = action.get("_metadata") == "finish" or result.should_finish
         if finished and self.agent_config.verbose:

--- a/AutoGLM_GUI/agents/protocols.py
+++ b/AutoGLM_GUI/agents/protocols.py
@@ -38,7 +38,9 @@ class AsyncAgent(Protocol):
         """
         ...
 
-    def stream(self, task: str) -> AsyncIterator[dict[str, Any]]:
+    def stream(
+        self, task: str, *, continue_with: str | None = None
+    ) -> AsyncIterator[dict[str, Any]]:
         """流式执行任务，返回异步生成器。
 
         这是核心方法，支持:

--- a/AutoGLM_GUI/agents/qwen/async_agent.py
+++ b/AutoGLM_GUI/agents/qwen/async_agent.py
@@ -354,6 +354,26 @@ class AsyncQwenAgent(AsyncAgentBase, AsyncAgent):
                 )
             )
 
+        # 6.5. 检测需要用户交互的 action (Take_over / Interact)
+        interaction_actions = ("Take_over", "Interact")
+        if action.get("action") in interaction_actions:
+            if self.agent_config.verbose:
+                logger.debug(f"Waiting for user input after {action.get('action')}")
+            yield {
+                "type": "step",
+                "data": {
+                    "step": self._step_count,
+                    "thinking": thinking,
+                    "action": action,
+                    "success": result.success,
+                    "finished": False,
+                    "waiting_for_input": True,
+                    "message": result.message or action.get("message"),
+                    "screenshot": screenshot.base64_data if screenshot else None,
+                },
+            }
+            return
+
         # 7. 检查完成
         finished = action.get("_metadata") == "finish" or result.should_finish
         if finished and self.agent_config.verbose:

--- a/AutoGLM_GUI/agents/qwen/prompts_zh.py
+++ b/AutoGLM_GUI/agents/qwen/prompts_zh.py
@@ -40,6 +40,8 @@ SYSTEM_PROMPT = (
     Type_Name是输入人名的操作,基本功能同Type。
 - do(action="Interact")  
     Interact是当有多个满足条件的选项时而触发的交互操作,询问用户如何选择。
+- do(action="Take_over", message="xxx")  
+    Take_over是接管操作，表示在登录和验证阶段需要用户协助。
 - do(action="Swipe", start=[x1,y1], end=[x2,y2])  
     Swipe是滑动操作,通过从起始坐标拖动到结束坐标来执行滑动手势。可用于滚动内容、在屏幕之间导航、下拉通知栏以及项目栏或进行基于手势的导航。坐标系统从左上角 (0,0) 开始到右下角(999,999)结束。滑动持续时间会自动调整以实现自然的移动。此操作完成后,您将自动收到结果状态的截图。
 - do(action="Note", message="True")  

--- a/AutoGLM_GUI/phone_agent_manager.py
+++ b/AutoGLM_GUI/phone_agent_manager.py
@@ -267,12 +267,26 @@ class PhoneAgentManager:
         )
         # 使用提供的 agent_type 或从配置中获取
         effective_agent_type = agent_type or effective_config.agent_type
+
+        # Web模式下使用空回调函数，不阻塞CLI
+        # 前端会通过事件流检测交互action并处理用户输入
+        def noop_takeover(message: str) -> None:
+            logger.info(f"Takeover action (Web mode): {message}")
+            # 不阻塞，让前端处理
+
+        def noop_confirmation(message: str) -> bool:
+            logger.info(f"Confirmation action (Web mode): {message}")
+            # 在Web模式下默认确认，让前端处理
+            return True
+
         self.initialize_agent_with_factory(
             device_id=agent_key,
             agent_type=effective_agent_type,
             model_config=model_config,
             agent_config=agent_config,
             agent_specific_config=agent_specific_config,
+            takeover_callback=noop_takeover,
+            confirmation_callback=noop_confirmation,
         )
         logger.info(f"Agent auto-initialized for key {agent_key}")
 

--- a/AutoGLM_GUI/task_manager.py
+++ b/AutoGLM_GUI/task_manager.py
@@ -38,6 +38,7 @@ class TaskManager:
         self._cancel_requested: set[str] = set()
         self._executors: dict[str, TaskExecutor] = {}
         self._started = False
+        self._takeover_sessions: dict[str, bool] = {}
         self._shutdown = False
         self.register_executor("classic_chat", self._execute_classic_chat)
         self.register_executor("layered_chat", self._execute_layered_chat)
@@ -535,7 +536,13 @@ class TaskManager:
                         image_attachment_setter(user_image_attachments)
                     event_type = ""
                     event_data: dict[str, Any] = {}
-                    async for event in agent.stream(task["input_text"]):
+
+                    # 检查是否有待继续的 takeover
+                    is_continue = self._takeover_sessions.pop(session_id, False)
+                    async for event in agent.stream(
+                        task["input_text"],
+                        continue_with=task["input_text"] if is_continue else None,
+                    ):
                         event_type = event["type"]
                         event_data = dict(event.get("data", {}))
 
@@ -558,7 +565,13 @@ class TaskManager:
                             task=task,
                         )
 
-                    if event_type == "done":
+                    if event_type == "takeover":
+                        final_message = str(event_data.get("message", ""))
+                        final_status = TaskStatus.SUCCEEDED.value
+                        stop_reason = "takeover"
+                        step_count = int(event_data.get("steps", step_count))
+                        self._takeover_sessions[session_id] = True
+                    elif event_type == "done":
                         final_message = str(event_data.get("message", ""))
                         final_status = (
                             TaskStatus.SUCCEEDED.value

--- a/AutoGLM_GUI/task_manager.py
+++ b/AutoGLM_GUI/task_manager.py
@@ -539,9 +539,16 @@ class TaskManager:
 
                     # 检查是否有待继续的 takeover
                     is_continue = self._takeover_sessions.pop(session_id, False)
+                    stream_kwargs: dict[str, Any] = {}
+                    if is_continue:
+                        # Only pass continue_with when the agent supports it
+                        # (DroidRunAgent and MidsceneAgent don't have this param)
+                        sig = inspect.signature(agent.stream)
+                        if "continue_with" in sig.parameters:
+                            stream_kwargs["continue_with"] = task["input_text"]
                     async for event in agent.stream(
                         task["input_text"],
-                        continue_with=task["input_text"] if is_continue else None,
+                        **stream_kwargs,
                     ):
                         event_type = event["type"]
                         event_data = dict(event.get("data", {}))

--- a/frontend/src/components/ChatKitPanel.tsx
+++ b/frontend/src/components/ChatKitPanel.tsx
@@ -20,6 +20,7 @@ import {
   ListChecks,
   Loader2,
   Square,
+  Hand,
 } from 'lucide-react';
 import type { Workflow, HistoryRecordResponse } from '../api';
 import {
@@ -53,6 +54,10 @@ import {
 } from '@/components/ui/tooltip';
 import { HistoryItemCard } from './HistoryItemCard';
 import { MarkdownContent } from './MarkdownContent';
+import {
+  isInteractionRequired,
+  getInteractionPrompt,
+} from '../lib/interaction-config';
 
 interface ChatKitPanelProps {
   deviceId: string;
@@ -127,6 +132,12 @@ function applyTaskEventToTask(
       typeof payload.message === 'string' ? payload.message : null;
     nextTask.error_message =
       typeof payload.message === 'string' ? payload.message : null;
+    nextTask.finished_at = event.created_at;
+  } else if (event.event_type === 'takeover') {
+    nextTask.status = 'SUCCEEDED';
+    nextTask.final_message =
+      typeof payload.message === 'string' ? payload.message : null;
+    nextTask.error_message = null;
     nextTask.finished_at = event.created_at;
   }
 
@@ -213,6 +224,11 @@ function buildAssistantMessage(
       typeof payload.message === 'string'
     ) {
       content = payload.message;
+    } else if (
+      event.event_type === 'takeover' &&
+      typeof payload.message === 'string'
+    ) {
+      content = payload.message;
     }
   }
 
@@ -275,6 +291,11 @@ export function ChatKitPanel({
   const [aborting, setAborting] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [sessionId, setSessionId] = React.useState<string | null>(null);
+  const [waitingForUserInteraction, setWaitingForUserInteraction] =
+    React.useState(false);
+  const [interactionPrompt, setInteractionPrompt] = React.useState<
+    string | null
+  >(null);
   const messagesEndRef = React.useRef<HTMLDivElement>(null);
   const scrollAreaRef = React.useRef<HTMLDivElement>(null);
   const isNearBottomRef = React.useRef(true);
@@ -477,17 +498,33 @@ export function ChatKitPanel({
           }
           replaceTaskMessages();
 
+          // Check for interaction required actions
+          if (event.event_type === 'step') {
+            const action = event.payload.action as Record<string, unknown>;
+            if (action && isInteractionRequired(action)) {
+              setWaitingForUserInteraction(true);
+              setInteractionPrompt(getInteractionPrompt(action));
+              setLoading(false);
+              setAborting(false);
+              return;
+            }
+          }
+
           const nextTask = taskRunsRef.current[taskId];
           if (nextTask && !isTaskActive(nextTask.status)) {
             currentTaskIdRef.current = null;
             setLoading(false);
             setAborting(false);
+            setWaitingForUserInteraction(false);
+            setInteractionPrompt(null);
           }
         },
         message => {
           setError(message);
           setLoading(false);
           setAborting(false);
+          setWaitingForUserInteraction(false);
+          setInteractionPrompt(null);
         },
         afterSeq
       );
@@ -613,6 +650,12 @@ export function ChatKitPanel({
     setLoading(true);
     setError(null);
 
+    // Clear interaction state if we were waiting for user interaction
+    if (waitingForUserInteraction) {
+      setWaitingForUserInteraction(false);
+      setInteractionPrompt(null);
+    }
+
     try {
       const task = await submitTaskSessionTask(sessionId, inputValue);
       const initialEvents = (await listTaskEvents(task.id)).events;
@@ -638,7 +681,14 @@ export function ChatKitPanel({
       setLoading(false);
       setAborting(false);
     }
-  }, [attachTaskStream, input, loading, replaceTaskMessages, sessionId]);
+  }, [
+    attachTaskStream,
+    input,
+    loading,
+    replaceTaskMessages,
+    sessionId,
+    waitingForUserInteraction,
+  ]);
 
   const handleAbort = React.useCallback(() => {
     const taskId = currentTaskIdRef.current;
@@ -694,6 +744,8 @@ export function ChatKitPanel({
       setLoading(false);
       setError(null);
       setAborting(false);
+      setWaitingForUserInteraction(false);
+      setInteractionPrompt(null);
     } catch (resetError) {
       console.error('Failed to reset layered task session:', resetError);
       setError(getErrorMessage(resetError));
@@ -822,6 +874,16 @@ export function ChatKitPanel({
           <div className="mx-4 mt-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-sm text-red-600 dark:text-red-400 flex items-center gap-2">
             <AlertCircle className="w-4 h-4 flex-shrink-0" />
             {error}
+          </div>
+        )}
+
+        {/* Interaction waiting indicator */}
+        {waitingForUserInteraction && (
+          <div className="mx-4 mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-xl text-sm text-blue-600 dark:text-blue-400 flex items-center gap-2">
+            <Hand className="w-4 h-4 flex-shrink-0" />
+            <span className="whitespace-pre-line">
+              {interactionPrompt || '等待用户输入...'}
+            </span>
           </div>
         )}
 
@@ -965,30 +1027,45 @@ export function ChatKitPanel({
                         )}
 
                         {/* Final Response */}
-                        {message.content && (
-                          <div className="flex justify-start">
-                            <div
-                              className={`max-w-[85%] rounded-2xl rounded-tl-sm px-4 py-3 ${
-                                message.success === false
-                                  ? 'bg-red-100 dark:bg-red-900/20 text-red-600 dark:text-red-400'
-                                  : 'bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300'
-                              }`}
-                            >
-                              <div className="flex items-start gap-2">
-                                {message.success !== undefined && (
-                                  <CheckCircle2
-                                    className={`w-5 h-5 flex-shrink-0 mt-0.5 ${
-                                      message.success
-                                        ? 'text-green-500'
-                                        : 'text-red-500'
-                                    }`}
-                                  />
-                                )}
-                                <MarkdownContent content={message.content} />
+                        {message.content &&
+                          (() => {
+                            const isTakeoverMsg =
+                              message.content.startsWith(
+                                'TAKEOVER_REQUIRED:'
+                              ) ||
+                              message.content.startsWith('INTERACT_REQUIRED:');
+                            return (
+                              <div className="flex justify-start">
+                                <div
+                                  className={`max-w-[85%] rounded-2xl rounded-tl-sm px-4 py-3 ${
+                                    message.success === false
+                                      ? 'bg-red-100 dark:bg-red-900/20 text-red-600 dark:text-red-400'
+                                      : isTakeoverMsg
+                                        ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-800'
+                                        : 'bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300'
+                                  }`}
+                                >
+                                  <div className="flex items-start gap-2">
+                                    {message.success !== undefined &&
+                                      (isTakeoverMsg ? (
+                                        <AlertCircle className="w-5 h-5 flex-shrink-0 mt-0.5 text-amber-500" />
+                                      ) : (
+                                        <CheckCircle2
+                                          className={`w-5 h-5 flex-shrink-0 mt-0.5 ${
+                                            message.success
+                                              ? 'text-green-500'
+                                              : 'text-red-500'
+                                          }`}
+                                        />
+                                      ))}
+                                    <MarkdownContent
+                                      content={message.content}
+                                    />
+                                  </div>
+                                </div>
                               </div>
-                            </div>
-                          </div>
-                        )}
+                            );
+                          })()}
 
                         {/* Streaming indicator */}
                         {message.isStreaming && !message.content && (
@@ -1038,10 +1115,12 @@ export function ChatKitPanel({
               onChange={e => setInput(e.target.value)}
               onKeyDown={handleInputKeyDown}
               placeholder={
-                t.devicePanel?.whatToDo ||
-                'What would you like to do? (Cmd+Enter to send)'
+                waitingForUserInteraction
+                  ? interactionPrompt || '请输入您的回复'
+                  : t.devicePanel?.whatToDo ||
+                    'What would you like to do? (Cmd+Enter to send)'
               }
-              disabled={loading}
+              disabled={loading && !waitingForUserInteraction}
               className="flex-1 min-h-[40px] max-h-[120px] resize-none"
               rows={1}
             />

--- a/frontend/src/components/ChatKitPanel.tsx
+++ b/frontend/src/components/ChatKitPanel.tsx
@@ -509,6 +509,22 @@ export function ChatKitPanel({
               return;
             }
           }
+          if (
+            event.event_type === 'takeover' &&
+            typeof event.payload.message === 'string'
+          ) {
+            setWaitingForUserInteraction(true);
+            setInteractionPrompt(
+              getInteractionPrompt({
+                action: 'Take_over',
+                message: event.payload.message,
+              })
+            );
+            setLoading(false);
+            setAborting(false);
+            currentTaskIdRef.current = null;
+            return;
+          }
 
           const nextTask = taskRunsRef.current[taskId];
           if (nextTask && !isTaskActive(nextTask.status)) {
@@ -644,7 +660,9 @@ export function ChatKitPanel({
 
   const handleSend = React.useCallback(async () => {
     const inputValue = input.trim();
-    if (!inputValue || loading || !sessionId) return;
+    const messageValue =
+      inputValue || (waitingForUserInteraction ? '继续' : '');
+    if (!messageValue || loading || !sessionId) return;
 
     setInput('');
     setLoading(true);
@@ -657,7 +675,7 @@ export function ChatKitPanel({
     }
 
     try {
-      const task = await submitTaskSessionTask(sessionId, inputValue);
+      const task = await submitTaskSessionTask(sessionId, messageValue);
       const initialEvents = (await listTaskEvents(task.id)).events;
       const reconciledTask = reconcileTaskRun(task, initialEvents);
       taskRunsRef.current[task.id] = reconciledTask;

--- a/frontend/src/components/DevicePanel.tsx
+++ b/frontend/src/components/DevicePanel.tsx
@@ -11,6 +11,7 @@ import {
   Square,
   ImagePlus,
   X,
+  Hand,
 } from 'lucide-react';
 import { DeviceMonitor } from './DeviceMonitor';
 import type {
@@ -67,6 +68,7 @@ interface DevicePanelProps {
   isConfigured: boolean;
   isVisible?: boolean; // ✅ 新增：控制视频流行为
   unlimitedStepsEnabled?: boolean;
+  agentType?: string;
 }
 
 const IMAGE_ATTACHMENT_TYPES = new Set([
@@ -214,6 +216,7 @@ export function DevicePanel({
   isConfigured,
   isVisible = true, // ✅ 新增：默认 true 向后兼容
   unlimitedStepsEnabled = false,
+  agentType,
 }: DevicePanelProps) {
   const t = useTranslation();
   const [input, setInput] = useState('');
@@ -233,6 +236,8 @@ export function DevicePanel({
     loading,
     aborting,
     waitingForDevice,
+    waitingForUserInteraction,
+    interactionPrompt,
     error,
     sessionReady,
     sendMessage,
@@ -242,6 +247,7 @@ export function DevicePanel({
     deviceId,
     deviceSerial,
     sessionStorageKey: `autoglm:classic-session:${deviceSerial}`,
+    agentType,
   });
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -835,7 +841,7 @@ export function DevicePanel({
                                   <Sparkles className="h-3 w-3 text-[#1d9bf0]" />
                                 </div>
                                 <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
-                                  Step {idx + 1}
+                                  Step {message.stepNumbers?.[idx] ?? idx + 1}
                                 </span>
                               </div>
                               <p className="text-sm whitespace-pre-wrap text-slate-700 dark:text-slate-300">
@@ -1005,46 +1011,57 @@ export function DevicePanel({
                         )}
 
                         {/* Final result */}
-                        {message.content && (
-                          <div
-                            className={`
-                          rounded-2xl px-4 py-3 flex items-start gap-2
-                          ${
-                            message.success === false
-                              ? 'bg-red-100 dark:bg-red-900/20 text-red-600 dark:text-red-400'
-                              : 'bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300'
-                          }
-                        `}
-                          >
-                            <CheckCircle2
-                              className={`w-5 h-5 flex-shrink-0 mt-0.5 ${
-                                message.success === false
-                                  ? 'text-red-500'
-                                  : 'text-green-500'
-                              }`}
-                            />
-                            <div className="min-w-0 flex-1">
-                              <MarkdownContent content={message.content} />
-                              {message.steps !== undefined && (
-                                <p className="text-xs mt-2 opacity-60 text-slate-500 dark:text-slate-400">
-                                  {message.steps} steps completed
-                                </p>
-                              )}
-                              {message.errorDetails && (
-                                <details className="mt-3 text-xs">
-                                  <summary className="cursor-pointer font-medium text-red-700 hover:text-red-800 dark:text-red-300 dark:hover:text-red-200 transition-colors">
-                                    Model error details
-                                  </summary>
-                                  <pre className="mt-2 max-h-80 overflow-auto rounded-lg border border-red-200 bg-white/80 p-3 text-left font-mono text-[11px] leading-relaxed text-slate-800 dark:border-red-900/60 dark:bg-slate-950/70 dark:text-slate-200">
-                                    {formatModelErrorDetails(
-                                      message.errorDetails
-                                    )}
-                                  </pre>
-                                </details>
-                              )}
-                            </div>
-                          </div>
-                        )}
+                        {message.content &&
+                          (() => {
+                            const isTakeoverMsg =
+                              message.content.startsWith(
+                                'TAKEOVER_REQUIRED:'
+                              ) ||
+                              message.content.startsWith('INTERACT_REQUIRED:');
+                            return (
+                              <div
+                                className={`rounded-2xl px-4 py-3 flex items-start gap-2 ${
+                                  message.success === false
+                                    ? 'bg-red-100 dark:bg-red-900/20 text-red-600 dark:text-red-400'
+                                    : isTakeoverMsg
+                                      ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-800'
+                                      : 'bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300'
+                                }`}
+                              >
+                                {isTakeoverMsg ? (
+                                  <AlertCircle className="w-5 h-5 flex-shrink-0 mt-0.5 text-amber-500" />
+                                ) : (
+                                  <CheckCircle2
+                                    className={`w-5 h-5 flex-shrink-0 mt-0.5 ${
+                                      message.success === false
+                                        ? 'text-red-500'
+                                        : 'text-green-500'
+                                    }`}
+                                  />
+                                )}
+                                <div className="min-w-0 flex-1">
+                                  <MarkdownContent content={message.content} />
+                                  {message.steps !== undefined && (
+                                    <p className="text-xs mt-2 opacity-60 text-slate-500 dark:text-slate-400">
+                                      {message.steps} steps completed
+                                    </p>
+                                  )}
+                                  {message.errorDetails && (
+                                    <details className="mt-3 text-xs">
+                                      <summary className="cursor-pointer font-medium text-red-700 hover:text-red-800 dark:text-red-300 dark:hover:text-red-200 transition-colors">
+                                        Model error details
+                                      </summary>
+                                      <pre className="mt-2 max-h-80 overflow-auto rounded-lg border border-red-200 bg-white/80 p-3 text-left font-mono text-[11px] leading-relaxed text-slate-800 dark:border-red-900/60 dark:bg-slate-950/70 dark:text-slate-200">
+                                        {formatModelErrorDetails(
+                                          message.errorDetails
+                                        )}
+                                      </pre>
+                                    </details>
+                                  )}
+                                </div>
+                              </div>
+                            );
+                          })()}
 
                         {/* Streaming indicator */}
                         {message.isStreaming && (
@@ -1130,6 +1147,14 @@ export function DevicePanel({
               <span>Waiting for device...</span>
             </div>
           )}
+          {waitingForUserInteraction && (
+            <div className="mb-3 flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-700 dark:border-blue-900/50 dark:bg-blue-950/30 dark:text-blue-300">
+              <Hand className="h-4 w-4" />
+              <span className="whitespace-pre-line">
+                {interactionPrompt || '等待用户输入...'}
+              </span>
+            </div>
+          )}
           {attachments.length > 0 && (
             <div className="mb-3 flex flex-wrap gap-2">
               {attachments.map((attachment, idx) => (
@@ -1163,11 +1188,13 @@ export function DevicePanel({
               onKeyDown={handleInputKeyDown}
               onPaste={handlePaste}
               placeholder={
-                !isConfigured
-                  ? t.devicePanel.configureFirst
-                  : t.devicePanel.whatToDo
+                waitingForUserInteraction
+                  ? interactionPrompt || '请输入您的回复'
+                  : !isConfigured
+                    ? t.devicePanel.configureFirst
+                    : t.devicePanel.whatToDo
               }
-              disabled={loading}
+              disabled={loading && !waitingForUserInteraction}
               className="flex-1 min-h-[40px] max-h-[120px] resize-none"
               rows={1}
             />

--- a/frontend/src/components/MarkdownContent.tsx
+++ b/frontend/src/components/MarkdownContent.tsx
@@ -15,7 +15,7 @@ export function MarkdownContent({
   prose = true,
 }: MarkdownContentProps) {
   const rootClassName = [
-    'min-w-0 w-full max-w-full',
+    'min-w-0 w-full max-w-full break-words',
     prose
       ? 'prose dark:prose-invert max-w-none prose-pre:text-sm prose-code:text-sm [&_ol:first-child]:mt-0 [&_ol:last-child]:mb-0 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_pre:first-child]:mt-0 [&_pre:last-child]:mb-0 [&_ul:first-child]:mt-0 [&_ul:last-child]:mb-0'
       : 'whitespace-pre-wrap text-current [&_a]:text-current [&_a]:underline [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:m-0 [&_strong]:text-current [&_ul]:list-disc [&_ul]:pl-5',

--- a/frontend/src/hooks/useTaskSessionConversation.ts
+++ b/frontend/src/hooks/useTaskSessionConversation.ts
@@ -381,6 +381,23 @@ export function useTaskSessionConversation({
           return;
         }
       }
+      if (
+        event.event_type === 'takeover' &&
+        typeof event.payload.message === 'string'
+      ) {
+        setWaitingForUserInteraction(true);
+        setInteractionPrompt(
+          getInteractionPrompt({
+            action: 'Take_over',
+            message: event.payload.message,
+          })
+        );
+        setLoading(false);
+        setAborting(false);
+        setWaitingForDevice(false);
+        currentTaskIdRef.current = null;
+        return;
+      }
 
       // 如果正在等待用户交互，不清除状态
       if (waitingForUserInteraction) {
@@ -533,7 +550,13 @@ export function useTaskSessionConversation({
   const sendMessage = useCallback(
     async (input: string, attachments: TaskImageAttachment[] = []) => {
       const inputValue = input.trim();
-      if ((!inputValue && attachments.length === 0) || loading || !sessionId) {
+      const messageValue =
+        inputValue || (waitingForUserInteraction ? '继续' : '');
+      if (
+        (!messageValue && attachments.length === 0) ||
+        loading ||
+        !sessionId
+      ) {
         return false;
       }
 
@@ -549,7 +572,7 @@ export function useTaskSessionConversation({
 
         const task = await submitTaskSessionTask(
           sessionId,
-          inputValue,
+          messageValue,
           attachments
         );
         const initialEvents = (await listTaskEvents(task.id)).events;

--- a/frontend/src/hooks/useTaskSessionConversation.ts
+++ b/frontend/src/hooks/useTaskSessionConversation.ts
@@ -23,6 +23,10 @@ import {
   streamTaskEvents,
   submitTaskSessionTask,
 } from '../api';
+import {
+  isInteractionRequired,
+  getInteractionPrompt,
+} from '../lib/interaction-config';
 
 export interface TaskConversationMessage {
   id: string;
@@ -30,6 +34,7 @@ export interface TaskConversationMessage {
   content: string;
   timestamp: Date;
   steps?: number;
+  stepNumbers?: number[];
   success?: boolean;
   thinking?: string[];
   actions?: Record<string, unknown>[];
@@ -45,6 +50,7 @@ interface UseTaskSessionConversationOptions {
   deviceId: string;
   deviceSerial: string;
   sessionStorageKey: string;
+  agentType?: string;
 }
 
 interface UseTaskSessionConversationResult {
@@ -53,6 +59,8 @@ interface UseTaskSessionConversationResult {
   loading: boolean;
   aborting: boolean;
   waitingForDevice: boolean;
+  waitingForUserInteraction: boolean;
+  interactionPrompt: string | null;
   error: string | null;
   sessionReady: boolean;
   sendMessage: (
@@ -108,6 +116,15 @@ function applyTaskEventToTask(
     nextTask.error_message =
       typeof payload.message === 'string' ? payload.message : null;
     nextTask.finished_at = event.created_at;
+  } else if (event.event_type === 'takeover') {
+    nextTask.status = 'SUCCEEDED';
+    nextTask.final_message =
+      typeof payload.message === 'string' ? payload.message : null;
+    nextTask.error_message = null;
+    nextTask.finished_at = event.created_at;
+    if (typeof payload.steps === 'number') {
+      nextTask.step_count = payload.steps;
+    }
   } else if (event.event_type === 'step' && typeof payload.step === 'number') {
     nextTask.step_count = Math.max(nextTask.step_count, payload.step);
   }
@@ -133,6 +150,7 @@ function buildAssistantMessage(
   const actions: Record<string, unknown>[] = [];
   const screenshots: (string | undefined)[] = [];
   const stepTimings: (StepTimingSummary | undefined)[] = [];
+  const stepNumbers: number[] = [];
   let errorDetails: ModelErrorDetails | undefined;
   let currentThinking = '';
   let content = task.final_message || task.error_message || '';
@@ -163,6 +181,9 @@ function buildAssistantMessage(
             : currentThinking;
         thinking.push(stepThinking);
         actions.push((payload.action as Record<string, unknown>) || {});
+        stepNumbers.push(
+          typeof payload.step === 'number' ? payload.step : thinking.length
+        );
         screenshots.push(
           typeof payload.screenshot === 'string'
             ? payload.screenshot
@@ -216,6 +237,17 @@ function buildAssistantMessage(
         currentThinking = '';
         break;
       }
+      case 'takeover': {
+        if (typeof payload.message === 'string') {
+          content = payload.message;
+        }
+        if (typeof payload.steps === 'number') {
+          steps = payload.steps;
+        }
+        success = true;
+        currentThinking = '';
+        break;
+      }
     }
   });
 
@@ -228,6 +260,7 @@ function buildAssistantMessage(
     actions,
     screenshots,
     stepTimings,
+    stepNumbers,
     errorDetails,
     steps,
     success,
@@ -270,11 +303,17 @@ export function useTaskSessionConversation({
   deviceId,
   deviceSerial,
   sessionStorageKey,
+  agentType,
 }: UseTaskSessionConversationOptions): UseTaskSessionConversationResult {
   const [messages, setMessages] = useState<TaskConversationMessage[]>([]);
   const [loading, setLoading] = useState(false);
   const [aborting, setAborting] = useState(false);
   const [waitingForDevice, setWaitingForDevice] = useState(false);
+  const [waitingForUserInteraction, setWaitingForUserInteraction] =
+    useState(false);
+  const [interactionPrompt, setInteractionPrompt] = useState<string | null>(
+    null
+  );
   const [error, setError] = useState<string | null>(null);
   const [sessionId, setSessionId] = useState<string | null>(null);
   const chatStreamRef = useRef<{ close: () => void } | null>(null);
@@ -330,6 +369,24 @@ export function useTaskSessionConversation({
       setWaitingForDevice(isTaskWaitingForDevice(nextTask));
       replaceTaskMessages(taskId);
 
+      // Check for interaction required actions
+      if (event.event_type === 'step') {
+        const action = event.payload.action as Record<string, unknown>;
+        if (action && isInteractionRequired(action, agentType)) {
+          setWaitingForUserInteraction(true);
+          setInteractionPrompt(getInteractionPrompt(action));
+          setLoading(false);
+          setAborting(false);
+          setWaitingForDevice(false);
+          return;
+        }
+      }
+
+      // 如果正在等待用户交互，不清除状态
+      if (waitingForUserInteraction) {
+        return;
+      }
+
       if (
         !isTaskActive(nextTask.status) &&
         currentTaskIdRef.current === taskId
@@ -337,10 +394,12 @@ export function useTaskSessionConversation({
         setLoading(false);
         setAborting(false);
         setWaitingForDevice(false);
+        setWaitingForUserInteraction(false);
+        setInteractionPrompt(null);
         currentTaskIdRef.current = null;
       }
     },
-    [replaceTaskMessages]
+    [replaceTaskMessages, agentType, waitingForUserInteraction]
   );
 
   const attachTaskStream = useCallback(
@@ -481,6 +540,13 @@ export function useTaskSessionConversation({
       try {
         setError(null);
         setLoading(true);
+
+        // Clear interaction state if we were waiting for user interaction
+        if (waitingForUserInteraction) {
+          setWaitingForUserInteraction(false);
+          setInteractionPrompt(null);
+        }
+
         const task = await submitTaskSessionTask(
           sessionId,
           inputValue,
@@ -518,7 +584,13 @@ export function useTaskSessionConversation({
         return false;
       }
     },
-    [attachTaskStream, loading, replaceTaskMessages, sessionId]
+    [
+      attachTaskStream,
+      loading,
+      replaceTaskMessages,
+      sessionId,
+      waitingForUserInteraction,
+    ]
   );
 
   const resetConversation = useCallback(async () => {
@@ -588,6 +660,8 @@ export function useTaskSessionConversation({
     loading,
     aborting,
     waitingForDevice,
+    waitingForUserInteraction,
+    interactionPrompt,
     error,
     sessionReady: sessionId !== null,
     sendMessage,

--- a/frontend/src/lib/interaction-config.ts
+++ b/frontend/src/lib/interaction-config.ts
@@ -1,0 +1,81 @@
+export interface InteractionConfig {
+  actions: string[];
+  agentOverrides?: Record<string, string[]>;
+}
+
+const defaultInteractionConfig: InteractionConfig = {
+  actions: ['Interact', 'Take_over'],
+  agentOverrides: {
+    mai: ['Interact', 'Take_over', 'Ask_User'],
+    gemini: ['Interact', 'Take_over'],
+    'glm-async': ['Interact', 'Take_over'],
+    qwen: ['Interact', 'Take_over'],
+    droidrun: ['Interact', 'Take_over'],
+    midscene: ['Interact', 'Take_over'],
+  },
+};
+
+export function getInteractionConfig(agentType?: string): InteractionConfig {
+  if (agentType && defaultInteractionConfig.agentOverrides?.[agentType]) {
+    return {
+      ...defaultInteractionConfig,
+      actions: defaultInteractionConfig.agentOverrides[agentType],
+    };
+  }
+  return defaultInteractionConfig;
+}
+
+export function isInteractionRequired(
+  action: Record<string, unknown>,
+  agentType?: string
+): boolean {
+  const actionName = action.action as string;
+  if (!actionName) return false;
+
+  // 检查action名称是否在配置中
+  const config = getInteractionConfig(agentType);
+  if (config.actions.includes(actionName)) return true;
+
+  // 检查消息内容是否包含交互标记
+  const message = action.message as string;
+  if (message) {
+    if (
+      message.startsWith('TAKEOVER_REQUIRED:') ||
+      message.startsWith('INTERACT_REQUIRED:')
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function getInteractionPrompt(action: Record<string, unknown>): string {
+  const actionName = action.action as string;
+  const message = action.message as string;
+
+  // 处理新的消息格式
+  if (message) {
+    if (message.startsWith('TAKEOVER_REQUIRED:')) {
+      return (
+        message.replace('TAKEOVER_REQUIRED:', '').trim() ||
+        '请完成操作后按回车继续'
+      );
+    }
+    if (message.startsWith('INTERACT_REQUIRED:')) {
+      return (
+        message.replace('INTERACT_REQUIRED:', '').trim() ||
+        '请选择一个选项或输入您的选择'
+      );
+    }
+  }
+
+  switch (actionName) {
+    case 'Interact':
+      return message || '请选择一个选项或输入您的选择';
+    case 'Take_over':
+      return message || '请完成操作后按回车继续';
+    default:
+      return message || '请输入您的回复';
+  }
+}

--- a/frontend/src/routes/chat.tsx
+++ b/frontend/src/routes/chat.tsx
@@ -1243,6 +1243,7 @@ export function ChatComponent() {
                     isConfigured={!!config?.base_url}
                     isVisible={currentDevice.id === currentDeviceId}
                     unlimitedStepsEnabled={config?.default_max_steps === null}
+                    agentType={config?.agent_type}
                   />
                 </div>
               )}

--- a/tests/test_agents_chat_config_api.py
+++ b/tests/test_agents_chat_config_api.py
@@ -39,8 +39,9 @@ class FakeAsyncAgent:
             raise self.run_error
         return self.run_result
 
-    async def stream(self, message: str):
+    async def stream(self, message: str, *, continue_with: str | None = None):
         _ = message
+        _ = continue_with
         if self.stream_error is not None:
             raise self.stream_error
         for event in self.stream_events:
@@ -371,8 +372,9 @@ def test_chat_stream_emits_sse_events(
 def test_chat_stream_persists_step_timings_from_trace_context(
     env: dict[str, Any],
 ) -> None:
-    async def traced_stream(message: str):
+    async def traced_stream(message: str, *, continue_with: str | None = None):
         _ = message
+        _ = continue_with
         with trace_module.trace_span("agent.step", attrs={"step": 1}):
             with trace_module.trace_span("step.llm", attrs={"step": 1}):
                 pass

--- a/tests/test_interaction_actions.py
+++ b/tests/test_interaction_actions.py
@@ -1,0 +1,224 @@
+"""Test Take_over / Interact action handling and user interaction flow."""
+
+from typing import Any
+from AutoGLM_GUI.actions import ActionHandler
+
+
+class FakeDevice:
+    """Minimal fake device for action handler tests."""
+
+    @property
+    def device_id(self) -> str:
+        return "fake-device"
+
+    def tap(self, x: int, y: int, delay: float | None = None) -> None:
+        _ = delay
+
+    def swipe(
+        self,
+        start_x: int,
+        start_y: int,
+        end_x: int,
+        end_y: int,
+        duration_ms: int | None = None,
+        delay: float | None = None,
+    ) -> None:
+        _ = (duration_ms, delay)
+
+    def type_text(self, text: str) -> None: ...
+
+    def back(self, delay: float | None = None) -> None:
+        _ = delay
+
+    def home(self, delay: float | None = None) -> None:
+        _ = delay
+
+    def double_tap(self, x: int, y: int, delay: float | None = None) -> None:
+        _ = delay
+
+    def long_press(
+        self,
+        x: int,
+        y: int,
+        duration_ms: int = 3000,
+        delay: float | None = None,
+    ) -> None:
+        _ = (duration_ms, delay)
+
+    def launch_app(self, app_name: str, delay: float | None = None) -> bool:
+        _ = delay
+        return True
+
+    def get_screenshot(self, timeout: int = 10) -> Any:
+        return None
+
+    def get_current_app(self) -> str:
+        return "TestApp"
+
+    def detect_and_set_adb_keyboard(self) -> str:
+        return ""
+
+    def restore_keyboard(self, ime: str) -> None: ...
+
+    def clear_text(self) -> None: ...
+
+
+def _noop_takeover(message: str) -> None:
+    pass
+
+
+class TestTakeoverAction:
+    """Test Take_over action handler behavior."""
+
+    def test_takeover_success_and_should_not_finish(self) -> None:
+        device = FakeDevice()
+        handler = ActionHandler(device, takeover_callback=_noop_takeover)
+
+        result = handler.execute(
+            {"_metadata": "do", "action": "Take_over", "message": "请登录后继续"},
+            100,
+            200,
+        )
+
+        assert result.success is True
+        assert result.should_finish is False
+        assert result.message == "TAKEOVER_REQUIRED:\n 请登录后继续"
+
+    def test_takeover_default_message(self) -> None:
+        device = FakeDevice()
+        handler = ActionHandler(device, takeover_callback=_noop_takeover)
+
+        result = handler.execute(
+            {"_metadata": "do", "action": "Take_over"},
+            100,
+            200,
+        )
+
+        assert result.success is True
+        assert result.message == ("TAKEOVER_REQUIRED:\n User intervention required")
+
+    def test_takeover_callback_receives_raw_message(self) -> None:
+        device = FakeDevice()
+        takeovers: list[str] = []
+
+        handler = ActionHandler(
+            device, takeover_callback=lambda msg: takeovers.append(msg)
+        )
+
+        result = handler.execute(
+            {"_metadata": "do", "action": "Take_over", "message": "login"},
+            100,
+            200,
+        )
+
+        assert result.success is True
+        assert takeovers == ["login"]
+
+
+class TestInteractAction:
+    """Test Interact action handler behavior."""
+
+    def test_interact_success_and_should_not_finish(self) -> None:
+        device = FakeDevice()
+        handler = ActionHandler(device)
+
+        result = handler.execute(
+            {"_metadata": "do", "action": "Interact"},
+            100,
+            200,
+        )
+
+        assert result.success is True
+        assert result.should_finish is False
+        assert result.message == "INTERACT_REQUIRED: User interaction required"
+
+
+class TestInteractionActionsIntegration:
+    """Test the full interaction flow covering agent-executor handoff.
+
+    These tests verify the contract between the backend ActionHandler,
+    the agent stream loop (takeover event yielding), and frontend detection.
+    """
+
+    def test_takeover_message_format_for_frontend_detection(self) -> None:
+        """Frontend detects takeover by content prefix."""
+        device = FakeDevice()
+        handler = ActionHandler(device, takeover_callback=_noop_takeover)
+
+        result = handler.execute(
+            {"_metadata": "do", "action": "Take_over", "message": "请操作"},
+            100,
+            200,
+        )
+
+        assert result.message is not None
+        assert result.message.startswith("TAKEOVER_REQUIRED:")
+
+    def test_interact_message_format_for_frontend_detection(self) -> None:
+        """Frontend detects interact by content prefix."""
+        device = FakeDevice()
+        handler = ActionHandler(device)
+
+        result = handler.execute(
+            {"_metadata": "do", "action": "Interact"},
+            100,
+            200,
+        )
+
+        assert result.message is not None
+        assert result.message.startswith("INTERACT_REQUIRED:")
+
+    def test_multiline_takeover_message(self) -> None:
+        """Take_over message with multiline content should keep format."""
+        device = FakeDevice()
+        handler = ActionHandler(device, takeover_callback=_noop_takeover)
+
+        message = "请选择登录方式：\n1. 手机号\n2. 邮箱"
+        result = handler.execute(
+            {"_metadata": "do", "action": "Take_over", "message": message},
+            100,
+            200,
+        )
+
+        assert result.message is not None
+        assert message in result.message
+        assert result.message.startswith("TAKEOVER_REQUIRED:")
+
+    def test_takeover_as_part_of_step_flow(self) -> None:
+        """Normal actions before and after Take_over should work correctly."""
+        device = FakeDevice()
+        handler = ActionHandler(device, takeover_callback=_noop_takeover)
+
+        launch = handler.execute(
+            {"_metadata": "do", "action": "Launch", "app": "飞书"}, 100, 200
+        )
+        assert launch.success is True
+        assert launch.should_finish is False
+
+        takeover = handler.execute(
+            {"_metadata": "do", "action": "Take_over", "message": "登录"},
+            100,
+            200,
+        )
+        assert takeover.success is True
+        assert takeover.should_finish is False
+
+        back = handler.execute({"_metadata": "do", "action": "Back"}, 100, 200)
+        assert back.success is True
+        assert back.should_finish is False
+
+    def test_takeover_preserves_should_not_finish(self) -> None:
+        """Take_over/Interact must never set should_finish=True so
+        the agent stream loop yields a takeover event instead of stopping."""
+        device = FakeDevice()
+        handler = ActionHandler(device, takeover_callback=_noop_takeover)
+
+        for action_dict in (
+            {"_metadata": "do", "action": "Take_over", "message": "x"},
+            {"_metadata": "do", "action": "Interact"},
+        ):
+            result = handler.execute(action_dict, 100, 200)
+            assert result.success is True, f"Expected success for {action_dict}"
+            assert result.should_finish is False, (
+                f"should_finish must be False for {action_dict}"
+            )

--- a/tests/test_interaction_actions.py
+++ b/tests/test_interaction_actions.py
@@ -1,7 +1,13 @@
 """Test Take_over / Interact action handling and user interaction flow."""
 
+import asyncio
+from collections.abc import AsyncGenerator
 from typing import Any
+
 from AutoGLM_GUI.actions import ActionHandler
+from AutoGLM_GUI.agents.base import AsyncAgentBase
+from AutoGLM_GUI.config import AgentConfig, ModelConfig
+from AutoGLM_GUI.model import MessageBuilder
 
 
 class FakeDevice:
@@ -61,6 +67,84 @@ class FakeDevice:
     def restore_keyboard(self, ime: str) -> None: ...
 
     def clear_text(self) -> None: ...
+
+
+class FakeScreenshot:
+    base64_data = "fake-screen"
+
+
+class StreamFakeDevice(FakeDevice):
+    def __init__(self) -> None:
+        self.screenshot_calls = 0
+        self.current_app_calls = 0
+
+    def get_screenshot(self, timeout: int = 10) -> Any:
+        _ = timeout
+        self.screenshot_calls += 1
+        return FakeScreenshot()
+
+    def get_current_app(self) -> str:
+        self.current_app_calls += 1
+        return "TestApp"
+
+
+class FakeInteractionAgent(AsyncAgentBase):
+    def __init__(self, device: StreamFakeDevice) -> None:
+        self.prepared_tasks: list[str] = []
+        super().__init__(
+            model_config=ModelConfig(),
+            agent_config=AgentConfig(max_steps=5, verbose=False),
+            device=device,
+            takeover_callback=_noop_takeover,
+        )
+
+    def _get_default_system_prompt(self, lang: str) -> str:
+        _ = lang
+        return "system"
+
+    def _prepare_initial_context(
+        self,
+        task: str,
+        screenshot_base64: str,
+        current_app: str,
+        reference_images: list[dict[str, str]] | None = None,
+    ) -> None:
+        _ = reference_images
+        self.prepared_tasks.append(task)
+        self._context.append(
+            MessageBuilder.create_user_message(
+                f"{task}|{screenshot_base64}|{current_app}"
+            )
+        )
+
+    async def _execute_step(self) -> AsyncGenerator[dict[str, Any], None]:
+        self._step_count += 1
+        if self._step_count == 1:
+            yield {
+                "type": "step",
+                "data": {
+                    "step": self._step_count,
+                    "thinking": "need user",
+                    "action": {"action": "Take_over", "message": "登录后继续"},
+                    "success": True,
+                    "finished": False,
+                    "waiting_for_input": True,
+                    "message": "TAKEOVER_REQUIRED:\n 登录后继续",
+                },
+            }
+            return
+
+        yield {
+            "type": "step",
+            "data": {
+                "step": self._step_count,
+                "thinking": "continued",
+                "action": {"action": "Tap"},
+                "success": True,
+                "finished": True,
+                "message": "done",
+            },
+        }
 
 
 def _noop_takeover(message: str) -> None:
@@ -134,11 +218,7 @@ class TestInteractAction:
 
 
 class TestInteractionActionsIntegration:
-    """Test the full interaction flow covering agent-executor handoff.
-
-    These tests verify the contract between the backend ActionHandler,
-    the agent stream loop (takeover event yielding), and frontend detection.
-    """
+    """Test interaction contracts across backend layers."""
 
     def test_takeover_message_format_for_frontend_detection(self) -> None:
         """Frontend detects takeover by content prefix."""
@@ -222,3 +302,44 @@ class TestInteractionActionsIntegration:
             assert result.should_finish is False, (
                 f"should_finish must be False for {action_dict}"
             )
+
+    def test_agent_stream_yields_takeover_and_continues_without_reset(self) -> None:
+        """Agent stream must pause on interaction and preserve state on continue."""
+        device = StreamFakeDevice()
+        agent = FakeInteractionAgent(device)
+
+        first_events = asyncio.run(_collect_stream(agent.stream("打开飞书")))
+
+        assert [event["type"] for event in first_events] == ["step", "takeover"]
+        assert first_events[0]["data"]["waiting_for_input"] is True
+        assert first_events[1]["data"] == {
+            "message": "TAKEOVER_REQUIRED:\n 登录后继续",
+            "steps": 1,
+            "success": True,
+            "stop_reason": "takeover",
+        }
+        assert agent.step_count == 1
+        assert agent.prepared_tasks == ["打开飞书"]
+        assert device.screenshot_calls == 1
+        assert device.current_app_calls == 1
+
+        second_events = asyncio.run(
+            _collect_stream(agent.stream("继续", continue_with="已完成登录"))
+        )
+
+        assert [event["type"] for event in second_events] == ["step", "done"]
+        assert second_events[0]["data"]["step"] == 2
+        assert second_events[1]["data"] == {
+            "message": "done",
+            "steps": 2,
+            "success": True,
+        }
+        assert agent.step_count == 2
+        assert agent.prepared_tasks == ["打开飞书"]
+        assert device.screenshot_calls == 1
+        assert device.current_app_calls == 1
+        assert agent.context[-1] == MessageBuilder.create_user_message("已完成登录")
+
+
+async def _collect_stream(stream: Any) -> list[dict[str, Any]]:
+    return [event async for event in stream]

--- a/tests/test_manager_device_coverage.py
+++ b/tests/test_manager_device_coverage.py
@@ -42,6 +42,7 @@ class FakeAgent:
         self.reset_count = 0
         self.cancel_count = 0
         self.attachments: list[dict[str, Any]] = []
+        self.stream_calls: list[tuple[str, str | None]] = []
 
     def reset(self) -> None:
         self.reset_count += 1
@@ -53,6 +54,7 @@ class FakeAgent:
         self.attachments = attachments
 
     async def stream(self, text: str, *, continue_with: str | None = None):
+        self.stream_calls.append((text, continue_with))
         yield {
             "type": "thinking",
             "data": {"chunk": "thinking"},
@@ -67,6 +69,47 @@ class FakeAgent:
                 "message": f"done {text}",
                 "success": True,
                 "steps": 1,
+            },
+        }
+
+
+class TakeoverResumeAgent(FakeAgent):
+    async def stream(self, text: str, *, continue_with: str | None = None):
+        self.stream_calls.append((text, continue_with))
+        if continue_with is None:
+            yield {
+                "type": "step",
+                "data": {
+                    "step": 1,
+                    "thinking": "need login",
+                    "action": {"action": "Take_over", "message": "登录后继续"},
+                    "waiting_for_input": True,
+                    "success": True,
+                    "finished": False,
+                    "message": "TAKEOVER_REQUIRED:\n 登录后继续",
+                },
+            }
+            yield {
+                "type": "takeover",
+                "data": {
+                    "message": "TAKEOVER_REQUIRED:\n 登录后继续",
+                    "steps": 1,
+                    "success": True,
+                    "stop_reason": "takeover",
+                },
+            }
+            return
+
+        yield {
+            "type": "step",
+            "data": {"step": 2, "thinking": "continued", "action": {"action": "Tap"}},
+        }
+        yield {
+            "type": "done",
+            "data": {
+                "message": f"done {continue_with}",
+                "success": True,
+                "steps": 2,
             },
         }
 
@@ -495,6 +538,79 @@ def test_task_manager_classic_chat_execution_paths(
     assert fake_phone_manager.errors[-1][1] == (
         "Current agent does not support user image attachments"
     )
+    store.close()
+
+
+def test_task_manager_classic_chat_resumes_takeover_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_task_tracing(monkeypatch)
+    store = TaskStore(tmp_path / "takeover.db")
+    manager = TaskManager(store)
+    monkeypatch.setattr(manager, "_ensure_worker", lambda device_id: None)
+
+    fake_agent = TakeoverResumeAgent()
+    fake_phone_manager = FakePhoneAgentManager(fake_agent)
+    monkeypatch.setattr(
+        PhoneAgentManager,
+        "get_instance",
+        classmethod(lambda cls: fake_phone_manager),
+    )
+
+    session = asyncio.run(
+        manager.create_chat_session(
+            device_id="device-1", device_serial="serial-1", mode="classic"
+        )
+    )
+    takeover_task = asyncio.run(
+        manager.submit_chat_task(
+            session_id=session["id"],
+            device_id="device-1",
+            device_serial="serial-1",
+            message="打开飞书",
+        )
+    )
+    takeover_task = store.get_task(takeover_task["id"])
+    assert takeover_task is not None
+
+    asyncio.run(manager._execute_classic_chat(takeover_task))
+
+    completed_takeover = store.get_task(takeover_task["id"])
+    assert completed_takeover is not None
+    assert completed_takeover["status"] == TaskStatus.SUCCEEDED.value
+    assert completed_takeover["stop_reason"] == "takeover"
+    assert completed_takeover["step_count"] == 1
+    assert manager._takeover_sessions == {session["id"]: True}
+    assert fake_agent.stream_calls == [("打开飞书", None)]
+    assert [
+        event["event_type"] for event in store.list_task_events(takeover_task["id"])
+    ].count("takeover") == 1
+
+    continue_task = asyncio.run(
+        manager.submit_chat_task(
+            session_id=session["id"],
+            device_id="device-1",
+            device_serial="serial-1",
+            message="已完成登录",
+        )
+    )
+    continue_task = store.get_task(continue_task["id"])
+    assert continue_task is not None
+
+    asyncio.run(manager._execute_classic_chat(continue_task))
+
+    completed_continue = store.get_task(continue_task["id"])
+    assert completed_continue is not None
+    assert completed_continue["status"] == TaskStatus.SUCCEEDED.value
+    assert completed_continue["final_message"] == "done 已完成登录"
+    assert completed_continue["stop_reason"] == "completed"
+    assert completed_continue["step_count"] == 2
+    assert manager._takeover_sessions == {}
+    assert fake_agent.stream_calls == [
+        ("打开飞书", None),
+        ("已完成登录", "已完成登录"),
+    ]
+    assert fake_phone_manager.errors == []
     store.close()
 
 

--- a/tests/test_manager_device_coverage.py
+++ b/tests/test_manager_device_coverage.py
@@ -52,7 +52,7 @@ class FakeAgent:
     def set_user_image_attachments(self, attachments: list[dict[str, Any]]) -> None:
         self.attachments = attachments
 
-    async def stream(self, text: str):
+    async def stream(self, text: str, *, continue_with: str | None = None):
         yield {
             "type": "thinking",
             "data": {"chunk": "thinking"},
@@ -468,7 +468,7 @@ def test_task_manager_classic_chat_execution_paths(
 
     no_attachment_agent = SimpleNamespace(cancel=lambda: None)
 
-    async def unused_stream(text: str):
+    async def unused_stream(text: str, *, continue_with: str | None = None):
         raise AssertionError("stream should not run")
         yield {}
 

--- a/tests/test_service_entry_coverage.py
+++ b/tests/test_service_entry_coverage.py
@@ -172,7 +172,7 @@ def test_action_handler_covers_supported_and_error_actions(
     assert handler.execute({"_metadata": "do", "action": "Call_API"}, 100, 200).success
     assert (
         handler.execute({"_metadata": "do", "action": "Interact"}, 100, 200).message
-        == "User interaction required"
+        == "INTERACT_REQUIRED: User interaction required"
     )
 
     def boom(*args, **kwargs):


### PR DESCRIPTION
## 改动说明
- 当模型输出 `do(action="Take_over")` 或 `do(action="Interact")` 需前端人工交互的 action 时，此前前端输入框处于 disabled 状态（loading），用户无法输入。本 PR 实现了完整的暂停-恢复流程。
- **后端**：agent 遇到 Take_over/Interact 时不停止，yield "takeover" 事件；executor 按 session 追踪 takeover 状态，下次同 session 任务以 `continue_with` 恢复，保留 step_count 不重置。
- **前端**：新增交互 action 配置模块；输入框在交互状态时可输入；takeover 消息展示 AlertCircle 琥珀色图标替代绿色 CheckCircle2。
## 相关 Issue

Closes #364 

## 改动类型
- [ ] 新功能
- [x] Bug 修复
- [ ] 文档更新
- [ ] 代码重构
- [ ] 性能优化
- [ ] 其他（请说明）

## 测试说明
- `uv run pytest tests/test_interaction_actions.py -v` — 新增测试，覆盖 takeover 消息格式、should_finish 约束、回调接口、多行消息、步骤流程
- `uv run pytest -v --ignore=tests/integration` — 507 passed, 1 skipped
- 手动测试：发送需登录的任务 → 前端弹出蓝色交互提示 → 输入凭证 → agent 继续执行且 step 编号递增

## 截图/录屏
Take_over 消息展示 AlertCircle + 蓝色背景，输入框可输入。
<img width="927" height="800" alt="image" src="https://github.com/user-attachments/assets/5e39227d-042f-48ee-bb58-6cc00a7db969" />


## 其他说明
- Qwen agent 同步补充了 step 6.5 显式检测和 Take_over prompt 定义
