### PR TITLE
fix(glm): adapt image format for Zhipu Cloud API

### DIFF
--- a/AutoGLM_GUI/agents/glm/async_agent.py
+++ b/AutoGLM_GUI/agents/glm/async_agent.py
@@ -342,14 +342,53 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
         self, messages: list[dict[str, Any]]
     ) -> AsyncGenerator[dict[str, str], None]:
         """流式调用 OpenAI，yield thinking chunks。"""
+        # 适配智谱云 API：提取图片到 extra_body，messages 只保留纯文本
+        is_zhipu_api = (
+            "bigmodel.cn" in self.model_config.base_url
+            or "zhipu" in self.model_config.base_url
+        )
+
+        extra_body = dict(self.model_config.extra_body)
+        processed_messages = messages
+
+        if is_zhipu_api:
+            processed_messages = []
+            for msg in messages:
+                content = msg.get("content")
+                if isinstance(content, list):
+                    text_parts: list[str] = []
+                    image_b64: str | None = None
+                    for part in content:
+                        if isinstance(part, dict):
+                            if part.get("type") == "image_url":
+                                image_url = part.get("image_url", {}).get("url", "")
+                                if image_url.startswith("data:"):
+                                    # 提取 base64 数据（去掉 data:image/png;base64, 前缀）
+                                    b64_data = (
+                                        image_url.split(",", 1)[1]
+                                        if "," in image_url
+                                        else image_url
+                                    )
+                                    image_b64 = b64_data
+                            elif part.get("type") == "text":
+                                text_parts.append(part.get("text", ""))
+                    # 重建 message，content 改为纯文本字符串
+                    new_content = "\n".join(text_parts) if text_parts else ""
+                    processed_messages.append({**msg, "content": new_content})
+                    # 将图片放入 extra_body（autoglm-phone 只支持单图，取第一张）
+                    if image_b64:
+                        extra_body["image"] = image_b64
+                else:
+                    processed_messages.append(msg)
+
         stream = await self.openai_client.chat.completions.create(
-            messages=messages,  # type: ignore[arg-type]
+            messages=processed_messages,  # type: ignore[arg-type]
             model=self.model_config.model_name,
             max_tokens=self.model_config.max_tokens,
             temperature=self.model_config.temperature,
             top_p=self.model_config.top_p,
             frequency_penalty=self.model_config.frequency_penalty,
-            extra_body=self.model_config.extra_body,
+            extra_body=extra_body,
             stream=True,
         )
 

--- a/AutoGLM_GUI/agents/glm/async_agent.py
+++ b/AutoGLM_GUI/agents/glm/async_agent.py
@@ -360,7 +360,7 @@ class AsyncGLMAgent(AsyncAgentBase, AsyncAgent):
                     image_b64: str | None = None
                     for part in content:
                         if isinstance(part, dict):
-                            if part.get("type") == "image_url":
+                            if part.get("type") == "image_url" and image_b64 is None:
                                 image_url = part.get("image_url", {}).get("url", "")
                                 if image_url.startswith("data:"):
                                     # 提取 base64 数据（去掉 data:image/png;base64, 前缀）

--- a/tests/test_glm_async_agent.py
+++ b/tests/test_glm_async_agent.py
@@ -230,3 +230,177 @@ def test_user_reference_images_are_sent_on_first_request_only(monkeypatch):
     assert _count_images(captured[0]) == 2
     assert _count_images(captured[1]) == 1
     assert "User attached 1 reference image" in _text_part(captured[0][-1])
+
+
+# ---------------------------------------------------------------------------
+# Zhipu Cloud API image format conversion
+# ---------------------------------------------------------------------------
+
+
+def test_zhipu_api_converts_image_url_to_extra_body(monkeypatch):
+    """When base_url points to Zhipu Cloud, image_url parts are extracted
+    to extra_body['image'] and messages are rebuilt with plain text content."""
+    agent = AsyncGLMAgent(
+        model_config=ModelConfig(
+            base_url="https://open.bigmodel.cn/api/paas/v4",
+            model_name="autoglm-phone",
+        ),
+        agent_config=AgentConfig(max_steps=10, verbose=False),
+        device=_FakeDevice(),
+    )
+
+    captured_kwargs: dict[str, Any] = {}
+
+    async def fake_create(**kwargs):
+        captured_kwargs.update(kwargs)
+
+        # Return an async iterator that yields one empty chunk
+        class _FakeStream:
+            async def __anext__(self):
+                raise StopAsyncIteration
+
+            def __aiter__(self):
+                return self
+
+            async def close(self):
+                pass
+
+        return _FakeStream()
+
+    monkeypatch.setattr(agent.openai_client.chat.completions, "create", fake_create)
+
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,screenshot_b64"},
+                },
+                {"type": "text", "text": "Tap the icon."},
+            ],
+        },
+    ]
+
+    async def run() -> None:
+        async for _ in agent._stream_openai(messages):
+            pass
+
+    asyncio.run(run())
+
+    assert captured_kwargs["extra_body"]["image"] == "screenshot_b64"
+    processed = captured_kwargs["messages"]
+    assert processed[0]["content"] == "You are a helpful assistant."
+    assert processed[1]["content"] == "Tap the icon."
+    assert isinstance(processed[1]["content"], str)
+
+
+def test_zhipu_api_uses_first_image_only(monkeypatch):
+    """When multiple images are present, only the first is sent to extra_body."""
+    agent = AsyncGLMAgent(
+        model_config=ModelConfig(
+            base_url="https://open.bigmodel.cn/api/paas/v4",
+            model_name="autoglm-phone",
+        ),
+        agent_config=AgentConfig(max_steps=10, verbose=False),
+        device=_FakeDevice(),
+    )
+
+    captured_kwargs: dict[str, Any] = {}
+
+    async def fake_create(**kwargs):
+        captured_kwargs.update(kwargs)
+
+        class _FakeStream:
+            async def __anext__(self):
+                raise StopAsyncIteration
+
+            def __aiter__(self):
+                return self
+
+            async def close(self):
+                pass
+
+        return _FakeStream()
+
+    monkeypatch.setattr(agent.openai_client.chat.completions, "create", fake_create)
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,first_img"},
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,second_img"},
+                },
+                {"type": "text", "text": "Do this."},
+            ],
+        },
+    ]
+
+    async def run() -> None:
+        async for _ in agent._stream_openai(messages):
+            pass
+
+    asyncio.run(run())
+
+    assert captured_kwargs["extra_body"]["image"] == "first_img"
+    assert captured_kwargs["messages"][0]["content"] == "Do this."
+
+
+def test_non_zhipu_api_leaves_messages_untouched(monkeypatch):
+    """Non-Zhipu endpoints keep the standard OpenAI vision format."""
+    agent = AsyncGLMAgent(
+        model_config=ModelConfig(
+            base_url="http://localhost:8000/v1",
+            model_name="autoglm-phone-9b",
+        ),
+        agent_config=AgentConfig(max_steps=10, verbose=False),
+        device=_FakeDevice(),
+    )
+
+    captured_kwargs: dict[str, Any] = {}
+
+    async def fake_create(**kwargs):
+        captured_kwargs.update(kwargs)
+
+        class _FakeStream:
+            async def __anext__(self):
+                raise StopAsyncIteration
+
+            def __aiter__(self):
+                return self
+
+            async def close(self):
+                pass
+
+        return _FakeStream()
+
+    monkeypatch.setattr(agent.openai_client.chat.completions, "create", fake_create)
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,img"},
+                },
+                {"type": "text", "text": "Tap."},
+            ],
+        },
+    ]
+
+    async def run() -> None:
+        async for _ in agent._stream_openai(messages):
+            pass
+
+    asyncio.run(run())
+
+    assert "image" not in captured_kwargs["extra_body"]
+    assert captured_kwargs["messages"] == messages


### PR DESCRIPTION
## Problem

When using `"glm-async"` agent with Zhipu Cloud API (`"https://open.bigmodel.cn/api/paas/v4"`) to call `"autoglm-phone"` model, the standard OpenAI vision format (`image_url` in `messages.content`) is not supported. The API returns:

```
Error code: 400 - {"error": {"code": "1210", "message": "messages.content.type 参数非法，取值范围 ['text']"}}
```

This prevents the agent from executing any task when configured with the official Zhipu Cloud endpoint.

## Root Cause

Zhipu Cloud's `autoglm-phone` model uses a custom image transmission format:
- Images must be passed via `extra_body["image"]` (base64 string)
- `messages` must contain only plain text (`content` as string, not array)

The current `AsyncGLMAgent._stream_openai` sends standard OpenAI vision format which is incompatible.

## Fix

In `AsyncGLMAgent._stream_openai`, detect Zhipu API endpoints (`bigmodel.cn` or `zhipu` in `base_url`) and convert the message format before calling the API:

1. Iterate through `messages`, extract `image_url` parts from `content` list
2. Move the first image's base64 data to `extra_body["image"]`
3. Rebuild messages with only text parts merged into a plain string `content`

## Verification

- [x] Real LLM + mock device test passes (autoglm-phone via Zhipu Cloud)
- [x] Existing mock LLM + mock device tests pass (no regression)
- [x] Backend lint passes (ruff + pyright)

## Related

Fixes #437
