### PR TITLE
fix: fix model connection check

### DIFF
--- a/AutoGLM_GUI/api/agents.py
+++ b/AutoGLM_GUI/api/agents.py
@@ -402,12 +402,11 @@ def model_connection_check(req: ModelConnectionRequest) -> dict[str, Any]:
                         "message": f"连接成功，但未返回模型列表\n{base}",
                     }
 
-            # 2) Auth error on /models — don't bother with fallback
+            # 2) Auth error on /models — log but try fallback
             if resp.status_code in (401, 403):
-                return {
-                    "success": False,
-                    "message": f"认证失败 ({resp.status_code})\n{(resp.text or '')[:120]}",
-                }
+                # Some providers disable /models but allow /chat/completions
+                # Continue to fallback to verify if the key/model actually work
+                pass
 
             # 3) /models not available — fall back to /chat/completions
             payload: dict[str, Any] = {

--- a/AutoGLM_GUI/api/agents.py
+++ b/AutoGLM_GUI/api/agents.py
@@ -356,7 +356,7 @@ class ModelConnectionRequest(BaseModel):
 
 @router.post("/api/config/model-connection-check")
 def model_connection_check(req: ModelConnectionRequest) -> dict[str, Any]:
-    """测试模型服务连通性：检查 base_url 是否可达、模型是否存在."""
+    """测试模型服务连通性：先尝试 /models 端点，不支持的降级到 /chat/completions."""
     base = req.base_url.rstrip("/")
     if not base:
         return {"success": False, "message": "请先填写 Base URL"}
@@ -372,31 +372,63 @@ def model_connection_check(req: ModelConnectionRequest) -> dict[str, Any]:
 
     try:
         with httpx.Client(timeout=10) as client:
+            # 1) Try /models endpoint (OpenAI-compatible standard)
             resp = client.get(f"{base}/models", headers=headers)
             if resp.status_code == 200:
-                data = resp.json()
-                ids = [
-                    m.get("id") for m in (data.get("data") or []) if isinstance(m, dict)
-                ]
-                if req.model_name in ids:
-                    return {
-                        "success": True,
-                        "message": f"连接成功 ({api_type})\n{base}\n{req.model_name}",
-                    }
-                if ids:
-                    show = ", ".join(str(id) for id in ids[:10] if id is not None)
-                    more = "" if len(ids) <= 10 else f" ...(+{len(ids) - 10})"
+                try:
+                    data = resp.json()
+                except Exception:
+                    data = None  # non-JSON body, fall through
+                if data and isinstance(data, dict):
+                    ids = [
+                        m.get("id")
+                        for m in (data.get("data") or [])
+                        if isinstance(m, dict)
+                    ]
+                    if req.model_name in ids:
+                        return {
+                            "success": True,
+                            "message": f"连接成功 ({api_type})\n{base}\n{req.model_name}",
+                        }
+                    if ids:
+                        show = ", ".join(str(id) for id in ids[:10] if id is not None)
+                        more = "" if len(ids) <= 10 else f" ...(+{len(ids) - 10})"
+                        return {
+                            "success": False,
+                            "message": f"连接成功，但未找到模型: {req.model_name}\n可用模型: {show}{more}",
+                        }
                     return {
                         "success": False,
-                        "message": f"连接成功，但未找到模型: {req.model_name}\n可用模型: {show}{more}",
+                        "message": f"连接成功，但未返回模型列表\n{base}",
                     }
+
+            # 2) Auth error on /models — don't bother with fallback
+            if resp.status_code in (401, 403):
                 return {
                     "success": False,
-                    "message": f"连接成功，但未返回模型列表\n{base}",
+                    "message": f"认证失败 ({resp.status_code})\n{(resp.text or '')[:120]}",
+                }
+
+            # 3) /models not available — fall back to /chat/completions
+            payload: dict[str, Any] = {
+                "model": req.model_name,
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 1,
+            }
+            chat_headers = {**headers, "Content-Type": "application/json"}
+            resp2 = client.post(
+                f"{base}/chat/completions",
+                json=payload,
+                headers=chat_headers,
+            )
+            if resp2.status_code == 200:
+                return {
+                    "success": True,
+                    "message": f"连接成功 ({api_type})\n{base}\n{req.model_name}",
                 }
             return {
                 "success": False,
-                "message": f"请求失败 ({resp.status_code})\n{(resp.text or '')[:120]}",
+                "message": f"请求失败 ({resp2.status_code})\n{(resp2.text or '')[:120]}",
             }
     except httpx.ConnectError:
         return {"success": False, "message": f"无法连接 {base}"}

--- a/tests/test_model_connection_check_api.py
+++ b/tests/test_model_connection_check_api.py
@@ -201,11 +201,15 @@ class TestModelNotFound:
 
 class TestHTTPError:
     def test_non_200_status(self) -> None:
-        mock_resp = _make_response(401, text="Unauthorized")
+        mock_resp_models = _make_response(401, text="Unauthorized")
+        mock_resp_chat = _make_response(401, text="Unauthorized")
         with patch("AutoGLM_GUI.api.agents.httpx.Client") as MockClient:
-            MockClient.return_value.__enter__ = MagicMock(
-                return_value=MagicMock(get=MagicMock(return_value=mock_resp))
-            )
+            mock_ctx = MagicMock()
+            get_mock = MagicMock(side_effect=[mock_resp_models, mock_resp_chat])
+            post_mock = MagicMock(return_value=mock_resp_chat)
+            mock_ctx.get = get_mock
+            mock_ctx.post = post_mock
+            MockClient.return_value.__enter__ = MagicMock(return_value=mock_ctx)
             MockClient.return_value.__exit__ = MagicMock(return_value=False)
             client = TestClient(_build_app())
             resp = client.post(
@@ -214,6 +218,7 @@ class TestHTTPError:
 
         body = resp.json()
         assert body["success"] is False
+        assert "请求失败" in body["message"]
         assert "401" in body["message"]
 
     def test_404_fallback_to_chat_completions(self) -> None:
@@ -254,12 +259,56 @@ class TestHTTPError:
         assert body["success"] is True
         assert "连接成功" in body["message"]
 
-    def test_403_no_fallback(self) -> None:
+    def test_403_fallback_allowed(self) -> None:
         mock_resp_models = _make_response(403, text="Forbidden")
+        mock_resp_chat = _make_response(200)
         with patch("AutoGLM_GUI.api.agents.httpx.Client") as MockClient:
-            MockClient.return_value.__enter__ = MagicMock(
-                return_value=MagicMock(get=MagicMock(return_value=mock_resp_models))
+            mock_ctx = MagicMock()
+            get_mock = MagicMock(side_effect=[mock_resp_models, mock_resp_chat])
+            post_mock = MagicMock(return_value=mock_resp_chat)
+            mock_ctx.get = get_mock
+            mock_ctx.post = post_mock
+            MockClient.return_value.__enter__ = MagicMock(return_value=mock_ctx)
+            MockClient.return_value.__exit__ = MagicMock(return_value=False)
+            client = TestClient(_build_app())
+            resp = client.post(
+                URL, json={"base_url": "http://localhost:8080/v1", "model_name": "m"}
             )
+
+        body = resp.json()
+        assert body["success"] is True
+        assert "连接成功" in body["message"]
+
+    def test_401_fallback_allowed(self) -> None:
+        mock_resp_models = _make_response(401, text="Unauthorized")
+        mock_resp_chat = _make_response(200)
+        with patch("AutoGLM_GUI.api.agents.httpx.Client") as MockClient:
+            mock_ctx = MagicMock()
+            get_mock = MagicMock(side_effect=[mock_resp_models, mock_resp_chat])
+            post_mock = MagicMock(return_value=mock_resp_chat)
+            mock_ctx.get = get_mock
+            mock_ctx.post = post_mock
+            MockClient.return_value.__enter__ = MagicMock(return_value=mock_ctx)
+            MockClient.return_value.__exit__ = MagicMock(return_value=False)
+            client = TestClient(_build_app())
+            resp = client.post(
+                URL, json={"base_url": "http://localhost:8080/v1", "model_name": "m"}
+            )
+
+        body = resp.json()
+        assert body["success"] is True
+        assert "连接成功" in body["message"]
+
+    def test_auth_fallback_auth_failure(self) -> None:
+        mock_resp_models = _make_response(403, text="Forbidden")
+        mock_resp_chat = _make_response(401, text="Unauthorized")
+        with patch("AutoGLM_GUI.api.agents.httpx.Client") as MockClient:
+            mock_ctx = MagicMock()
+            get_mock = MagicMock(side_effect=[mock_resp_models, mock_resp_chat])
+            post_mock = MagicMock(return_value=mock_resp_chat)
+            mock_ctx.get = get_mock
+            mock_ctx.post = post_mock
+            MockClient.return_value.__enter__ = MagicMock(return_value=mock_ctx)
             MockClient.return_value.__exit__ = MagicMock(return_value=False)
             client = TestClient(_build_app())
             resp = client.post(
@@ -268,7 +317,8 @@ class TestHTTPError:
 
         body = resp.json()
         assert body["success"] is False
-        assert "认证失败" in body["message"]
+        assert "请求失败" in body["message"]
+        assert "401" in body["message"]
 
     def test_json_parsing_error_fallback(self) -> None:
         mock_resp_models = MagicMock()

--- a/tests/test_model_connection_check_api.py
+++ b/tests/test_model_connection_check_api.py
@@ -179,11 +179,15 @@ class TestModelNotFound:
         assert "未返回模型列表" in body["message"]
 
     def test_no_data_key(self) -> None:
-        mock_resp = _make_response(200, {})
+        mock_resp_models = _make_response(200, {})
+        mock_resp_chat = _make_response(500, text="Chat error")
         with patch("AutoGLM_GUI.api.agents.httpx.Client") as MockClient:
-            MockClient.return_value.__enter__ = MagicMock(
-                return_value=MagicMock(get=MagicMock(return_value=mock_resp))
-            )
+            mock_ctx = MagicMock()
+            get_mock = MagicMock(return_value=mock_resp_models)
+            post_mock = MagicMock(return_value=mock_resp_chat)
+            mock_ctx.get = get_mock
+            mock_ctx.post = post_mock
+            MockClient.return_value.__enter__ = MagicMock(return_value=mock_ctx)
             MockClient.return_value.__exit__ = MagicMock(return_value=False)
             client = TestClient(_build_app())
             resp = client.post(
@@ -192,7 +196,7 @@ class TestModelNotFound:
 
         body = resp.json()
         assert body["success"] is False
-        assert "未返回模型列表" in body["message"]
+        assert "Chat error" in body["message"]
 
 
 class TestHTTPError:
@@ -211,6 +215,85 @@ class TestHTTPError:
         body = resp.json()
         assert body["success"] is False
         assert "401" in body["message"]
+
+    def test_404_fallback_to_chat_completions(self) -> None:
+        mock_resp_models = _make_response(404, text="Not Found")
+        mock_resp_chat = _make_response(200)
+        with patch("AutoGLM_GUI.api.agents.httpx.Client") as MockClient:
+            mock_ctx = MagicMock()
+            get_mock = MagicMock(side_effect=[mock_resp_models, mock_resp_chat])
+            mock_ctx.get = get_mock
+            mock_ctx.post = MagicMock(return_value=mock_resp_chat)
+            MockClient.return_value.__enter__ = MagicMock(return_value=mock_ctx)
+            MockClient.return_value.__exit__ = MagicMock(return_value=False)
+            client = TestClient(_build_app())
+            resp = client.post(
+                URL, json={"base_url": "http://localhost:8080/v1", "model_name": "m"}
+            )
+
+        body = resp.json()
+        assert body["success"] is True
+        assert "连接成功" in body["message"]
+
+    def test_500_fallback_to_chat_completions(self) -> None:
+        mock_resp_models = _make_response(500, text="Internal Server Error")
+        mock_resp_chat = _make_response(200)
+        with patch("AutoGLM_GUI.api.agents.httpx.Client") as MockClient:
+            mock_ctx = MagicMock()
+            get_mock = MagicMock(side_effect=[mock_resp_models, mock_resp_chat])
+            mock_ctx.get = get_mock
+            mock_ctx.post = MagicMock(return_value=mock_resp_chat)
+            MockClient.return_value.__enter__ = MagicMock(return_value=mock_ctx)
+            MockClient.return_value.__exit__ = MagicMock(return_value=False)
+            client = TestClient(_build_app())
+            resp = client.post(
+                URL, json={"base_url": "http://localhost:8080/v1", "model_name": "m"}
+            )
+
+        body = resp.json()
+        assert body["success"] is True
+        assert "连接成功" in body["message"]
+
+    def test_403_no_fallback(self) -> None:
+        mock_resp_models = _make_response(403, text="Forbidden")
+        with patch("AutoGLM_GUI.api.agents.httpx.Client") as MockClient:
+            MockClient.return_value.__enter__ = MagicMock(
+                return_value=MagicMock(get=MagicMock(return_value=mock_resp_models))
+            )
+            MockClient.return_value.__exit__ = MagicMock(return_value=False)
+            client = TestClient(_build_app())
+            resp = client.post(
+                URL, json={"base_url": "http://localhost:8080/v1", "model_name": "m"}
+            )
+
+        body = resp.json()
+        assert body["success"] is False
+        assert "认证失败" in body["message"]
+
+    def test_json_parsing_error_fallback(self) -> None:
+        mock_resp_models = MagicMock()
+        mock_resp_models.status_code = 200
+        mock_resp_models.json.side_effect = ValueError("Invalid JSON")
+        mock_resp_models.text = "<html>Error page</html>"
+
+        mock_resp_chat = _make_response(200)
+
+        with patch("AutoGLM_GUI.api.agents.httpx.Client") as MockClient:
+            mock_ctx = MagicMock()
+            get_mock = MagicMock(side_effect=[mock_resp_models, mock_resp_chat])
+            post_mock = MagicMock(return_value=mock_resp_chat)
+            mock_ctx.get = get_mock
+            mock_ctx.post = post_mock
+            MockClient.return_value.__enter__ = MagicMock(return_value=mock_ctx)
+            MockClient.return_value.__exit__ = MagicMock(return_value=False)
+            client = TestClient(_build_app())
+            resp = client.post(
+                URL, json={"base_url": "http://localhost:8080/v1", "model_name": "m"}
+            )
+
+        body = resp.json()
+        assert body["success"] is True
+        assert "连接成功" in body["message"]
 
 
 class TestNetworkError:


### PR DESCRIPTION
# 改动说明

- 增强模型连接检查逻辑，采用更健壮的回退机制
- 当 `/models` 端点不可用时，系统会自动回退到 `/chat/completions` 端点，提供更全面的模型验证和错误处理

## 相关 Issue

<!-- 如果有相关 issue 链接，请在这里填写，如：Closes #123 -->

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 代码重构

## 测试说明

测试用例验证了以下场景：
- `/models` 端点可用的正常情况
- `/models` 端点返回认证错误的情况
- `/models` 端点返回空模型列表的情况
- `/models` 端点完全不可用时的回退机制
- JSON 响应的处理逻辑

## 截图/录屏
- None

## 其他说明
- None