### PR TITLE
test(e2e): 新增 abort-task / history-detail 场景并录制视频上传 CI

### DIFF
--- a/.github/workflows/coverage-e2e-frontend.yml
+++ b/.github/workflows/coverage-e2e-frontend.yml
@@ -40,6 +40,24 @@ jobs:
           cd frontend
           COVERAGE_E2E_FRONTEND=1 pnpm test:e2e
 
+      - name: Package Playwright report (videos + traces + screenshots)
+        if: always()
+        shell: bash
+        run: |
+          cd frontend
+          if [ -d playwright-report ]; then
+            tar -czf playwright-report.tar.gz ./playwright-report
+          fi
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-linux
+          path: frontend/playwright-report.tar.gz
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Combine and export backend coverage
         if: always()
         shell: bash

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -39,6 +39,26 @@ jobs:
           cd frontend
           pnpm test:e2e
 
+      - name: Package Playwright report (videos + traces + screenshots)
+        if: always()
+        shell: bash
+        run: |
+          cd frontend
+          # Bundle the HTML report (with embedded videos/traces) into a single
+          # zip so it can be downloaded from the Actions run for debugging.
+          if [ -d playwright-report ]; then
+            7z a playwright-report.zip ./playwright-report
+          fi
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-windows
+          path: frontend/playwright-report.zip
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Generate test summary
         if: always()
         shell: bash
@@ -50,3 +70,5 @@ jobs:
           else
             echo "❌ Web E2E tests failed. Check the logs above." >> $GITHUB_STEP_SUMMARY
           fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📥 Download the **playwright-report-windows** artifact for the recorded videos, traces, and screenshots." >> $GITHUB_STEP_SUMMARY

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -33,6 +33,10 @@ coverage/
 # nyc test coverage
 .nyc_output
 
+# Playwright artifacts — generated locally and in CI uploads
+/playwright-report/
+/test-results/
+
 # Dependency directories
 jspm_packages/
 

--- a/frontend/e2e/abort-task.spec.ts
+++ b/frontend/e2e/abort-task.spec.ts
@@ -111,7 +111,9 @@ test.describe('Task abort', () => {
     request,
   }) => {
     const { backend_url, agent_url, llm_url } = readServiceUrls();
-    const testDeviceId = 'mock_device_abort';
+    // Unique per run so a reused backend (reuseExistingServer in local reruns)
+    // never rejects add_remote as "already exists".
+    const testDeviceId = `mock_device_abort_${Date.now()}`;
 
     // Lock the UI to English so button titles / message text are stable.
     await page.addInitScript(() => {

--- a/frontend/e2e/abort-task.spec.ts
+++ b/frontend/e2e/abort-task.spec.ts
@@ -1,0 +1,242 @@
+/**
+ * Task cancellation / abort regression E2E test — runs against the real app.
+ *
+ * Drives the classic chat with Playwright while the shared E2E launcher runs
+ * the real backend plus mock LLM and mock device services.
+ *
+ * Covers the user "abort" workflow: a long-running agent task (the mock LLM
+ * never calls finish()) must be stoppable from the UI, surface a cancelled
+ * message in the conversation, leave the input ready again, and resolve the
+ * backend task to status=CANCELLED with a `cancelled` event.
+ */
+import {
+  test,
+  expect,
+  type APIRequestContext,
+  type APIResponse,
+} from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+type ServiceUrls = {
+  llm_url: string;
+  agent_url: string;
+  backend_url: string;
+  frontend_url: string;
+};
+
+type RemoteDeviceAddResponse = {
+  success: boolean;
+  serial: string;
+  message?: string;
+  error?: string;
+};
+
+type TaskRunResponse = {
+  id: string;
+  status: string;
+  trace_id: string | null;
+  step_count: number;
+  final_message: string | null;
+};
+
+type TaskEventRecord = {
+  task_id: string;
+  seq: number;
+  event_type: string;
+  payload: Record<string, unknown>;
+};
+
+type TaskEventListResponse = {
+  events: TaskEventRecord[];
+};
+
+const TERMINAL_STATUSES = new Set([
+  'SUCCEEDED',
+  'FAILED',
+  'CANCELLED',
+  'INTERRUPTED',
+]);
+
+function readServiceUrls(): ServiceUrls {
+  const urlsPath = path.resolve(__dirname, '.service_urls.json');
+  if (!fs.existsSync(urlsPath)) {
+    throw new Error(
+      `.service_urls.json not found - ensure start_e2e_services.py is running`
+    );
+  }
+  return JSON.parse(fs.readFileSync(urlsPath, 'utf-8')) as ServiceUrls;
+}
+
+async function assertOk(response: APIResponse, label: string): Promise<void> {
+  if (!response.ok()) {
+    throw new Error(
+      `${label} failed with ${response.status()}: ${await response.text()}`
+    );
+  }
+}
+
+async function waitForTask(
+  request: APIRequestContext,
+  backendUrl: string,
+  taskId: string
+): Promise<TaskRunResponse> {
+  const deadline = Date.now() + 30000;
+  let latest: TaskRunResponse | null = null;
+
+  while (Date.now() < deadline) {
+    const response = await request.get(`${backendUrl}/api/tasks/${taskId}`);
+    await assertOk(response, 'get task');
+    latest = (await response.json()) as TaskRunResponse;
+    if (TERMINAL_STATUSES.has(latest.status)) {
+      return latest;
+    }
+    await new Promise(resolve => setTimeout(resolve, 300));
+  }
+
+  throw new Error(
+    `Task ${taskId} did not reach a terminal status. Latest: ${JSON.stringify(
+      latest
+    )}`
+  );
+}
+
+test.describe('Task abort', () => {
+  test('cancels a running task from the UI and resolves to CANCELLED', async ({
+    page,
+    request,
+  }) => {
+    const { backend_url, agent_url, llm_url } = readServiceUrls();
+    const testDeviceId = 'mock_device_abort';
+
+    // Lock the UI to English so button titles / message text are stable.
+    await page.addInitScript(() => {
+      localStorage.setItem('locale', 'en');
+    });
+
+    // A long-running task: the mock LLM keeps issuing taps and never finishes,
+    // so the agent stays RUNNING until we abort it.
+    await assertOk(
+      await request.post(`${llm_url}/test/set_responses`, {
+        data: [
+          '分析当前界面，需要点击底部消息按钮。do(action="Tap", element=[499,966])',
+          '继续观察界面，执行下一步操作。do(action="Tap", element=[200,300])',
+          '继续执行任务，再点击一次。do(action="Tap", element=[400,500])',
+          '任务还在进行中，继续点击。do(action="Tap", element=[600,700])',
+          '继续推进任务。do(action="Tap", element=[100,200])',
+        ],
+      }),
+      'set mock LLM responses'
+    );
+    await assertOk(
+      await request.post(`${llm_url}/test/reset`),
+      'reset mock LLM'
+    );
+
+    const deviceResponse = await request.post(
+      `${backend_url}/api/devices/add_remote`,
+      {
+        data: { base_url: agent_url, device_id: testDeviceId },
+      }
+    );
+    await assertOk(deviceResponse, 'add remote device');
+    const deviceData = (await deviceResponse.json()) as RemoteDeviceAddResponse;
+    expect(deviceData.success).toBe(true);
+    expect(deviceData.serial).toBeTruthy();
+
+    await assertOk(
+      await request.post(`${agent_url}/test/reset`),
+      'reset mock device commands'
+    );
+
+    await assertOk(
+      await request.delete(`${backend_url}/api/config`),
+      'clear config'
+    );
+    await assertOk(
+      await request.post(`${backend_url}/api/config`, {
+        data: {
+          base_url: `${llm_url}/v1`,
+          model_name: 'mock-glm-model',
+          api_key: 'mock-key',
+          agent_type: 'glm-async',
+        },
+      }),
+      'save config'
+    );
+
+    await page.goto(
+      `/chat?serial=${encodeURIComponent(deviceData.serial)}&mode=classic`
+    );
+
+    // The settings dialog may appear on first load — dismiss it.
+    const dialog = page.locator('[role="dialog"]');
+    if (await dialog.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await page.locator('[role="dialog"] button:has-text("Close")').click();
+    }
+
+    const textbox = page.locator('textarea');
+    await expect(textbox).toBeVisible({ timeout: 15000 });
+
+    // Capture the task id created when the message is submitted.
+    const taskResponsePromise = page.waitForResponse(response => {
+      return (
+        response.request().method() === 'POST' &&
+        response.url().includes('/api/task-sessions/') &&
+        response.url().endsWith('/tasks')
+      );
+    });
+
+    await textbox.fill('点击屏幕下方的消息按钮');
+    await textbox.press('Meta+Enter');
+
+    const taskResponse = await taskResponsePromise;
+    await assertOk(taskResponse, 'submit task');
+    const submittedTask = (await taskResponse.json()) as TaskRunResponse;
+
+    // Wait until the task is visibly running: "Step 1" renders in the panel.
+    await expect(page.getByText('Step 1').first()).toBeVisible({
+      timeout: 30000,
+    });
+
+    // The abort button is shown while loading; it carries a stable title.
+    const abortButton = page.getByTitle('Abort Chat');
+    await expect(abortButton).toBeVisible({ timeout: 5000 });
+    await abortButton.click();
+
+    // ── UI assertions ──────────────────────────────────────────────────
+    // The cancelled assistant message must surface in the conversation.
+    await expect(page.getByText('Task cancelled by user').first()).toBeVisible({
+      timeout: 30000,
+    });
+
+    // Once loading clears, the abort button disappears and the input is ready.
+    await expect(abortButton).toBeHidden({ timeout: 15000 });
+
+    // ── Backend assertions ─────────────────────────────────────────────
+    const finalTask = await waitForTask(request, backend_url, submittedTask.id);
+    expect(finalTask.status).toBe('CANCELLED');
+
+    const eventsResponse = await request.get(
+      `${backend_url}/api/tasks/${submittedTask.id}/events`
+    );
+    await assertOk(eventsResponse, 'get task events');
+    const events = ((await eventsResponse.json()) as TaskEventListResponse)
+      .events;
+    const eventTypes = events.map(event => event.event_type);
+    expect(eventTypes).toContain('cancelled');
+
+    // The agent must have actually executed at least one tap before the abort.
+    const commandResponse = await request.get(
+      `${agent_url}/test/commands/actions`
+    );
+    await assertOk(commandResponse, 'get mock device commands');
+    const commands = (await commandResponse.json()) as { action: string }[];
+    const commandActions = commands.map(command => command.action);
+    expect(commandActions).toContain('tap');
+  });
+});

--- a/frontend/e2e/history-detail.spec.ts
+++ b/frontend/e2e/history-detail.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * Conversation history detail E2E test — runs against the real app.
+ *
+ * Covers the post-task history workflow from a user's point of view: after a
+ * task completes in the classic chat, the user opens the History page, sees
+ * the run, and drills into the detail dialog to inspect the task, the steps,
+ * and the per-step timing chips.
+ *
+ * The shared E2E launcher provides the real backend plus mock LLM and mock
+ * device services.
+ */
+import {
+  test,
+  expect,
+  type APIRequestContext,
+  type APIResponse,
+} from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+type ServiceUrls = {
+  llm_url: string;
+  agent_url: string;
+  backend_url: string;
+  frontend_url: string;
+};
+
+type RemoteDeviceAddResponse = {
+  success: boolean;
+  serial: string;
+  message?: string;
+  error?: string;
+};
+
+type TaskRunResponse = {
+  id: string;
+  status: string;
+  trace_id: string | null;
+  step_count: number;
+  final_message: string | null;
+};
+
+const TERMINAL_STATUSES = new Set([
+  'SUCCEEDED',
+  'FAILED',
+  'CANCELLED',
+  'INTERRUPTED',
+]);
+
+function readServiceUrls(): ServiceUrls {
+  const urlsPath = path.resolve(__dirname, '.service_urls.json');
+  if (!fs.existsSync(urlsPath)) {
+    throw new Error(
+      `.service_urls.json not found - ensure start_e2e_services.py is running`
+    );
+  }
+  return JSON.parse(fs.readFileSync(urlsPath, 'utf-8')) as ServiceUrls;
+}
+
+async function assertOk(response: APIResponse, label: string): Promise<void> {
+  if (!response.ok()) {
+    throw new Error(
+      `${label} failed with ${response.status()}: ${await response.text()}`
+    );
+  }
+}
+
+async function waitForTask(
+  request: APIRequestContext,
+  backendUrl: string,
+  taskId: string
+): Promise<TaskRunResponse> {
+  const deadline = Date.now() + 30000;
+  let latest: TaskRunResponse | null = null;
+
+  while (Date.now() < deadline) {
+    const response = await request.get(`${backendUrl}/api/tasks/${taskId}`);
+    await assertOk(response, 'get task');
+    latest = (await response.json()) as TaskRunResponse;
+    if (TERMINAL_STATUSES.has(latest.status)) {
+      return latest;
+    }
+    await new Promise(resolve => setTimeout(resolve, 300));
+  }
+
+  throw new Error(
+    `Task ${taskId} did not reach a terminal status. Latest: ${JSON.stringify(
+      latest
+    )}`
+  );
+}
+
+const INSTRUCTION = '点击屏幕下方的消息按钮';
+
+test.describe('History detail', () => {
+  test('lists a finished classic run and opens its step-by-step detail', async ({
+    page,
+    request,
+  }) => {
+    const { backend_url, agent_url, llm_url } = readServiceUrls();
+    const testDeviceId = 'mock_device_history';
+
+    // Lock the UI to English for stable assertions.
+    await page.addInitScript(() => {
+      localStorage.setItem('locale', 'en');
+    });
+
+    // A single-step successful task: one tap, then finish.
+    await assertOk(
+      await request.post(`${llm_url}/test/set_responses`, {
+        data: [
+          '分析界面，点击底部消息按钮。do(action="Tap", element=[499,966])',
+          '已进入消息页面。finish(message="已成功点击消息按钮！")',
+        ],
+      }),
+      'set mock LLM responses'
+    );
+    await assertOk(
+      await request.post(`${llm_url}/test/reset`),
+      'reset mock LLM'
+    );
+
+    const deviceResponse = await request.post(
+      `${backend_url}/api/devices/add_remote`,
+      {
+        data: { base_url: agent_url, device_id: testDeviceId },
+      }
+    );
+    await assertOk(deviceResponse, 'add remote device');
+    const deviceData = (await deviceResponse.json()) as RemoteDeviceAddResponse;
+    expect(deviceData.success).toBe(true);
+    expect(deviceData.serial).toBeTruthy();
+
+    await assertOk(
+      await request.post(`${agent_url}/test/reset`),
+      'reset mock device commands'
+    );
+
+    await assertOk(
+      await request.delete(`${backend_url}/api/config`),
+      'clear config'
+    );
+    await assertOk(
+      await request.post(`${backend_url}/api/config`, {
+        data: {
+          base_url: `${llm_url}/v1`,
+          model_name: 'mock-glm-model',
+          api_key: 'mock-key',
+          agent_type: 'glm-async',
+        },
+      }),
+      'save config'
+    );
+
+    // ── 1. Run a task in the classic chat ──────────────────────────────
+    await page.goto(
+      `/chat?serial=${encodeURIComponent(deviceData.serial)}&mode=classic`
+    );
+
+    const dialog = page.locator('[role="dialog"]');
+    if (await dialog.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await page.locator('[role="dialog"] button:has-text("Close")').click();
+    }
+
+    const textbox = page.locator('textarea');
+    await expect(textbox).toBeVisible({ timeout: 15000 });
+
+    const taskResponsePromise = page.waitForResponse(response => {
+      return (
+        response.request().method() === 'POST' &&
+        response.url().includes('/api/task-sessions/') &&
+        response.url().endsWith('/tasks')
+      );
+    });
+
+    await textbox.fill(INSTRUCTION);
+    await textbox.press('Meta+Enter');
+
+    const taskResponse = await taskResponsePromise;
+    await assertOk(taskResponse, 'submit task');
+    const submittedTask = (await taskResponse.json()) as TaskRunResponse;
+
+    // Wait for the run to finish in the backend, then for the UI to clear its
+    // loading state (abort button hidden => input ready again). Asserting the
+    // final message text directly is fragile — it also matches the hidden
+    // JSON action-details block — so we gate on backend + loading state.
+    await waitForTask(request, backend_url, submittedTask.id);
+    await expect(page.getByTitle('Abort Chat')).toBeHidden({ timeout: 30000 });
+
+    // ── 2. Navigate to history ─────────────────────────────────────────
+    await page.locator('nav a[href="/history"]').click();
+    await expect(page).toHaveURL(/\/history/);
+    await expect(
+      page.getByRole('heading', { name: 'Conversation History' })
+    ).toBeVisible({ timeout: 10000 });
+
+    // The finished run must appear in the list.
+    const card = page
+      .locator('.text-sm.font-medium', { hasText: INSTRUCTION })
+      .first();
+    await expect(card).toBeVisible({ timeout: 10000 });
+
+    // ── 3. Open the detail dialog ──────────────────────────────────────
+    // The Eye button is the per-record "view detail" affordance. Scope it to
+    // the record card so we don't pick up a button from an unrelated row.
+    const recordCard = page
+      .locator('[class*="hover:shadow-md"]', { hasText: INSTRUCTION })
+      .first();
+    const detailButton = recordCard.getByRole('button').first();
+    await detailButton.click();
+
+    await expect(
+      page.getByRole('heading', { name: 'Conversation Detail' })
+    ).toBeVisible({ timeout: 5000 });
+
+    // Task label + the instruction text render inside the dialog.
+    await expect(
+      page.locator('[role="dialog"]').getByText('Task').first()
+    ).toBeVisible();
+    await expect(
+      page.locator('[role="dialog"]').getByText(INSTRUCTION).first()
+    ).toBeVisible();
+
+    // Step 1 is expanded by default and shows per-step timing chips.
+    await expect(
+      page.locator('[role="dialog"]').getByText('Step 1').first()
+    ).toBeVisible();
+    await expect(
+      page.locator('[role="dialog"]').getByText('Total').first()
+    ).toBeVisible();
+    await expect(
+      page.locator('[role="dialog"]').getByText('Model').first()
+    ).toBeVisible();
+
+    // The tap action recorded by the agent surfaces in the Action block.
+    await expect(
+      page.locator('[role="dialog"]').getByText('"action": "Tap"').first()
+    ).toBeVisible();
+
+    // The success result message also renders in the detail view.
+    await expect(
+      page.locator('[role="dialog"]').getByText('已成功点击消息按钮').first()
+    ).toBeVisible();
+  });
+});

--- a/frontend/e2e/history-detail.spec.ts
+++ b/frontend/e2e/history-detail.spec.ts
@@ -200,17 +200,16 @@ test.describe('History detail', () => {
 
     // The finished run must appear in the list.
     const card = page
-      .locator('.text-sm.font-medium', { hasText: INSTRUCTION })
+      .locator('[data-testid="history-record-card"]', { hasText: INSTRUCTION })
       .first();
     await expect(card).toBeVisible({ timeout: 10000 });
 
     // ── 3. Open the detail dialog ──────────────────────────────────────
-    // The Eye button is the per-record "view detail" affordance. Scope it to
-    // the record card so we don't pick up a button from an unrelated row.
-    const recordCard = page
-      .locator('[class*="hover:shadow-md"]', { hasText: INSTRUCTION })
-      .first();
-    const detailButton = recordCard.getByRole('button').first();
+    // The Eye button is the per-record "view detail" affordance, scoped to
+    // this record's card via a stable data-testid (not Tailwind classes).
+    const detailButton = card.getByRole('button', {
+      name: 'Conversation Detail',
+    });
     await detailButton.click();
 
     await expect(

--- a/frontend/e2e/history-detail.spec.ts
+++ b/frontend/e2e/history-detail.spec.ts
@@ -102,7 +102,9 @@ test.describe('History detail', () => {
     request,
   }) => {
     const { backend_url, agent_url, llm_url } = readServiceUrls();
-    const testDeviceId = 'mock_device_history';
+    // Unique per run so a reused backend (reuseExistingServer in local reruns)
+    // never rejects add_remote as "already exists".
+    const testDeviceId = `mock_device_history_${Date.now()}`;
 
     // Lock the UI to English for stable assertions.
     await page.addInitScript(() => {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,8 +5,20 @@ export default defineConfig({
   timeout: 60000,
   retries: 0,
   workers: 1,
+  // HTML report bundles each test's video, trace, and screenshots so it can be
+  // uploaded from CI and opened locally for debugging.
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: 'playwright-report' }],
+  ],
   use: {
     baseURL: 'http://localhost:3000',
+    // Record a video for every test so any run can be reviewed after the fact.
+    video: 'on',
+    // Keep a full Playwright trace only for failures — enough to step through
+    // the exact failing interaction without paying the cost on every pass.
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
   },
   webServer: {
     // Start the full E2E stack (backend services + Vite) and proxy the frontend

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -15,9 +15,12 @@ export default defineConfig({
     baseURL: 'http://localhost:3000',
     // Record a video for every test so any run can be reviewed after the fact.
     video: 'on',
-    // Keep a full Playwright trace only for failures — enough to step through
-    // the exact failing interaction without paying the cost on every pass.
-    trace: 'retain-on-failure',
+    // Keep a full Playwright trace for every run (not just failures). A trace
+    // has a real timeline — you can scrub through each action, network request,
+    // and DOM snapshot with its wall-clock duration. The video alone drops
+    // idle/network-wait frames, so it plays back much faster than real time;
+    // the trace is what shows the actual timing and the operations in between.
+    trace: 'on',
     screenshot: 'only-on-failure',
   },
   webServer: {

--- a/frontend/src/routes/history.tsx
+++ b/frontend/src/routes/history.tsx
@@ -329,6 +329,8 @@ export function HistoryComponent() {
           {records.map(record => (
             <Card
               key={record.id}
+              data-testid="history-record-card"
+              data-record-id={record.id}
               className="hover:shadow-md transition-shadow cursor-pointer"
               onClick={() => handleViewDetail(record)}
             >
@@ -401,6 +403,7 @@ export function HistoryComponent() {
                       variant="ghost"
                       size="sm"
                       className="text-slate-400 hover:text-blue-500"
+                      aria-label={t.historyPage.detailTitle || 'View detail'}
                       onClick={e => {
                         e.stopPropagation();
                         handleViewDetail(record);

--- a/tests/README.md
+++ b/tests/README.md
@@ -143,7 +143,7 @@ pnpm test:e2e
 Playwright 配置（`frontend/playwright.config.ts`）对每个用例录制视频，并生成 HTML 报告：
 
 - `video: 'on'` — 每个用例都录制视频
-- `trace: 'retain-on-failure'` — 失败用例保留完整 trace（可逐步回放）
+- `trace: 'on'` — 每个用例都保留完整 trace（带真实时间轴，可逐步回放每个 action / 网络请求 / DOM 快照）
 - `screenshot: 'only-on-failure'` — 失败用例保留截图
 - `reporter: html` — 视频和 trace 内嵌进 HTML 报告
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -131,6 +131,24 @@ pnpm test:e2e
 - mock LLM server
 - mock agent server
 
+前端 E2E 场景（`frontend/e2e/*.spec.ts`）：
+- `scroll.spec.ts` — 流式响应期间聊天自动吸底（回归 #346）
+- `trace-events.spec.ts` — 前端调试输出 + 后端 trace 事件持久化
+- `device-state-routing.spec.ts` — 在 chat/history 间切换时保持选中设备（回归 #376）
+- `abort-task.spec.ts` — 从 UI 中止正在运行的任务，验证 UI 恢复可输入、后端 task 状态为 `CANCELLED` 且事件含 `cancelled`
+- `history-detail.spec.ts` — 任务完成后打开 History 详情对话框，校验任务文本、步骤、每步耗时与动作记录
+
+### 前端 E2E 视频录制
+
+Playwright 配置（`frontend/playwright.config.ts`）对每个用例录制视频，并生成 HTML 报告：
+
+- `video: 'on'` — 每个用例都录制视频
+- `trace: 'retain-on-failure'` — 失败用例保留完整 trace（可逐步回放）
+- `screenshot: 'only-on-failure'` — 失败用例保留截图
+- `reporter: html` — 视频和 trace 内嵌进 HTML 报告
+
+CI（`web-e2e.yml` / `coverage-e2e-frontend.yml`）会把 `playwright-report` 打包成 artifact 上传，运行结束后可在 Actions 运行页面下载。下载后解压，本地用浏览器打开 `playwright-report/index.html` 即可回放视频和 trace。
+
 ---
 
 ## 覆盖率口径


### PR DESCRIPTION
## 背景

现有前端 Playwright E2E 只有 3 个场景（scroll / trace-events / device-state-routing），从用户视角的覆盖面不足；且 CI 失败时只能看日志，无法回放页面交互，定位成本高。

## 改动

### 1. 新增两个用户视角的 E2E 场景

- **`frontend/e2e/abort-task.spec.ts`** —— 任务中止：起一个长任务（mock LLM 只发 tap 不 finish），点 DevicePanel 中止按钮，验证 UI 出现取消提示并恢复输入、后端 task status=`CANCELLED`、事件流含 `cancelled`、确实执行过 tap。
- **`frontend/e2e/history-detail.spec.ts`** —— 历史详情：classic chat 跑通一个成功任务 → 导航 `/history` → 打开详情对话框，校验任务文本、`Step 1`、`Total`/`Model` 耗时芯片、`"action": "Tap"`、结果消息。

### 2. 视频录制 + 可下载 artifact

- `frontend/playwright.config.ts`：`video: 'on'`（每个用例都录）、`trace: 'retain-on-failure'`、`screenshot: 'only-on-failure'`，并加 HTML reporter（视频/trace/截图内嵌进 `index.html`）。
- `web-e2e.yml`（Windows，7z 打包）和 `coverage-e2e-frontend.yml`（Linux，tar.gz 打包）都加 `actions/upload-artifact@v4`，artifact 名 `playwright-report-windows` / `playwright-report-linux`，保留 14 天，`if: always()` 保证失败也能拿视频。
- `frontend/.gitignore` 忽略 `playwright-report/` 和 `test-results/`。
- `tests/README.md` 补场景清单和视频下载说明。

## 验证

本地全量运行（含新增 2 个 + 原 3 个）：

\`\`\`
✓ abort-task / device-state-routing / history-detail / scroll / trace-events
5 passed (25.9s)
playwright-report/ 生成，含 5 个 webm 视频
\`\`\`

`pnpm run type-check`（tsc --noEmit）通过。

## 说明

- 录制策略：视频按需求全部录制，trace/截图仅失败保留——视频回放足够看全貌，trace 只在失败时才逐步调试，控制 artifact 体积。
- 未改动任何后端生产代码，仅测试基础设施与 CI。