### PR TITLE
Fix dual-display screenshot selection

### DIFF
--- a/AutoGLM_GUI/adb_plus/display.py
+++ b/AutoGLM_GUI/adb_plus/display.py
@@ -1,0 +1,331 @@
+"""ADB display discovery and primary-display selection helpers."""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+
+from AutoGLM_GUI.logger import logger
+from AutoGLM_GUI.platform_utils import (
+    build_adb_command,
+    run_cmd_silently,
+    run_cmd_silently_sync,
+)
+
+
+DISPLAY_SELECTION_TTL_SECONDS = 60.0
+
+
+@dataclass(frozen=True)
+class DisplayInfo:
+    """Parsed Android display information."""
+
+    logical_id: str
+    physical_id: str | None
+    width: int
+    height: int
+    state: str | None
+
+
+@dataclass(frozen=True)
+class DisplaySelection:
+    """Selected display ids for screenshot and scrcpy."""
+
+    logical_id: str
+    screencap_id: str
+    width: int
+    height: int
+    reason: str
+
+
+@dataclass(frozen=True)
+class _CacheEntry:
+    selection: DisplaySelection | None
+    expires_at: float
+
+
+_display_selection_cache: dict[tuple[str, str], _CacheEntry] = {}
+
+_DISPLAY_ID_RE = re.compile(r"\bDisplay\s+(\d+)\b|\bmDisplayId=(\d+)\b")
+_DISPLAY_ID_ALT_RE = re.compile(r"\bdisplayId\s+(\d+)\b")
+_SIZE_RE = re.compile(r"\b(\d{2,5})\s*[xX\u00d7]\s*(\d{2,5})\b")
+_UNIQUE_LOCAL_RE = re.compile(r"\buniqueId\s*=?\s*\"?local:([^\",\s}]+)")
+_STATE_RE = re.compile(
+    r"\b(?:mState|state|Display State)\s*[:= ]\s*([A-Z_]+)\b",
+    re.IGNORECASE,
+)
+_SURFACE_FLINGER_DISPLAY_ID_RE = re.compile(
+    r"\b(?:Display|display)\s+([0-9a-fA-Fx]+)\b"
+)
+
+
+def clear_display_selection_cache(
+    device_id: str | None = None,
+    adb_path: str = "adb",
+) -> None:
+    """Clear cached display selections."""
+    if device_id is None:
+        _display_selection_cache.clear()
+        return
+
+    _display_selection_cache.pop(_cache_key(device_id, adb_path), None)
+
+
+def select_primary_display(
+    device_id: str | None = None,
+    adb_path: str = "adb",
+    ttl_seconds: float = DISPLAY_SELECTION_TTL_SECONDS,
+) -> DisplaySelection | None:
+    """Select the primary display for a local ADB device."""
+    cached = _get_cached_selection(device_id, adb_path)
+    if cached is not None:
+        return cached.selection
+
+    selection = _select_primary_display_uncached(device_id, adb_path)
+    _set_cached_selection(device_id, adb_path, selection, ttl_seconds)
+    return selection
+
+
+async def select_primary_display_async(
+    device_id: str | None = None,
+    adb_path: str = "adb",
+    ttl_seconds: float = DISPLAY_SELECTION_TTL_SECONDS,
+) -> DisplaySelection | None:
+    """Async primary-display selection for API and streaming paths."""
+    cached = _get_cached_selection(device_id, adb_path)
+    if cached is not None:
+        return cached.selection
+
+    selection = await _select_primary_display_uncached_async(device_id, adb_path)
+    _set_cached_selection(device_id, adb_path, selection, ttl_seconds)
+    return selection
+
+
+def _select_primary_display_uncached(
+    device_id: str | None,
+    adb_path: str,
+) -> DisplaySelection | None:
+    display_output = _run_adb_text(
+        [*build_adb_command(device_id, adb_path), "shell", "dumpsys", "display"],
+        timeout=5.0,
+    )
+    surface_output = _run_adb_text(
+        [
+            *build_adb_command(device_id, adb_path),
+            "shell",
+            "dumpsys",
+            "SurfaceFlinger",
+            "--display-id",
+        ],
+        timeout=5.0,
+    )
+    return _select_from_outputs(display_output, surface_output)
+
+
+async def _select_primary_display_uncached_async(
+    device_id: str | None,
+    adb_path: str,
+) -> DisplaySelection | None:
+    display_output = await _run_adb_text_async(
+        [*build_adb_command(device_id, adb_path), "shell", "dumpsys", "display"],
+        timeout=5.0,
+    )
+    surface_output = await _run_adb_text_async(
+        [
+            *build_adb_command(device_id, adb_path),
+            "shell",
+            "dumpsys",
+            "SurfaceFlinger",
+            "--display-id",
+        ],
+        timeout=5.0,
+    )
+    return _select_from_outputs(display_output, surface_output)
+
+
+def _select_from_outputs(
+    display_output: str,
+    surface_output: str,
+) -> DisplaySelection | None:
+    displays = _parse_dumpsys_display(display_output)
+    if not displays:
+        return None
+
+    candidates = [display for display in displays if _is_on_state(display.state)]
+    reason = "largest_on_display"
+    if not candidates:
+        candidates = displays
+        reason = "largest_parsed_display"
+
+    selected = max(
+        candidates,
+        key=lambda display: (
+            display.width * display.height,
+            display.logical_id == "0",
+        ),
+    )
+
+    surface_ids = _parse_surfaceflinger_display_ids(surface_output)
+    screencap_id = selected.physical_id or selected.logical_id
+    if selected.physical_id is None and len(displays) == 1 and len(surface_ids) == 1:
+        screencap_id = surface_ids[0]
+        reason = f"{reason}_surfaceflinger_single_id"
+
+    return DisplaySelection(
+        logical_id=selected.logical_id,
+        screencap_id=screencap_id,
+        width=selected.width,
+        height=selected.height,
+        reason=reason,
+    )
+
+
+def _parse_dumpsys_display(output: str) -> list[DisplayInfo]:
+    sections: list[list[str]] = []
+    current: list[str] = []
+
+    for line in output.splitlines():
+        if _line_has_display_id(line):
+            if current:
+                sections.append(current)
+            current = [line]
+        elif current:
+            current.append(line)
+
+    if current:
+        sections.append(current)
+
+    displays: list[DisplayInfo] = []
+    seen: set[str] = set()
+    for section in sections:
+        display = _parse_display_section(section)
+        if not display or display.logical_id in seen:
+            continue
+        displays.append(display)
+        seen.add(display.logical_id)
+
+    return displays
+
+
+def _parse_display_section(lines: list[str]) -> DisplayInfo | None:
+    text = "\n".join(lines)
+    logical_id = _extract_logical_display_id(text)
+    if logical_id is None:
+        return None
+
+    size = _extract_largest_size(text)
+    if size is None:
+        return None
+
+    state = _extract_state(text)
+    physical_id_match = _UNIQUE_LOCAL_RE.search(text)
+    physical_id = physical_id_match.group(1) if physical_id_match else None
+
+    return DisplayInfo(
+        logical_id=logical_id,
+        physical_id=physical_id,
+        width=size[0],
+        height=size[1],
+        state=state,
+    )
+
+
+def _parse_surfaceflinger_display_ids(output: str) -> list[str]:
+    ids: list[str] = []
+    for match in _SURFACE_FLINGER_DISPLAY_ID_RE.finditer(output):
+        value = match.group(1)
+        if value not in ids:
+            ids.append(value)
+    return ids
+
+
+def _line_has_display_id(line: str) -> bool:
+    return bool(_DISPLAY_ID_RE.search(line) or _DISPLAY_ID_ALT_RE.search(line))
+
+
+def _extract_logical_display_id(text: str) -> str | None:
+    match = _DISPLAY_ID_RE.search(text)
+    if match:
+        return match.group(1) or match.group(2)
+
+    match = _DISPLAY_ID_ALT_RE.search(text)
+    if match:
+        return match.group(1)
+
+    return None
+
+
+def _extract_largest_size(text: str) -> tuple[int, int] | None:
+    sizes = [
+        (int(match.group(1)), int(match.group(2))) for match in _SIZE_RE.finditer(text)
+    ]
+    if not sizes:
+        return None
+    return max(sizes, key=lambda size: size[0] * size[1])
+
+
+def _extract_state(text: str) -> str | None:
+    for match in _STATE_RE.finditer(text):
+        value = match.group(1).upper()
+        if value in {"ON", "OFF", "DOZE", "DOZE_SUSPEND", "VR", "UNKNOWN"}:
+            return value
+    return None
+
+
+def _is_on_state(state: str | None) -> bool:
+    return state == "ON"
+
+
+def _run_adb_text(cmd: list[str], timeout: float) -> str:
+    try:
+        result = run_cmd_silently_sync(cmd, timeout=timeout)
+    except Exception as exc:
+        logger.debug("Failed to run display command %s: %s", cmd, exc)
+        return ""
+
+    if result.returncode != 0:
+        logger.debug("Display command failed %s: %s", cmd, result.stderr)
+        return ""
+
+    return result.stdout or ""
+
+
+async def _run_adb_text_async(cmd: list[str], timeout: float) -> str:
+    try:
+        result = await run_cmd_silently(cmd, timeout=timeout)
+    except Exception as exc:
+        logger.debug("Failed to run async display command %s: %s", cmd, exc)
+        return ""
+
+    if result.returncode != 0:
+        logger.debug("Async display command failed %s: %s", cmd, result.stderr)
+        return ""
+
+    return result.stdout or ""
+
+
+def _get_cached_selection(
+    device_id: str | None,
+    adb_path: str,
+) -> _CacheEntry | None:
+    entry = _display_selection_cache.get(_cache_key(device_id, adb_path))
+    if entry and entry.expires_at > time.monotonic():
+        return entry
+    return None
+
+
+def _set_cached_selection(
+    device_id: str | None,
+    adb_path: str,
+    selection: DisplaySelection | None,
+    ttl_seconds: float,
+) -> None:
+    _display_selection_cache[_cache_key(device_id, adb_path)] = _CacheEntry(
+        selection=selection,
+        expires_at=time.monotonic() + ttl_seconds,
+    )
+
+
+def _cache_key(device_id: str | None, adb_path: str) -> tuple[str, str]:
+    return adb_path, device_id or ""

--- a/AutoGLM_GUI/adb_plus/screenshot.py
+++ b/AutoGLM_GUI/adb_plus/screenshot.py
@@ -14,10 +14,16 @@ from io import BytesIO
 
 from PIL import Image
 
+from AutoGLM_GUI.adb_plus.display import (
+    DisplaySelection,
+    clear_display_selection_cache,
+    select_primary_display,
+    select_primary_display_async,
+)
 from AutoGLM_GUI.exceptions import DeviceNotAvailableError
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.platform_utils import is_windows
-from AutoGLM_GUI.trace import trace_span
+from AutoGLM_GUI.trace import TraceSpan, trace_span
 
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
@@ -58,53 +64,85 @@ def capture_screenshot(
         "adb.capture_screenshot",
         attrs={"device_id": device_id, "timeout": timeout, "retries": retries},
     ) as span:
+        selection = select_primary_display(device_id=device_id, adb_path=adb_path)
+        _set_display_trace_attrs(span, selection)
+        display_fallback = False
         attempts = max(1, retries + 1)
         for attempt in range(attempts):
-            data = _try_capture(device_id=device_id, adb_path=adb_path, timeout=timeout)
-            if not data:
-                continue
-
-            if not _is_valid_png(data):
-                continue
-
-            try:
-                img = Image.open(BytesIO(data))
-                width, height = img.size
-                base64_data = base64.b64encode(data).decode("utf-8")
+            data = _try_capture(
+                device_id=device_id,
+                adb_path=adb_path,
+                timeout=timeout,
+                display_id=selection.screencap_id if selection else None,
+            )
+            screenshot = _decode_screenshot(data, device_id)
+            if screenshot:
                 span.set_attributes(
                     {
                         "success": True,
                         "attempt": attempt + 1,
-                        "width": width,
-                        "height": height,
+                        "width": screenshot.width,
+                        "height": screenshot.height,
+                        "display_fallback": display_fallback,
                     }
                 )
-                return Screenshot(base64_data=base64_data, width=width, height=height)
-            except Exception as exc:
-                logger.debug(
-                    "Failed to decode screenshot PNG for %s: %s", device_id, exc
-                )
-                continue
+                return screenshot
 
-        span.set_attributes({"success": False, "fallback": True})
+            if selection:
+                clear_display_selection_cache(device_id=device_id, adb_path=adb_path)
+                display_fallback = True
+                selection = None
+                fallback_data = _try_capture(
+                    device_id=device_id,
+                    adb_path=adb_path,
+                    timeout=timeout,
+                )
+                screenshot = _decode_screenshot(fallback_data, device_id)
+                if screenshot:
+                    span.set_attributes(
+                        {
+                            "success": True,
+                            "attempt": attempt + 1,
+                            "width": screenshot.width,
+                            "height": screenshot.height,
+                            "display_fallback": True,
+                        }
+                    )
+                    return screenshot
+
+        span.set_attributes(
+            {"success": False, "fallback": True, "display_fallback": display_fallback}
+        )
         return _fallback_screenshot()
 
 
-def _try_capture(device_id: str | None, adb_path: str, timeout: int) -> bytes | None:
+def _try_capture(
+    device_id: str | None,
+    adb_path: str,
+    timeout: int,
+    display_id: str | None = None,
+) -> bytes | None:
     """Run exec-out screencap and return raw bytes or None on failure.
 
     Raises:
         DeviceNotAvailableError: When device is not found or offline.
     """
-    cmd: list[str | bytes] = [adb_path]
+    cmd: list[str] = [adb_path]
     if device_id:
         cmd.extend(["-s", device_id])
-    cmd.extend(["exec-out", "screencap", "-p"])
+    cmd.extend(["exec-out", "screencap"])
+    if display_id:
+        cmd.extend(["-d", display_id])
+    cmd.append("-p")
 
     try:
         with trace_span(
             "adb.exec_out_screencap",
-            attrs={"device_id": device_id, "timeout": timeout},
+            attrs={
+                "device_id": device_id,
+                "timeout": timeout,
+                "display_id": display_id,
+            },
         ):
             result = subprocess.run(
                 cmd,
@@ -142,54 +180,84 @@ async def capture_screenshot_async(
         "adb.capture_screenshot_async",
         attrs={"device_id": device_id, "timeout": timeout, "retries": retries},
     ) as span:
+        selection = await select_primary_display_async(
+            device_id=device_id,
+            adb_path=adb_path,
+        )
+        _set_display_trace_attrs(span, selection)
+        display_fallback = False
         attempts = max(1, retries + 1)
         for attempt in range(attempts):
             data = await _try_capture_async(
                 device_id=device_id,
                 adb_path=adb_path,
                 timeout=timeout,
+                display_id=selection.screencap_id if selection else None,
             )
-            if not data or not _is_valid_png(data):
-                continue
-
-            try:
-                image = await asyncio.to_thread(Image.open, BytesIO(data))
-                width, height = image.size
-                base64_data = base64.b64encode(data).decode("utf-8")
+            screenshot = await _decode_screenshot_async(data, device_id)
+            if screenshot:
                 span.set_attributes(
                     {
                         "success": True,
                         "attempt": attempt + 1,
-                        "width": width,
-                        "height": height,
+                        "width": screenshot.width,
+                        "height": screenshot.height,
+                        "display_fallback": display_fallback,
                     }
                 )
-                return Screenshot(base64_data=base64_data, width=width, height=height)
-            except Exception as exc:
-                logger.debug(
-                    "Failed to decode async screenshot PNG for %s: %s",
-                    device_id,
-                    exc,
-                )
-                continue
+                return screenshot
 
-        span.set_attributes({"success": False, "fallback": True})
+            if selection:
+                clear_display_selection_cache(device_id=device_id, adb_path=adb_path)
+                display_fallback = True
+                selection = None
+                fallback_data = await _try_capture_async(
+                    device_id=device_id,
+                    adb_path=adb_path,
+                    timeout=timeout,
+                )
+                screenshot = await _decode_screenshot_async(fallback_data, device_id)
+                if screenshot:
+                    span.set_attributes(
+                        {
+                            "success": True,
+                            "attempt": attempt + 1,
+                            "width": screenshot.width,
+                            "height": screenshot.height,
+                            "display_fallback": True,
+                        }
+                    )
+                    return screenshot
+
+        span.set_attributes(
+            {"success": False, "fallback": True, "display_fallback": display_fallback}
+        )
         return _fallback_screenshot()
 
 
 async def _try_capture_async(
-    device_id: str | None, adb_path: str, timeout: int
+    device_id: str | None,
+    adb_path: str,
+    timeout: int,
+    display_id: str | None = None,
 ) -> bytes | None:
     """Async exec-out screencap helper."""
     cmd: list[str] = [adb_path]
     if device_id:
         cmd.extend(["-s", device_id])
-    cmd.extend(["exec-out", "screencap", "-p"])
+    cmd.extend(["exec-out", "screencap"])
+    if display_id:
+        cmd.extend(["-d", display_id])
+    cmd.append("-p")
 
     try:
         with trace_span(
             "adb.exec_out_screencap_async",
-            attrs={"device_id": device_id, "timeout": timeout},
+            attrs={
+                "device_id": device_id,
+                "timeout": timeout,
+                "display_id": display_id,
+            },
         ):
             if is_windows():
                 result = await asyncio.to_thread(
@@ -242,6 +310,62 @@ def _is_valid_png(data: bytes) -> bool:
     return (
         len(data) > len(PNG_SIGNATURE) + 8  # header + IHDR length
         and data.startswith(PNG_SIGNATURE)
+    )
+
+
+def _decode_screenshot(data: bytes | None, device_id: str | None) -> Screenshot | None:
+    if not data or not _is_valid_png(data):
+        return None
+
+    try:
+        img = Image.open(BytesIO(data))
+        width, height = img.size
+        base64_data = base64.b64encode(data).decode("utf-8")
+        return Screenshot(base64_data=base64_data, width=width, height=height)
+    except Exception as exc:
+        logger.debug("Failed to decode screenshot PNG for %s: %s", device_id, exc)
+        return None
+
+
+async def _decode_screenshot_async(
+    data: bytes | None,
+    device_id: str | None,
+) -> Screenshot | None:
+    if not data or not _is_valid_png(data):
+        return None
+
+    try:
+        image = await asyncio.to_thread(Image.open, BytesIO(data))
+        width, height = image.size
+        base64_data = base64.b64encode(data).decode("utf-8")
+        return Screenshot(base64_data=base64_data, width=width, height=height)
+    except Exception as exc:
+        logger.debug("Failed to decode async screenshot PNG for %s: %s", device_id, exc)
+        return None
+
+
+def _set_display_trace_attrs(
+    span: TraceSpan,
+    selection: DisplaySelection | None,
+) -> None:
+    if not selection:
+        span.set_attributes(
+            {
+                "display_id": None,
+                "display_width": None,
+                "display_height": None,
+                "display_selection_reason": None,
+            }
+        )
+        return
+
+    span.set_attributes(
+        {
+            "display_id": selection.screencap_id,
+            "display_width": selection.width,
+            "display_height": selection.height,
+            "display_selection_reason": selection.reason,
+        }
     )
 
 

--- a/AutoGLM_GUI/scrcpy_stream.py
+++ b/AutoGLM_GUI/scrcpy_stream.py
@@ -12,6 +12,11 @@ from asyncio.subprocess import Process as AsyncProcess
 from collections.abc import AsyncGenerator
 
 from AutoGLM_GUI.adb_plus import check_device_available
+from AutoGLM_GUI.adb_plus.display import (
+    DisplaySelection,
+    clear_display_selection_cache,
+    select_primary_display_async,
+)
 from AutoGLM_GUI.logger import logger
 from AutoGLM_GUI.platform_utils import is_windows, run_cmd_silently, spawn_process
 from AutoGLM_GUI.scrcpy_protocol import (
@@ -108,6 +113,7 @@ class ScrcpyServerOptions:
     send_codec_meta: bool
     send_dummy_byte: bool
     video_codec_options: str | None
+    display_id: str | None
 
 
 class ScrcpyStreamer:
@@ -146,6 +152,7 @@ class ScrcpyStreamer:
         self._read_buffer = bytearray()
         self._metadata: ScrcpyVideoStreamMetadata | None = None
         self._dummy_byte_skipped = False
+        self._display_selection: DisplaySelection | None = None
 
         # Find scrcpy-server location
         self.scrcpy_server_path = self._find_scrcpy_server()
@@ -205,6 +212,10 @@ class ScrcpyStreamer:
             logger.info(f"Checking device {self.device_id} availability...")
             await check_device_available(self.device_id)
             logger.info(f"Device {self.device_id} is available")
+
+            self._display_selection = await select_primary_display_async(
+                device_id=self.device_id
+            )
 
             # 1. Kill existing scrcpy server processes on device
             logger.info("Cleaning up existing scrcpy processes...")
@@ -307,14 +318,31 @@ class ScrcpyStreamer:
             send_codec_meta=self.stream_options.send_codec_meta,
             send_dummy_byte=self.stream_options.send_dummy_byte,
             video_codec_options=codec_options,
+            display_id=(
+                self._display_selection.logical_id if self._display_selection else None
+            ),
         )
 
     async def _start_server(self) -> None:
         """Start scrcpy server on device with intelligent retry."""
+        try:
+            await self._start_server_with_options(self._build_server_options())
+        except RuntimeError as exc:
+            if not self._display_selection or not _can_retry_without_display_id(exc):
+                raise
+
+            clear_display_selection_cache(device_id=self.device_id)
+            logger.warning(
+                "Scrcpy failed with display_id=%s, retrying without display_id",
+                self._display_selection.logical_id,
+            )
+            self._display_selection = None
+            await self._start_server_with_options(self._build_server_options())
+
+    async def _start_server_with_options(self, options: ScrcpyServerOptions) -> None:
+        """Start scrcpy server on device with the provided options."""
         max_retries = 3
         retry_delay = 1.0  # Reduced from 2s (cleanup handles waiting now)
-
-        options = self._build_server_options()
 
         for attempt in range(max_retries):
             cmd = ["adb"]
@@ -343,6 +371,8 @@ class ScrcpyStreamer:
                 f"send_dummy_byte={str(options.send_dummy_byte).lower()}",
                 f"video_codec_options={options.video_codec_options}",
             ]
+            if options.display_id:
+                server_args.append(f"display_id={options.display_id}")
             cmd.extend(server_args)
 
             self.scrcpy_process = await spawn_process(cmd, capture_output=True)
@@ -589,3 +619,10 @@ class ScrcpyStreamer:
 
     def __del__(self):
         self.stop()
+
+
+def _can_retry_without_display_id(exc: RuntimeError) -> bool:
+    error = str(exc)
+    return (
+        "persistently occupied" not in error and "Address already in use" not in error
+    )

--- a/tests/test_hardware_boundary_coverage.py
+++ b/tests/test_hardware_boundary_coverage.py
@@ -16,6 +16,7 @@ import AutoGLM_GUI.adb.connection as adb_connection
 import AutoGLM_GUI.adb.device as adb_core_device
 import AutoGLM_GUI.adb.input as adb_input
 import AutoGLM_GUI.adb_plus.device as adb_device
+import AutoGLM_GUI.adb_plus.display as adb_display
 import AutoGLM_GUI.adb_plus.ip as adb_ip
 import AutoGLM_GUI.adb_plus.keyboard_installer as keyboard
 import AutoGLM_GUI.adb_plus.mdns as mdns
@@ -28,6 +29,7 @@ import AutoGLM_GUI.devices.adb_device as adb_device_impl
 import AutoGLM_GUI.platform_utils as platform_utils
 import AutoGLM_GUI.scrcpy_stream as scrcpy_stream
 from AutoGLM_GUI.exceptions import DeviceNotAvailableError
+from AutoGLM_GUI.adb_plus.display import DisplaySelection
 from AutoGLM_GUI.scrcpy_protocol import (
     PTS_CONFIG,
     PTS_KEYFRAME,
@@ -95,6 +97,9 @@ def test_scrcpy_start_cleanup_and_server_commands(
     async def fake_check(device_id: str | None) -> None:
         calls.append(["check", str(device_id)])
 
+    async def fake_select_display(device_id: str | None):
+        return DisplaySelection("0", "physical-0", 1200, 2608, "test")
+
     async def fake_wait(port: int, timeout: float, poll_interval: float):
         return True
 
@@ -113,6 +118,9 @@ def test_scrcpy_start_cleanup_and_server_commands(
     monkeypatch.setattr(scrcpy_stream, "wait_for_port_release", fake_wait)
     monkeypatch.setattr(scrcpy_stream, "spawn_process", fake_spawn)
     monkeypatch.setattr(scrcpy_stream, "is_windows", lambda: False)
+    monkeypatch.setattr(
+        scrcpy_stream, "select_primary_display_async", fake_select_display
+    )
     monkeypatch.setattr(asyncio, "sleep", _noop_sleep)
 
     async def fake_connect(self):
@@ -132,7 +140,8 @@ def test_scrcpy_start_cleanup_and_server_commands(
         "/data/local/tmp/scrcpy-server",
     ] in calls
     assert streamer.forward_cleanup_needed is True
-    assert any("app_process" in cmd for cmd in calls)
+    server_cmd = next(cmd for cmd in calls if "app_process" in cmd)
+    assert "display_id=0" in server_cmd
 
 
 def test_scrcpy_start_failure_and_server_port_conflict(
@@ -751,9 +760,81 @@ def test_adb_ip_sync_and_async(monkeypatch: pytest.MonkeyPatch) -> None:
     assert asyncio.run(adb_ip.get_wifi_ip_async("adb", "serial")) == "192.168.1.10"
 
 
+def test_display_selection_parsing_and_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    adb_display.clear_display_selection_cache()
+
+    dumpsys_display = """
+Logical Displays:
+  Display 1:
+    mDisplayId=1
+    mBaseDisplayInfo=DisplayInfo{"Rear", displayId 1, real 976 x 596, state OFF, uniqueId="local:222"}
+  Display 0:
+    mDisplayId=0
+    mBaseDisplayInfo=DisplayInfo{"Built-in Screen", displayId 0, real 1200 x 2608, state ON, uniqueId "local:111"}
+"""
+    selection = adb_display._select_from_outputs(dumpsys_display, "")
+    assert selection == DisplaySelection(
+        logical_id="0",
+        screencap_id="111",
+        width=1200,
+        height=2608,
+        reason="largest_on_display",
+    )
+
+    equal_area = """
+  Display 2:
+    mDisplayId=2
+    mBaseDisplayInfo=DisplayInfo{"External", displayId 2, 1000 x 1000, state ON}
+  Display 0:
+    mDisplayId=0
+    mBaseDisplayInfo=DisplayInfo{"Main", displayId 0, 1000 x 1000, state ON}
+"""
+    assert adb_display._select_from_outputs(equal_area, "").logical_id == "0"
+
+    multiple_on = """
+  Display 0:
+    mBaseDisplayInfo=DisplayInfo{"Small", displayId 0, 800 x 600, state ON}
+  Display 2:
+    mBaseDisplayInfo=DisplayInfo{"Large", displayId 2, 1600 x 900, state ON}
+"""
+    assert adb_display._select_from_outputs(multiple_on, "").logical_id == "2"
+
+    assert adb_display._select_from_outputs("not display output", "") is None
+
+    now = {"value": 100.0}
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, timeout=None):
+        calls.append(cmd)
+        if "SurfaceFlinger" in cmd:
+            return _completed(stdout="")
+        return _completed(stdout=dumpsys_display)
+
+    monkeypatch.setattr(adb_display.time, "monotonic", lambda: now["value"])
+    monkeypatch.setattr(adb_display, "run_cmd_silently_sync", fake_run)
+
+    first = adb_display.select_primary_display("serial", ttl_seconds=60)
+    second = adb_display.select_primary_display("serial", ttl_seconds=60)
+    assert first == second
+    assert len(calls) == 2
+
+    now["value"] = 161.0
+    adb_display.select_primary_display("serial", ttl_seconds=60)
+    assert len(calls) == 4
+
+    adb_display.clear_display_selection_cache()
+
+
 def test_screenshot_sync_async_and_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
     assert screenshot._is_valid_png(PNG_1X1_BYTES)
     assert not screenshot._is_valid_png(b"nope")
+
+    monkeypatch.setattr(screenshot, "select_primary_display", lambda *a, **k: None)
+
+    async def no_async_display(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(screenshot, "select_primary_display_async", no_async_display)
 
     monkeypatch.setattr(
         screenshot.subprocess,
@@ -799,6 +880,59 @@ def test_screenshot_sync_async_and_helpers(monkeypatch: pytest.MonkeyPatch) -> N
         screenshot.capture_screenshot_async("serial", retries=0)
     )
     assert async_captured.width == 1
+
+
+def test_screenshot_uses_display_id_and_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selection = DisplaySelection("0", "111", 1200, 2608, "test")
+    monkeypatch.setattr(screenshot, "select_primary_display", lambda *a, **k: selection)
+
+    cleared: list[tuple[str | None, str]] = []
+    monkeypatch.setattr(
+        screenshot,
+        "clear_display_selection_cache",
+        lambda device_id=None, adb_path="adb": cleared.append((device_id, adb_path)),
+    )
+
+    commands: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        if "-d" in cmd:
+            return subprocess.CompletedProcess(cmd, 1, b"", b"bad display")
+        return subprocess.CompletedProcess(cmd, 0, PNG_1X1_BYTES, b"")
+
+    monkeypatch.setattr(screenshot.subprocess, "run", fake_run)
+    captured = screenshot.capture_screenshot("serial", retries=0)
+
+    assert captured.width == 1
+    assert commands[0][-4:] == ["screencap", "-d", "111", "-p"]
+    assert commands[1][-2:] == ["screencap", "-p"]
+    assert cleared == [("serial", "adb")]
+
+
+def test_screenshot_async_uses_display_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    selection = DisplaySelection("0", "111", 1200, 2608, "test")
+
+    async def async_display(*args, **kwargs):
+        return selection
+
+    monkeypatch.setattr(screenshot, "select_primary_display_async", async_display)
+    monkeypatch.setattr(screenshot, "is_windows", lambda: True)
+
+    commands: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, PNG_1X1_BYTES, b"")
+
+    monkeypatch.setattr(screenshot.subprocess, "run", fake_run)
+
+    captured = asyncio.run(screenshot.capture_screenshot_async("serial", retries=0))
+
+    assert captured.width == 1
+    assert commands[0][-4:] == ["screencap", "-d", "111", "-p"]
 
 
 def test_mdns_pair_touch_version_and_keyboard(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_scrcpy_stream_edges.py
+++ b/tests/test_scrcpy_stream_edges.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 import AutoGLM_GUI.scrcpy_stream as scrcpy_stream
+from AutoGLM_GUI.adb_plus.display import DisplaySelection
 from AutoGLM_GUI.scrcpy_protocol import (
     SCRCPY_CODEC_H264,
     ScrcpyMediaStreamPacket,
@@ -132,6 +133,65 @@ async def test_start_server_reports_windows_process_error(
     streamer = ScrcpyStreamer(device_id="serial")
     with pytest.raises(RuntimeError, match="fatal startup"):
         await streamer._start_server()
+
+
+@pytest.mark.anyio
+async def test_start_server_retries_without_display_id(
+    fake_server: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailedProcess:
+        returncode = 1
+
+        async def communicate(self):
+            return b"stdout", b"display not found"
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    class RunningProcess:
+        returncode = None
+
+        async def communicate(self):
+            return b"", b""
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    commands: list[list[str]] = []
+
+    async def fake_spawn(cmd: list[str], capture_output: bool):
+        commands.append(cmd)
+        if len(commands) == 1:
+            return FailedProcess()
+        return RunningProcess()
+
+    cleared: list[str | None] = []
+    original_sleep = asyncio.sleep
+
+    monkeypatch.setattr(scrcpy_stream, "spawn_process", fake_spawn)
+    monkeypatch.setattr(scrcpy_stream, "is_windows", lambda: False)
+    monkeypatch.setattr(scrcpy_stream.asyncio, "sleep", lambda delay: original_sleep(0))
+    monkeypatch.setattr(
+        scrcpy_stream,
+        "clear_display_selection_cache",
+        lambda device_id=None: cleared.append(device_id),
+    )
+
+    streamer = ScrcpyStreamer(device_id="serial")
+    streamer._display_selection = DisplaySelection("0", "111", 1200, 2608, "test")
+
+    await streamer._start_server()
+
+    assert "display_id=0" in commands[0]
+    assert all("display_id=0" not in arg for arg in commands[1])
+    assert cleared == ["serial"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- add ADB display discovery with a 60s TTL cache for primary display selection
- capture screenshots with `screencap -d <display> -p` and fallback to the legacy command on failure
- pass selected logical display id to scrcpy server and retry without it if startup fails

## Tests
- `uv run pytest tests/test_hardware_boundary_coverage.py tests/test_scrcpy_stream_edges.py tests/test_socketio_server.py -v`
- `uv run python scripts/lint.py --backend --check-only`

Closes #426