### PR TITLE
[codex] Add backend coverage modes for integration and e2e

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -38,3 +38,106 @@ jobs:
           name: backend-py311
           fail_ci_if_error: true
           verbose: true
+
+  integration-coverage:
+    name: Integration Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python & uv
+        uses: ./.github/actions/setup-python
+        with:
+          python-version: "3.11"
+          frozen: "true"
+
+      - name: Run integration tests with backend coverage
+        run: |
+          uv run python scripts/run_coverage.py integration --no-report
+
+      - name: Upload integration coverage to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.integration.xml
+          flags: backend-integration
+          name: backend-integration-py311
+          fail_ci_if_error: true
+          verbose: true
+
+  backend-e2e-coverage:
+    name: Backend E2E Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python & uv
+        uses: ./.github/actions/setup-python
+        with:
+          python-version: "3.11"
+          frozen: "true"
+
+      - name: Run backend E2E tests with backend coverage
+        run: |
+          uv run python scripts/run_coverage.py backend-e2e --no-report
+
+      - name: Upload backend E2E coverage to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.backend-e2e.xml
+          flags: backend-e2e
+          name: backend-e2e-py311
+          fail_ci_if_error: true
+          verbose: true
+
+  frontend-e2e-backend-coverage:
+    name: Frontend E2E Backend Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python & uv
+        uses: ./.github/actions/setup-python
+        with:
+          python-version: "3.11"
+          frozen: "true"
+
+      - name: Setup Node.js & pnpm
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: "24"
+
+      - name: Install Playwright Chromium
+        run: |
+          cd frontend
+          pnpm exec playwright install chromium
+
+      - name: Run frontend E2E tests with backend coverage
+        run: |
+          uv run python scripts/run_coverage.py frontend-e2e --no-report
+
+      - name: Upload frontend E2E backend coverage to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.frontend-e2e-backend.xml
+          flags: frontend-e2e-backend
+          name: frontend-e2e-backend-py311
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -7,6 +7,7 @@ on:
       - 'Dockerfile'
       - 'AutoGLM_GUI/**'
       - 'tests/integration/**'
+      - 'tests/e2e/backend/**'
       - 'pyproject.toml'
       - '.github/workflows/docker-e2e.yml'
   push:
@@ -15,6 +16,7 @@ on:
       - 'Dockerfile'
       - 'AutoGLM_GUI/**'
       - 'tests/integration/**'
+      - 'tests/e2e/backend/**'
   workflow_dispatch:
 
 jobs:
@@ -34,7 +36,7 @@ jobs:
 
       - name: Run Docker E2E tests
         run: |
-          uv run pytest tests/integration/test_docker_e2e.py -v -s
+          uv run pytest tests/e2e/backend/test_docker.py -v -s
 
       - name: Generate test summary
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,16 @@ artifacts = ["AutoGLM_GUI/static/**/*"]
 [tool.hatch.metadata]
 allow-direct-references = true
 
+[tool.coverage.run]
+source = ["AutoGLM_GUI"]
+parallel = true
+concurrency = ["multiprocessing"]
+patch = ["subprocess"]
+sigterm = true
+
+[tool.coverage.report]
+skip_covered = true
+
 [dependency-groups]
 dev = [
     "pyinstaller>=6.17.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ python_files = test_*.py
 python_functions = test_*
 markers =
     contract: Stable API behavior contracts; should survive internal refactors.
+    e2e: End-to-end tests that drive deployed or live service boundaries.
     integration: Cross-module or multi-process integration tests.
     release_gate: Must-pass regression gate for release readiness.
 filterwarnings =

--- a/scripts/run_coverage.py
+++ b/scripts/run_coverage.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Run backend coverage for integration and E2E test modes."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+FRONTEND_DIR = PROJECT_ROOT / "frontend"
+
+
+@dataclass(frozen=True)
+class CoverageMode:
+    name: str
+    coverage_file: str
+    xml_file: str
+    command: list[str]
+    cwd: Path
+    uses_coverage_run: bool = True
+
+
+MODES = {
+    "integration": CoverageMode(
+        name="integration",
+        coverage_file=".coverage.integration",
+        xml_file="coverage.integration.xml",
+        command=[
+            "uv",
+            "run",
+            "coverage",
+            "run",
+            "-m",
+            "pytest",
+            "tests/integration",
+            "tests/test_trace_observability_integration.py",
+            "-v",
+        ],
+        cwd=PROJECT_ROOT,
+    ),
+    "backend-e2e": CoverageMode(
+        name="backend-e2e",
+        coverage_file=".coverage.backend-e2e",
+        xml_file="coverage.backend-e2e.xml",
+        command=[
+            "uv",
+            "run",
+            "coverage",
+            "run",
+            "-m",
+            "pytest",
+            "tests/e2e/backend",
+            "--ignore=tests/e2e/backend/test_docker.py",
+            "-v",
+            "-s",
+        ],
+        cwd=PROJECT_ROOT,
+    ),
+    "frontend-e2e": CoverageMode(
+        name="frontend-e2e",
+        coverage_file=".coverage.frontend-e2e",
+        xml_file="coverage.frontend-e2e-backend.xml",
+        command=["pnpm", "test:e2e"],
+        cwd=FRONTEND_DIR,
+        uses_coverage_run=False,
+    ),
+}
+
+
+def _run(cmd: list[str], *, cwd: Path, env: dict[str, str]) -> None:
+    print(f"\n$ {' '.join(cmd)}")
+    subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        check=True,
+        shell=platform.system() == "Windows" and cmd[0] in {"pnpm", "npm", "yarn"},
+    )
+
+
+def _remove_coverage_data(coverage_file: Path) -> None:
+    for path in coverage_file.parent.glob(f"{coverage_file.name}*"):
+        if path.is_file():
+            path.unlink()
+
+
+def _coverage_env(mode: CoverageMode) -> dict[str, str]:
+    env = os.environ.copy()
+    env["COVERAGE_FILE"] = str(PROJECT_ROOT / mode.coverage_file)
+    if not mode.uses_coverage_run:
+        env["COVERAGE_PROCESS_START"] = str(PROJECT_ROOT / "pyproject.toml")
+    return env
+
+
+def _run_mode(mode: CoverageMode, *, keep_data: bool, report: bool) -> None:
+    coverage_file = PROJECT_ROOT / mode.coverage_file
+    xml_file = PROJECT_ROOT / mode.xml_file
+    env = _coverage_env(mode)
+
+    if not keep_data:
+        _remove_coverage_data(coverage_file)
+        if xml_file.exists():
+            xml_file.unlink()
+
+    _run(mode.command, cwd=mode.cwd, env=env)
+    _run(["uv", "run", "coverage", "combine"], cwd=PROJECT_ROOT, env=env)
+
+    if report:
+        _run(["uv", "run", "coverage", "report"], cwd=PROJECT_ROOT, env=env)
+
+    _run(
+        ["uv", "run", "coverage", "xml", "-o", str(xml_file)],
+        cwd=PROJECT_ROOT,
+        env=env,
+    )
+    print(f"\nWrote {xml_file.relative_to(PROJECT_ROOT)}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run backend coverage for one test mode."
+    )
+    parser.add_argument(
+        "mode",
+        choices=[*MODES.keys(), "all"],
+        help="Coverage mode to run.",
+    )
+    parser.add_argument(
+        "--keep-data",
+        action="store_true",
+        help="Keep existing .coverage files before running.",
+    )
+    parser.add_argument(
+        "--no-report",
+        action="store_true",
+        help="Skip the terminal coverage report.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    modes = MODES.values() if args.mode == "all" else [MODES[args.mode]]
+    for mode in modes:
+        print(f"\n=== {mode.name} backend coverage ===")
+        _run_mode(mode, keep_data=args.keep_data, report=not args.no_report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_harness.py
+++ b/scripts/run_harness.py
@@ -52,12 +52,12 @@ from tests.integration.device_agent.test_client import (  # noqa: E402
     MockAgentTestClient,
 )
 from tests.integration.schema import TestScenarioSchema  # noqa: E402
-from tests.integration.test_task_system_e2e import (  # noqa: E402
+from tests.e2e.backend.test_task_system import (  # noqa: E402
     _configure_mock_llm,
     _register_remote_device,
     _wait_for_task_completion,
 )
-from tests.integration.test_trace_replay_e2e import _read_jsonl  # noqa: E402
+from tests.e2e.backend.test_trace_replay import _read_jsonl  # noqa: E402
 
 
 SCENARIOS_DIR = PROJECT_ROOT / "tests" / "integration" / "fixtures" / "scenarios"

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end test suites."""

--- a/tests/e2e/backend/__init__.py
+++ b/tests/e2e/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend service end-to-end tests."""

--- a/tests/e2e/backend/conftest.py
+++ b/tests/e2e/backend/conftest.py
@@ -1,0 +1,7 @@
+"""Backend E2E pytest fixtures.
+
+The concrete mock service fixtures still live under tests.integration because
+component integration tests use the same harness.
+"""
+
+from tests.integration.conftest import *  # noqa: F403

--- a/tests/e2e/backend/test_docker.py
+++ b/tests/e2e/backend/test_docker.py
@@ -42,10 +42,12 @@ def _is_docker_available() -> bool:
 
 # Skip all tests in this module if Docker is not available
 pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.e2e,
     pytest.mark.skipif(
         not _is_docker_available(),
         reason="Docker is not installed or not running. Skip Docker E2E tests.",
-    )
+    ),
 ]
 
 
@@ -82,7 +84,7 @@ def docker_container(mock_agent_server: str, mock_llm_server: str):
             subprocess.run(
                 ["docker", "build", "-t", image_name, "."],
                 check=True,
-                cwd=Path(__file__).parent.parent.parent,
+                cwd=Path(__file__).parents[3],
             )
             break  # Success, exit retry loop
         except subprocess.CalledProcessError:

--- a/tests/e2e/backend/test_local.py
+++ b/tests/e2e/backend/test_local.py
@@ -1,8 +1,8 @@
-"""Local end-to-end integration tests (without Docker).
+"""Local backend end-to-end tests (without Docker).
 
 This test module runs AutoGLM-GUI server locally and communicates
 with a Mock Device Agent and Mock LLM server, providing the same
-test coverage as test_docker_e2e.py but without requiring Docker.
+test coverage as test_docker.py but without requiring Docker.
 
 Prerequisites:
     - None (runs entirely in local Python processes)
@@ -15,6 +15,7 @@ import pytest
 
 
 @pytest.mark.integration
+@pytest.mark.e2e
 class TestLocalE2E:
     """End-to-end tests with AutoGLM-GUI running locally (no Docker)."""
 
@@ -29,7 +30,7 @@ class TestLocalE2E:
     ):
         """Test complete flow: Local server -> Mock LLM -> Mock Agent.
 
-        This test provides the same coverage as test_docker_e2e.py::TestDockerE2E::test_meituan_message_scenario
+        This test provides the same coverage as test_docker.py::TestDockerE2E::test_meituan_message_scenario
         but runs the server locally instead of in a Docker container.
         """
         # Update local_server with actual mock_agent_server URL
@@ -181,6 +182,7 @@ class TestLocalE2E:
         mock_llm_client,
         mock_agent_server: str,
         test_client,
+        wechat_test_case: Path,
     ):
         """Test 10-step WeChat scenario.
 
@@ -204,14 +206,7 @@ class TestLocalE2E:
         llm_url = local_server["llm_url"]
 
         # Load WeChat test scenario
-        scenario_path = (
-            Path(__file__).parent
-            / "fixtures"
-            / "scenarios"
-            / "wechat_multi_step"
-            / "scenario.yaml"
-        )
-        test_client.load_scenario(str(scenario_path))
+        test_client.load_scenario(str(wechat_test_case))
 
         print(f"[Local E2E] Registering remote device at {access_url}")
         print(f"[Local E2E] Remote URL: {remote_url}")

--- a/tests/e2e/backend/test_task_system.py
+++ b/tests/e2e/backend/test_task_system.py
@@ -86,6 +86,7 @@ def _wait_for_task_completion(
 
 
 @pytest.mark.integration
+@pytest.mark.e2e
 class TestTaskSystemE2E:
     """End-to-end tests that exercise the new Task APIs directly."""
 

--- a/tests/e2e/backend/test_trace_replay.py
+++ b/tests/e2e/backend/test_trace_replay.py
@@ -11,7 +11,7 @@ import httpx
 import pytest
 
 from AutoGLM_GUI.trace_export import export_otlp_jsonl
-from tests.integration.test_task_system_e2e import (
+from tests.e2e.backend.test_task_system import (
     _configure_mock_llm,
     _register_remote_device,
     _wait_for_task_completion,
@@ -88,6 +88,7 @@ def _submit_trace_task(
 
 
 @pytest.mark.integration
+@pytest.mark.e2e
 class TestTraceReplayE2E:
     """Validate replay trace behavior through the real local server stack."""
 


### PR DESCRIPTION
## Summary

- Move backend service E2E tests from `tests/integration` to `tests/e2e/backend` and add an `e2e` pytest marker.
- Add `scripts/run_coverage.py` to produce separate backend coverage XML files for integration, backend E2E, and frontend E2E modes.
- Extend Codecov CI with separate uploads for `backend-integration`, `backend-e2e`, and `frontend-e2e-backend` flags.

## Validation

- `uv run python scripts/lint.py --backend --check-only`
- `uv run pytest tests/e2e/backend --collect-only -q`
- `uv run pytest -m e2e --collect-only -q`
- `uv run python scripts/run_coverage.py integration --no-report`
- `uv run python scripts/run_coverage.py backend-e2e --no-report`
- `pnpm install` and `pnpm exec playwright install chromium` in `frontend/` for local setup
- `uv run python scripts/run_coverage.py frontend-e2e --no-report`
