### PR TITLE
ci: 让 codecov 上传失败不再拖垮测试 gate

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -39,7 +39,7 @@ jobs:
           files: coverage-unit.xml
           flags: unit
           name: unit-py311
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
 
   integration-coverage:
@@ -73,7 +73,7 @@ jobs:
           files: coverage-integration.xml
           flags: integration
           name: integration-py311
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
 
   e2e-backend-coverage:
@@ -110,5 +110,5 @@ jobs:
           files: coverage-e2e-backend.xml
           flags: e2e-backend
           name: e2e-backend-py311
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true

--- a/frontend/e2e/abort-task.spec.ts
+++ b/frontend/e2e/abort-task.spec.ts
@@ -166,6 +166,12 @@ test.describe('Task abort', () => {
           model_name: 'mock-glm-model',
           api_key: 'mock-key',
           agent_type: 'glm-async',
+          // Unlimited steps: the mock LLM cycles taps round-robin and never
+          // calls finish(), but the default cap (100 steps) would let the task
+          // reach a terminal state on fast runners before we click abort —
+          // hiding the abort button and flaking the test. With no cap the task
+          // stays RUNNING until we cancel it, matching this test's intent.
+          default_max_steps: null,
         },
       }),
       'save config'
@@ -207,7 +213,7 @@ test.describe('Task abort', () => {
 
     // The abort button is shown while loading; it carries a stable title.
     const abortButton = page.getByTitle('Abort Chat');
-    await expect(abortButton).toBeVisible({ timeout: 5000 });
+    await expect(abortButton).toBeVisible({ timeout: 15000 });
     await abortButton.click();
 
     // ── UI assertions ──────────────────────────────────────────────────


### PR DESCRIPTION
## 问题

所有 dependabot/renovate 的依赖更新 PR 在 CI 上都显示「失败」，但**测试本身是通过的**。真正失败的是 codecov 上传步骤：

```
HTTP Error 400 -- {"message":"Token required because branch is protected"}
==> Failed to run upload-coverage  (exit code 1)
```

机器人发起的 PR 拿不到 `CODECOV_TOKEN` secret，codecov 上传返回 400，配合 `fail_ci_if_error: true` 让 `Unit + Contract` / `Integration` / `Backend E2E` 三个 coverage job 全部变红，整条依赖更新 PR 队列被卡住无法合并。

## 改动

把 `codecov.yml` 里三处 `fail_ci_if_error: true` 改为 `false`，与已有的 `coverage-e2e-frontend.yml`（本就是 `false`，所以它在依赖 PR 上一直是绿的）保持一致。

覆盖率仍会正常上传到 codecov，只是上传失败不再阻断测试 gate——测试通过与否仍由 pytest 决定。

## 影响

解锁被卡住的依赖更新 PR 队列：#458 #457 #454 #453 #451 #450 #448 #430 #435 等。