### PR TITLE
feat: add MobileForge protocol agent and Qwen3-VL-4B SFT recipe

### DIFF
--- a/AutoGLM_GUI/agents/factory.py
+++ b/AutoGLM_GUI/agents/factory.py
@@ -280,3 +280,26 @@ def _create_qwen_agent(
 
 
 register_agent("qwen", _create_qwen_agent)
+
+
+def _create_mobileforge_agent(
+    model_config: ModelConfig,
+    agent_config: AgentConfig,
+    agent_specific_config: AgentSpecificConfig,  # noqa: ARG001
+    device: DeviceProtocol,
+    takeover_callback: Callable[..., Any] | None = None,
+    confirmation_callback: Callable[..., Any] | None = None,
+) -> AsyncAgent:
+    """Create an agent for MobileForge-format Qwen-VL checkpoints."""
+    from .mobileforge.async_agent import AsyncMobileForgeAgent
+
+    return AsyncMobileForgeAgent(  # type: ignore[return-value]
+        model_config=model_config,
+        agent_config=agent_config,
+        device=device,
+        confirmation_callback=confirmation_callback,
+        takeover_callback=takeover_callback,
+    )
+
+
+register_agent("mobileforge", _create_mobileforge_agent)

--- a/AutoGLM_GUI/agents/mobileforge/__init__.py
+++ b/AutoGLM_GUI/agents/mobileforge/__init__.py
@@ -1,0 +1,6 @@
+"""MobileForge model protocol adapter."""
+
+from .async_agent import AsyncMobileForgeAgent
+from .parser import MobileForgeParser
+
+__all__ = ["AsyncMobileForgeAgent", "MobileForgeParser"]

--- a/AutoGLM_GUI/agents/mobileforge/async_agent.py
+++ b/AutoGLM_GUI/agents/mobileforge/async_agent.py
@@ -1,0 +1,42 @@
+"""Async agent for MobileForge-compatible Qwen-VL models."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .parser import MobileForgeParser
+from .prompts import SYSTEM_PROMPT
+from AutoGLM_GUI.agents.qwen.async_agent import AsyncQwenAgent
+from AutoGLM_GUI.config import AgentConfig, ModelConfig
+from AutoGLM_GUI.device_protocol import DeviceProtocol
+
+
+class AsyncMobileForgeAgent(AsyncQwenAgent):
+    """Reuse the reliable Qwen execution loop with MobileForge wire format."""
+
+    def __init__(
+        self,
+        model_config: ModelConfig,
+        agent_config: AgentConfig,
+        device: DeviceProtocol,
+        confirmation_callback: Callable[[str], bool] | None = None,
+        takeover_callback: Callable[[str], None] | None = None,
+    ):
+        super().__init__(
+            model_config=model_config,
+            agent_config=agent_config,
+            device=device,
+            confirmation_callback=confirmation_callback,
+            takeover_callback=takeover_callback,
+        )
+        self.parser = MobileForgeParser()
+        self._action_markers = ["<tool_call>"]
+
+    def _get_default_system_prompt(self, lang: str) -> str:  # noqa: ARG002
+        return SYSTEM_PROMPT
+
+    def _format_assistant_context(
+        self, raw_content: str, thinking: str, action_str: str
+    ) -> str:  # noqa: ARG002
+        # Native history matters for models fine-tuned on MobileForge traces.
+        return raw_content

--- a/AutoGLM_GUI/agents/mobileforge/parser.py
+++ b/AutoGLM_GUI/agents/mobileforge/parser.py
@@ -1,0 +1,91 @@
+"""Translate MobileForge JSON tool calls to AutoGLM GUI actions."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+
+class MobileForgeParser:
+    """Parse ``<tool_call>`` JSON without evaluating model-produced code."""
+
+    @property
+    def coordinate_scale(self) -> int:
+        return 1000
+
+    @staticmethod
+    def parse_response(content: str) -> tuple[str, str]:
+        thinking_match = re.search(r"<thinking>(.*?)</thinking>", content, re.DOTALL)
+        thinking = thinking_match.group(1).strip() if thinking_match else ""
+        call_match = re.search(r"<tool_call>\s*(.*?)\s*</tool_call>", content, re.DOTALL)
+        if not call_match:
+            # Keep the base agent's standard parse-error/finish behavior.
+            return thinking, content
+        return thinking, call_match.group(1)
+
+    def parse(self, action_str: str) -> dict[str, Any]:
+        try:
+            tool_call = json.loads(action_str)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Invalid MobileForge tool-call JSON") from exc
+        if not isinstance(tool_call, dict):
+            raise ValueError("MobileForge tool call must be a JSON object")
+
+        action = tool_call.get("action")
+        if not isinstance(action, str):
+            raise ValueError("MobileForge tool call needs a string action")
+
+        if action in {"answer", "terminate"}:
+            message = tool_call.get("text", tool_call.get("message", "Task completed"))
+            return {"_metadata": "finish", "message": str(message)}
+        if action == "click":
+            return self._point_action("Tap", tool_call)
+        if action == "long_press":
+            return self._point_action("Long Press", tool_call)
+        if action == "swipe":
+            return {
+                "_metadata": "do",
+                "action": "Swipe",
+                "start": self._point(tool_call.get("start"), "start"),
+                "end": self._point(tool_call.get("end"), "end"),
+            }
+        if action == "type":
+            text = tool_call.get("text")
+            if not isinstance(text, str):
+                raise ValueError("type action needs text")
+            return {"_metadata": "do", "action": "Type", "text": text}
+        if action == "open":
+            app = tool_call.get("app")
+            if not isinstance(app, str) or not app:
+                raise ValueError("open action needs app")
+            return {"_metadata": "do", "action": "Launch", "app": app}
+        if action == "system_button":
+            button = str(tool_call.get("button", "")).lower()
+            names = {"back": "Back", "home": "Home"}
+            if button not in names:
+                raise ValueError("system_button must be back or home")
+            return {"_metadata": "do", "action": names[button]}
+        if action == "wait":
+            duration = tool_call.get("duration", 1)
+            if not isinstance(duration, int | float) or duration < 0:
+                raise ValueError("wait duration must be a non-negative number")
+            return {"_metadata": "do", "action": "Wait", "duration": f"{duration} seconds"}
+        raise ValueError(f"Unsupported MobileForge action: {action}")
+
+    def _point_action(self, action: str, tool_call: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "_metadata": "do",
+            "action": action,
+            "element": self._point(tool_call.get("coordinate"), "coordinate"),
+        }
+
+    @staticmethod
+    def _point(value: Any, name: str) -> list[int]:
+        if (
+            not isinstance(value, list)
+            or len(value) != 2
+            or any(not isinstance(item, int | float) for item in value)
+        ):
+            raise ValueError(f"{name} must be a two-number coordinate")
+        return [max(0, min(1000, int(value[0]))), max(0, min(1000, int(value[1])))]

--- a/AutoGLM_GUI/agents/mobileforge/parser.py
+++ b/AutoGLM_GUI/agents/mobileforge/parser.py
@@ -16,47 +16,72 @@ class MobileForgeParser:
 
     @staticmethod
     def parse_response(content: str) -> tuple[str, str]:
-        thinking_match = re.search(r"<thinking>(.*?)</thinking>", content, re.DOTALL)
+        thinking_match = re.search(
+            r"<thinking>(.*?)</thinking>", content, re.DOTALL | re.IGNORECASE
+        )
         thinking = thinking_match.group(1).strip() if thinking_match else ""
-        call_match = re.search(r"<tool_call>\s*(.*?)\s*</tool_call>", content, re.DOTALL)
+        call_match = re.search(
+            r"<tool_call>\s*(.*?)\s*</tool_call>",
+            content,
+            re.DOTALL | re.IGNORECASE,
+        )
         if not call_match:
             # Keep the base agent's standard parse-error/finish behavior.
             return thinking, content
         return thinking, call_match.group(1)
 
     def parse(self, action_str: str) -> dict[str, Any]:
+        action_str = re.sub(
+            r"^```(?:json)?\s*|\s*```$",
+            "",
+            action_str.strip(),
+            flags=re.IGNORECASE,
+        )
         try:
-            tool_call = json.loads(action_str)
+            payload = json.loads(action_str)
         except json.JSONDecodeError as exc:
             raise ValueError("Invalid MobileForge tool-call JSON") from exc
+        if not isinstance(payload, dict):
+            raise TypeError("MobileForge tool call must be a JSON object")
+
+        tool_call = payload.get("arguments", payload)
         if not isinstance(tool_call, dict):
-            raise ValueError("MobileForge tool call must be a JSON object")
+            raise TypeError("MobileForge tool-call arguments must be an object")
 
         action = tool_call.get("action")
         if not isinstance(action, str):
-            raise ValueError("MobileForge tool call needs a string action")
+            raise TypeError("MobileForge tool call needs a string action")
+        action = action.lower()
 
-        if action in {"answer", "terminate"}:
-            message = tool_call.get("text", tool_call.get("message", "Task completed"))
+        if action == "answer":
+            message = tool_call.get("text", tool_call.get("message", ""))
             return {"_metadata": "finish", "message": str(message)}
-        if action == "click":
+        if action == "terminate":
+            message = tool_call.get("text", tool_call.get("message"))
+            if message is None:
+                status = str(tool_call.get("status", "success")).lower()
+                message = "Task completed" if status == "success" else "Task infeasible"
+            return {"_metadata": "finish", "message": str(message)}
+        if action in {"click", "tap"}:
             return self._point_action("Tap", tool_call)
         if action == "long_press":
             return self._point_action("Long Press", tool_call)
         if action == "swipe":
+            start = tool_call.get("coordinate", tool_call.get("start"))
+            end = tool_call.get("coordinate2", tool_call.get("end"))
             return {
                 "_metadata": "do",
                 "action": "Swipe",
-                "start": self._point(tool_call.get("start"), "start"),
-                "end": self._point(tool_call.get("end"), "end"),
+                "start": self._point(start, "start"),
+                "end": self._point(end, "end"),
             }
-        if action == "type":
+        if action in {"type", "input_text"}:
             text = tool_call.get("text")
             if not isinstance(text, str):
                 raise ValueError("type action needs text")
             return {"_metadata": "do", "action": "Type", "text": text}
-        if action == "open":
-            app = tool_call.get("app")
+        if action in {"open", "open_app"}:
+            app = tool_call.get("text", tool_call.get("app", tool_call.get("app_name")))
             if not isinstance(app, str) or not app:
                 raise ValueError("open action needs app")
             return {"_metadata": "do", "action": "Launch", "app": app}
@@ -67,10 +92,14 @@ class MobileForgeParser:
                 raise ValueError("system_button must be back or home")
             return {"_metadata": "do", "action": names[button]}
         if action == "wait":
-            duration = tool_call.get("duration", 1)
+            duration = tool_call.get("time", tool_call.get("duration", 1))
             if not isinstance(duration, int | float) or duration < 0:
                 raise ValueError("wait duration must be a non-negative number")
-            return {"_metadata": "do", "action": "Wait", "duration": f"{duration} seconds"}
+            return {
+                "_metadata": "do",
+                "action": "Wait",
+                "duration": f"{duration} seconds",
+            }
         raise ValueError(f"Unsupported MobileForge action: {action}")
 
     def _point_action(self, action: str, tool_call: dict[str, Any]) -> dict[str, Any]:

--- a/AutoGLM_GUI/agents/mobileforge/prompts.py
+++ b/AutoGLM_GUI/agents/mobileforge/prompts.py
@@ -4,8 +4,8 @@ SYSTEM_PROMPT = """You are a smartphone operation agent. Inspect the current scr
 
 Reply using exactly this structure:
 <thinking>brief reasoning</thinking>
-<tool_call>{"action":"click","coordinate":[500,500]}</tool_call>
+<tool_call>{"name":"mobile_use","arguments":{"action":"click","coordinate":[500,500]}}</tool_call>
 
-The tool call must be valid JSON and contain one action. Coordinates use the 0-1000 scale.
-Supported actions are: click and long_press with coordinate [x,y]; swipe with start [x,y] and end [x,y]; type with text; open with app; system_button with button "back" or "home"; wait; answer with text; terminate with an optional status.
+The tool call must be valid JSON with name "mobile_use" and an arguments object. Coordinates use the 0-1000 scale.
+Supported actions are: click and long_press with coordinate [x,y]; swipe with coordinate [x1,y1] and coordinate2 [x2,y2]; type with text; open with text; system_button with button "Back" or "Home"; wait with time; answer with text; terminate with an optional status.
 Do not use Markdown fences. Finish with answer or terminate when the task is complete."""

--- a/AutoGLM_GUI/agents/mobileforge/prompts.py
+++ b/AutoGLM_GUI/agents/mobileforge/prompts.py
@@ -1,0 +1,11 @@
+"""Prompts for models trained with the MobileForge tool-call protocol."""
+
+SYSTEM_PROMPT = """You are a smartphone operation agent. Inspect the current screenshot and take one safe action toward the user's task.
+
+Reply using exactly this structure:
+<thinking>brief reasoning</thinking>
+<tool_call>{"action":"click","coordinate":[500,500]}</tool_call>
+
+The tool call must be valid JSON and contain one action. Coordinates use the 0-1000 scale.
+Supported actions are: click and long_press with coordinate [x,y]; swipe with start [x,y] and end [x,y]; type with text; open with app; system_button with button "back" or "home"; wait; answer with text; terminate with an optional status.
+Do not use Markdown fences. Finish with answer or terminate when the task is complete."""

--- a/AutoGLM_GUI/agents/qwen/async_agent.py
+++ b/AutoGLM_GUI/agents/qwen/async_agent.py
@@ -70,6 +70,7 @@ class AsyncQwenAgent(AsyncAgentBase, AsyncAgent):
         # official Open-AutoGLM layout.
         self._pending_task: str | None = None
         self._pending_reference_images: list[dict[str, str]] = []
+        self._action_markers = ["<answer>", "finish(message=", "do(action="]
 
     def _get_default_system_prompt(self, lang: str) -> str:
         return get_system_prompt(lang)
@@ -349,7 +350,7 @@ class AsyncQwenAgent(AsyncAgentBase, AsyncAgent):
             )
             self._context.append(
                 MessageBuilder.create_assistant_message(
-                    f"<thought>{thinking}</thought><answer>{action_str}</answer>"
+                    self._format_assistant_context(raw_content, thinking, action_str)
                 )
             )
 
@@ -396,6 +397,12 @@ class AsyncQwenAgent(AsyncAgentBase, AsyncAgent):
             },
         }
 
+    def _format_assistant_context(
+        self, raw_content: str, thinking: str, action_str: str
+    ) -> str:
+        """Return the assistant turn to retain in the next model request."""
+        return f"<thought>{thinking}</thought><answer>{action_str}</answer>"
+
     async def _stream_openai(
         self, messages: list[dict[str, Any]]
     ) -> AsyncGenerator[dict[str, str], None]:
@@ -412,7 +419,7 @@ class AsyncQwenAgent(AsyncAgentBase, AsyncAgent):
         )
 
         buffer = ""
-        action_markers = ["<answer>", "finish(message=", "do(action="]
+        action_markers = self._action_markers
         in_action_phase = False
 
         try:

--- a/examples/mobileforge/README.md
+++ b/examples/mobileforge/README.md
@@ -10,6 +10,16 @@ This directory documents how to serve or reproduce a **MobileForge-protocol** Qw
 
 It deliberately excludes LoRA/merged checkpoint weights, screenshots, task data, credentials, and training logs. Those artifacts are both too large for source control and may contain private content. Publish model weights separately only after checking the base-model license, dataset permissions, and a privacy review.
 
+## Pretrained LoRA adapter
+
+A privacy-reviewed LoRA adapter is published separately from the source tree:
+
+- [Qwen3-VL-4B MobileForge LoRA v1](https://github.com/YoungJulY0728/AutoGLM-GUI/releases/tag/mobileforge-qwen3-vl-4b-lora-v1)
+
+The release removes local absolute paths and identity metadata and includes a
+SHA-256 checksum. Raw screenshots, device identifiers, credentials, and logs
+are not bundled with the adapter.
+
 ## Serve a local adapter
 
 Install a Qwen3-VL-compatible vLLM build, then point the GUI's **MobileForge Agent** at an OpenAI-compatible endpoint. For example:

--- a/examples/mobileforge/README.md
+++ b/examples/mobileforge/README.md
@@ -1,14 +1,23 @@
 # MobileForge-compatible Qwen3-VL LoRA
 
-This directory documents how to serve or reproduce a **MobileForge-protocol** Qwen3-VL-4B adapter with AutoGLM-GUI. The `mobileforge` agent converts the model's JSON `<tool_call>` output into the GUI's existing Android actions.
+This directory shows how to fine-tune and serve
+`Qwen/Qwen3-VL-4B-Instruct` with MobileForge conversation data. The
+`mobileforge` agent translates the model's `mobile_use` JSON tool calls into
+AutoGLM-GUI actions.
+
+The recipe is an experimental reference, not an official model release or
+benchmark result.
 
 ## What this PR includes
 
-- The protocol adapter and GUI preset.
-- A model-serving command and a small smoke test.
-- Guidance for using an adapter trained on data you are permitted to use.
+- A MobileForge protocol adapter and GUI preset.
+- A small LoRA SFT recipe for positive MobileForge action steps.
+- Commands for serving either a LoRA adapter or a merged model.
+- Offline parser and sanitized action-shape tests.
 
-It deliberately excludes LoRA/merged checkpoint weights, screenshots, task data, credentials, and training logs. Those artifacts are both too large for source control and may contain private content. Publish model weights separately only after checking the base-model license, dataset permissions, and a privacy review.
+It deliberately excludes model weights, checkpoints, screenshots, raw task
+data, credentials, device identifiers, network addresses, and training or
+device logs.
 
 ## Pretrained LoRA adapter
 
@@ -17,26 +26,87 @@ A privacy-reviewed LoRA adapter is published separately from the source tree:
 - [Qwen3-VL-4B MobileForge LoRA v1](https://github.com/YoungJulY0728/AutoGLM-GUI/releases/tag/mobileforge-qwen3-vl-4b-lora-v1)
 
 The release removes local absolute paths and identity metadata and includes a
-SHA-256 checksum. Raw screenshots, device identifiers, credentials, and logs
-are not bundled with the adapter.
+SHA-256 checksum. Review the base-model and dataset licenses before publishing
+another adapter.
 
-## Serve a local adapter
+## Install optional training dependencies
 
-Install a Qwen3-VL-compatible vLLM build, then point the GUI's **MobileForge Agent** at an OpenAI-compatible endpoint. For example:
+Create a separate environment, install AutoGLM-GUI, then install:
+
+```bash
+pip install -r examples/mobileforge/requirements.txt
+```
+
+Install `bitsandbytes` separately when using `--use-4bit`. Install `vllm` in
+the serving environment.
+
+## Prepare data
+
+Download or generate MobileForge training data following the
+[MobileForge data documentation](https://github.com/kwai/MobileForge/blob/main/docs/data_release.md).
+The JSON file must contain conversation records with an `is_positive` flag,
+and image references must be relative to `--image-dir`.
+
+Do not train on or publish screenshots containing personal information unless
+you have reviewed and appropriately sanitized them.
+
+## Train
+
+The defaults use up to 2,000 positive samples, two epochs, LoRA rank 16, and
+bf16 weights:
+
+```bash
+python examples/mobileforge/train_qwen3_vl_4b_lora.py \
+  --data-path /path/to/mobileforge_grpo_image_paths.json \
+  --image-dir /path/to/mobileforge_images \
+  --output-dir /path/to/qwen3-vl-4b-mobileforge-lora
+```
+
+On smaller GPUs, add `--use-4bit`. The 4-bit path saves an adapter only because
+merging a quantized training model is not reliable. The bf16 path saves both
+`lora_adapter/` and a standalone `merged/` model.
+
+## Serve
+
+Serve a LoRA adapter directly:
 
 ```bash
 vllm serve /path/to/Qwen3-VL-4B-Instruct \
-  --enable-lora --lora-modules mobileforge=/path/to/lora_adapter \
+  --enable-lora \
+  --lora-modules mobileforge=/path/to/lora_adapter \
   --served-model-name qwen3-vl-4b-mobileforge
 ```
 
-In the GUI configure the endpoint URL, model name `qwen3-vl-4b-mobileforge`, and select **MobileForge Agent**. This repository currently uses Android ADB transport. HarmonyOS/HDC transport requires a separate device backend and is not claimed by this adapter.
+Or serve the merged model:
+
+```bash
+bash examples/mobileforge/serve_qwen3_vl_4b.sh \
+  /path/to/qwen3-vl-4b-mobileforge-lora/merged
+```
+
+In the GUI, configure the endpoint URL and served model name, then select
+**MobileForge Agent**.
 
 ## Expected model response
 
 ```text
 <thinking>The search box is visible.</thinking>
-<tool_call>{"action":"click","coordinate":[500,220]}</tool_call>
+<tool_call>{"name":"mobile_use","arguments":{"action":"click","coordinate":[500,220]}}</tool_call>
 ```
 
-Coordinates are normalized to 0–1000. Allowed actions are `click`, `long_press`, `swipe`, `type`, `open`, `system_button` (`back` or `home`), `wait`, `answer`, and `terminate`.
+Coordinates are normalized to 0–1000. Supported actions are `click`,
+`long_press`, `swipe`, `type`, `open`, `system_button` (`Back` or `Home`),
+`wait`, `answer`, and `terminate`. For compatibility, the parser also accepts
+the earlier flat JSON form used by the first version of this PR.
+
+## Device trace privacy and transport compatibility
+
+HDC or ADB screenshots, model responses, prompts, and runtime logs can contain
+account details, messages, locations, device identifiers, and private network
+addresses. Do not attach raw traces to an issue or pull request. Reduce a
+failure to a synthetic protocol response without real task text, coordinates,
+identifiers, paths, or network details.
+
+The regression tests include only sanitized action shapes observed during
+HarmonyOS 6 experiments. AutoGLM-GUI currently provides an Android ADB device
+backend; this PR does not add or claim HarmonyOS/HDC transport support.

--- a/examples/mobileforge/README.md
+++ b/examples/mobileforge/README.md
@@ -1,0 +1,32 @@
+# MobileForge-compatible Qwen3-VL LoRA
+
+This directory documents how to serve or reproduce a **MobileForge-protocol** Qwen3-VL-4B adapter with AutoGLM-GUI. The `mobileforge` agent converts the model's JSON `<tool_call>` output into the GUI's existing Android actions.
+
+## What this PR includes
+
+- The protocol adapter and GUI preset.
+- A model-serving command and a small smoke test.
+- Guidance for using an adapter trained on data you are permitted to use.
+
+It deliberately excludes LoRA/merged checkpoint weights, screenshots, task data, credentials, and training logs. Those artifacts are both too large for source control and may contain private content. Publish model weights separately only after checking the base-model license, dataset permissions, and a privacy review.
+
+## Serve a local adapter
+
+Install a Qwen3-VL-compatible vLLM build, then point the GUI's **MobileForge Agent** at an OpenAI-compatible endpoint. For example:
+
+```bash
+vllm serve /path/to/Qwen3-VL-4B-Instruct \
+  --enable-lora --lora-modules mobileforge=/path/to/lora_adapter \
+  --served-model-name qwen3-vl-4b-mobileforge
+```
+
+In the GUI configure the endpoint URL, model name `qwen3-vl-4b-mobileforge`, and select **MobileForge Agent**. This repository currently uses Android ADB transport. HarmonyOS/HDC transport requires a separate device backend and is not claimed by this adapter.
+
+## Expected model response
+
+```text
+<thinking>The search box is visible.</thinking>
+<tool_call>{"action":"click","coordinate":[500,220]}</tool_call>
+```
+
+Coordinates are normalized to 0–1000. Allowed actions are `click`, `long_press`, `swipe`, `type`, `open`, `system_button` (`back` or `home`), `wait`, `answer`, and `terminate`.

--- a/examples/mobileforge/requirements.txt
+++ b/examples/mobileforge/requirements.txt
@@ -1,0 +1,5 @@
+accelerate>=1.10
+Pillow>=10.0
+peft>=0.19
+torch>=2.6
+transformers>=4.57

--- a/examples/mobileforge/serve_qwen3_vl_4b.sh
+++ b/examples/mobileforge/serve_qwen3_vl_4b.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Serve a merged Qwen3-VL-4B MobileForge LoRA model through vLLM.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 /path/to/merged-model" >&2
+  exit 2
+fi
+
+MODEL_DIR="$1"
+SERVED_NAME="${SERVED_NAME:-qwen3-vl-4b-mobileforge-sft}"
+PORT="${PORT:-8000}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-24576}"
+GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.85}"
+MAX_PIXELS="${MAX_PIXELS:-1258291}"
+
+if [[ ! -d "$MODEL_DIR" ]]; then
+  echo "Model directory not found: $MODEL_DIR" >&2
+  exit 2
+fi
+
+exec python -m vllm.entrypoints.openai.api_server \
+  --model "$MODEL_DIR" \
+  --served-model-name "$SERVED_NAME" \
+  --port "$PORT" \
+  --max-model-len "$MAX_MODEL_LEN" \
+  --limit-mm-per-prompt '{"image":10}' \
+  --mm-processor-kwargs "{\"max_pixels\":$MAX_PIXELS}" \
+  --chat-template-content-format string \
+  --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION"

--- a/examples/mobileforge/smoke_test.py
+++ b/examples/mobileforge/smoke_test.py
@@ -10,7 +10,8 @@ def main() -> None:
     parser = MobileForgeParser()
     response = (
         "<thinking>I should tap Search.</thinking>"
-        '<tool_call>{"action":"click","coordinate":[500,120]}</tool_call>'
+        '<tool_call>{"name":"mobile_use","arguments":'
+        '{"action":"click","coordinate":[500,120]}}</tool_call>'
     )
     thinking, action_text = parser.parse_response(response)
     action = parser.parse(action_text)

--- a/examples/mobileforge/smoke_test.py
+++ b/examples/mobileforge/smoke_test.py
@@ -1,0 +1,23 @@
+"""Offline validation for MobileForge protocol responses.
+
+Run: uv run python examples/mobileforge/smoke_test.py
+"""
+
+from AutoGLM_GUI.agents.mobileforge.parser import MobileForgeParser
+
+
+def main() -> None:
+    parser = MobileForgeParser()
+    response = (
+        "<thinking>I should tap Search.</thinking>"
+        '<tool_call>{"action":"click","coordinate":[500,120]}</tool_call>'
+    )
+    thinking, action_text = parser.parse_response(response)
+    action = parser.parse(action_text)
+    assert thinking == "I should tap Search."
+    assert action == {"_metadata": "do", "action": "Tap", "element": [500, 120]}
+    print("MobileForge protocol smoke test passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mobileforge/train_qwen3_vl_4b_lora.py
+++ b/examples/mobileforge/train_qwen3_vl_4b_lora.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""LoRA SFT for Qwen3-VL-4B using positive MobileForge action steps."""
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import torch
+from peft import (
+    LoraConfig,
+    TaskType,
+    get_peft_model,
+    prepare_model_for_kbit_training,
+)
+from PIL import Image
+from transformers import (
+    AutoModelForImageTextToText,
+    AutoProcessor,
+    BitsAndBytesConfig,
+    Trainer,
+    TrainingArguments,
+)
+
+IMAGE_GRID_KEY = "image_grid_thw"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="LoRA SFT for Qwen3-VL-4B on MobileForge data"
+    )
+    parser.add_argument("--model-path", default="Qwen/Qwen3-VL-4B-Instruct")
+    parser.add_argument("--data-path", type=Path, required=True)
+    parser.add_argument("--image-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--max-samples", type=int, default=2000)
+    parser.add_argument("--max-image-size", type=int, default=768)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--gradient-accumulation-steps", type=int, default=4)
+    parser.add_argument("--num-epochs", type=float, default=2)
+    parser.add_argument("--learning-rate", type=float, default=2e-5)
+    parser.add_argument("--lora-rank", type=int, default=16)
+    parser.add_argument("--lora-alpha", type=int, default=32)
+    parser.add_argument("--max-length", type=int, default=8192)
+    parser.add_argument("--use-4bit", action="store_true")
+    return parser.parse_args()
+
+
+def load_positive_samples(path: Path, max_samples: int) -> list[dict[str, Any]]:
+    """Load positive conversation records without exposing their contents."""
+    with path.open(encoding="utf-8") as data_file:
+        data = json.load(data_file)
+    if not isinstance(data, list):
+        raise TypeError("Training data must be a JSON list")
+    positive = [sample for sample in data if sample.get("is_positive", False)]
+    if not positive:
+        raise ValueError("Training data contains no positive samples")
+    return positive[:max_samples] if max_samples > 0 else positive
+
+
+def resolve_image(image_dir: Path, reference: str) -> Path:
+    """Resolve a relative image reference without allowing path traversal."""
+    root = image_dir.resolve()
+    candidate = (root / reference).resolve()
+    if not candidate.is_relative_to(root):
+        raise ValueError(f"Image reference escapes --image-dir: {reference}")
+    return candidate
+
+
+def prepare_sample(
+    sample: dict[str, Any], image_dir: Path, max_image_size: int
+) -> tuple[list[dict[str, Any]], str]:
+    """Convert one MobileForge conversation into prompt messages and target."""
+    input_messages: list[dict[str, Any]] = []
+    target_text = ""
+
+    for message in sample["conversations"]:
+        role = message["role"]
+        content = message["content"]
+        if role == "assistant":
+            if isinstance(content, list):
+                target_text = content[0].get("text", "")
+            else:
+                target_text = str(content)
+            continue
+
+        if not isinstance(content, list):
+            input_messages.append({"role": role, "content": content})
+            continue
+
+        converted: list[dict[str, Any]] = []
+        for part in content:
+            if part.get("type") == "text":
+                converted.append({"type": "text", "text": part["text"]})
+            elif part.get("type") == "image_url":
+                reference = part["image_url"]["url"]
+                image_path = resolve_image(image_dir, reference)
+                if not image_path.is_file():
+                    raise FileNotFoundError(f"Training image not found: {reference}")
+                with Image.open(image_path) as source:
+                    image = source.convert("RGB")
+                image.thumbnail((max_image_size, max_image_size))
+                converted.append({"type": "image", "image": image})
+        input_messages.append({"role": role, "content": converted})
+
+    if not target_text:
+        raise ValueError("Sample has no assistant target")
+    return input_messages, target_text
+
+
+class MobileForgeLoRADataset(torch.utils.data.Dataset):
+    """Tokenize MobileForge conversations and mask prompt tokens."""
+
+    def __init__(
+        self,
+        samples: list[dict[str, Any]],
+        processor: Any,
+        image_dir: Path,
+        max_image_size: int,
+        max_length: int,
+    ):
+        self.samples = samples
+        self.processor = processor
+        self.image_dir = image_dir
+        self.max_image_size = max_image_size
+        self.max_length = max_length
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
+        input_messages, target = prepare_sample(
+            self.samples[index], self.image_dir, self.max_image_size
+        )
+        full_messages = input_messages + [{"role": "assistant", "content": target}]
+        full_text = self.processor.apply_chat_template(
+            full_messages, tokenize=False, add_generation_prompt=False
+        )
+        prompt_text = self.processor.apply_chat_template(
+            input_messages, tokenize=False, add_generation_prompt=True
+        )
+        images = [
+            part["image"]
+            for message in input_messages
+            if isinstance(message.get("content"), list)
+            for part in message["content"]
+            if part.get("type") == "image"
+        ]
+        image_input = images or None
+        inputs = self.processor(
+            text=[full_text],
+            images=image_input,
+            return_tensors="pt",
+            truncation=True,
+            max_length=self.max_length,
+        )
+        prompt = self.processor(
+            text=[prompt_text],
+            images=image_input,
+            return_tensors="pt",
+            truncation=True,
+            max_length=self.max_length,
+        )
+
+        input_ids = inputs["input_ids"].squeeze(0)
+        labels = input_ids.clone()
+        labels[: prompt["input_ids"].shape[1]] = -100
+        item = {
+            "input_ids": input_ids,
+            "attention_mask": inputs["attention_mask"].squeeze(0),
+            "labels": labels,
+        }
+        for key in ("pixel_values", IMAGE_GRID_KEY):
+            if key in inputs:
+                item[key] = inputs[key]
+        return item
+
+
+class MobileForgeCollator:
+    """Pad text tensors and combine vision inputs."""
+
+    def __init__(self, pad_token_id: int):
+        self.pad_token_id = pad_token_id
+
+    def __call__(self, batch: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:
+        max_length = max(item["input_ids"].shape[0] for item in batch)
+
+        def pad(tensor: torch.Tensor, value: int) -> torch.Tensor:
+            amount = max_length - tensor.shape[0]
+            return torch.cat([tensor, torch.full((amount,), value, dtype=tensor.dtype)])
+
+        result = {
+            "input_ids": torch.stack(
+                [pad(item["input_ids"], self.pad_token_id) for item in batch]
+            ),
+            "attention_mask": torch.stack(
+                [pad(item["attention_mask"], 0) for item in batch]
+            ),
+            "labels": torch.stack([pad(item["labels"], -100) for item in batch]),
+        }
+        for key in ("pixel_values", IMAGE_GRID_KEY):
+            if key in batch[0]:
+                result[key] = torch.cat([item[key] for item in batch], dim=0)
+        return result
+
+
+def copy_processor_files(model_path: str, merged_dir: Path) -> None:
+    """Copy local tokenizer assets that save_pretrained may omit."""
+    source_dir = Path(model_path)
+    if not source_dir.is_dir():
+        return
+    for name in (
+        "vocab.json",
+        "merges.txt",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+        "chat_template.json",
+        "preprocessor_config.json",
+        "video_preprocessor_config.json",
+        "added_tokens.json",
+    ):
+        source = source_dir / name
+        destination = merged_dir / name
+        if source.is_file() and not destination.exists():
+            shutil.copy2(source, destination)
+
+
+def main() -> None:
+    args = parse_args()
+    samples = load_positive_samples(args.data_path, args.max_samples)
+    processor = AutoProcessor.from_pretrained(args.model_path)
+
+    model_kwargs: dict[str, Any] = {
+        "dtype": torch.bfloat16,
+        "device_map": "auto" if args.use_4bit else "cuda:0",
+        "trust_remote_code": True,
+    }
+    if args.use_4bit:
+        model_kwargs["quantization_config"] = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=torch.bfloat16,
+            bnb_4bit_use_double_quant=True,
+        )
+    model = AutoModelForImageTextToText.from_pretrained(args.model_path, **model_kwargs)
+    if args.use_4bit:
+        model = prepare_model_for_kbit_training(model)
+    model.config.use_cache = False
+
+    model = get_peft_model(
+        model,
+        LoraConfig(
+            task_type=TaskType.CAUSAL_LM,
+            r=args.lora_rank,
+            lora_alpha=args.lora_alpha,
+            lora_dropout=0.05,
+            target_modules=[
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "o_proj",
+                "gate_proj",
+                "up_proj",
+                "down_proj",
+            ],
+            bias="none",
+        ),
+    )
+    model.print_trainable_parameters()
+
+    dataset = MobileForgeLoRADataset(
+        samples,
+        processor,
+        args.image_dir,
+        args.max_image_size,
+        args.max_length,
+    )
+    pad_token_id = processor.tokenizer.pad_token_id
+    if pad_token_id is None:
+        pad_token_id = processor.tokenizer.eos_token_id
+
+    trainer = Trainer(
+        model=model,
+        args=TrainingArguments(
+            output_dir=str(args.output_dir),
+            num_train_epochs=args.num_epochs,
+            per_device_train_batch_size=args.batch_size,
+            gradient_accumulation_steps=args.gradient_accumulation_steps,
+            learning_rate=args.learning_rate,
+            warmup_ratio=0.05,
+            logging_steps=10,
+            save_steps=200,
+            save_total_limit=2,
+            bf16=True,
+            report_to="none",
+            remove_unused_columns=False,
+            dataloader_num_workers=0,
+            gradient_checkpointing=True,
+            gradient_checkpointing_kwargs={"use_reentrant": False},
+        ),
+        train_dataset=dataset,
+        data_collator=MobileForgeCollator(pad_token_id),
+    )
+    trainer.train()
+
+    adapter_dir = args.output_dir / "lora_adapter"
+    model.save_pretrained(adapter_dir)
+    processor.save_pretrained(adapter_dir)
+    if args.use_4bit:
+        print(f"Saved adapter to {adapter_dir}; skipped quantized merge")
+        return
+
+    merged_dir = args.output_dir / "merged"
+    merged_model = model.merge_and_unload()
+    merged_model.save_pretrained(merged_dir, safe_serialization=True)
+    processor.save_pretrained(merged_dir)
+    copy_processor_files(args.model_path, merged_dir)
+    print(f"Saved adapter to {adapter_dir} and merged model to {merged_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/src/lib/interaction-config.ts
+++ b/frontend/src/lib/interaction-config.ts
@@ -10,6 +10,7 @@ const defaultInteractionConfig: InteractionConfig = {
     gemini: ['Interact', 'Take_over'],
     'glm-async': ['Interact', 'Take_over'],
     qwen: ['Interact', 'Take_over'],
+    mobileforge: ['Interact', 'Take_over'],
     droidrun: ['Interact', 'Take_over'],
     midscene: ['Interact', 'Take_over'],
   },

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -77,6 +77,7 @@ export const en = {
     agentMidsceneDesc:
       'Midscene.js vision-driven, requires Node.js environment',
     agentQwenDesc: 'Adapted for Qwen3.6 series',
+    agentMobileForgeDesc: 'Qwen-VL models using the MobileForge tool-call protocol',
   },
   deviceSidebar: {
     devices: 'Devices',

--- a/frontend/src/lib/locales/zh.ts
+++ b/frontend/src/lib/locales/zh.ts
@@ -72,6 +72,7 @@ export const zh = {
     agentDroidrunDesc: '基于 DroidRun 框架，需安装 Portal APK',
     agentMidsceneDesc: '基于 Midscene.js 视觉驱动，需要 Node.js 环境',
     agentQwenDesc: 'Qwen3.6系列适配',
+    agentMobileForgeDesc: '适配 MobileForge 工具调用协议的 Qwen-VL 模型',
   },
   deviceSidebar: {
     devices: '设备',

--- a/frontend/src/routes/chat.tsx
+++ b/frontend/src/routes/chat.tsx
@@ -125,6 +125,13 @@ const AGENT_PRESETS = [
     icon: Layers,
     defaultConfig: {},
   },
+  {
+    name: 'mobileforge',
+    displayName: 'MobileForge Agent',
+    descriptionKey: 'agentMobileForgeDesc',
+    icon: Layers,
+    defaultConfig: {},
+  },
 ] as const;
 
 // 决策模型预设配置（与视觉模型保持一致）

--- a/tests/test_mobileforge_agent.py
+++ b/tests/test_mobileforge_agent.py
@@ -1,6 +1,7 @@
 """Tests for the MobileForge protocol adapter."""
 
 import asyncio
+import json
 
 import pytest
 
@@ -14,7 +15,7 @@ from AutoGLM_GUI.device_protocol import Screenshot
 class _FakeDevice:
     device_id = "mobileforge-test"
 
-    def get_screenshot(self, timeout: int = 10) -> Screenshot:  # noqa: ARG002
+    def get_screenshot(self, timeout: int = 10) -> Screenshot:
         return Screenshot(base64_data="image", width=1080, height=2400)
 
     def get_current_app(self) -> str:
@@ -26,12 +27,17 @@ class TestMobileForgeParser:
         ("content", "expected"),
         [
             (
-                '<thinking>tap it</thinking><tool_call>{"action":"click","coordinate":[12,999]}</tool_call>',
+                '<thinking>tap it</thinking><tool_call>{"name":"mobile_use","arguments":{"action":"click","coordinate":[12,999]}}</tool_call>',
                 {"_metadata": "do", "action": "Tap", "element": [12, 999]},
             ),
             (
                 '<tool_call>{"action":"swipe","start":[100,200],"end":[300,400]}</tool_call>',
-                {"_metadata": "do", "action": "Swipe", "start": [100, 200], "end": [300, 400]},
+                {
+                    "_metadata": "do",
+                    "action": "Swipe",
+                    "start": [100, 200],
+                    "end": [300, 400],
+                },
             ),
             (
                 '<tool_call>{"action":"type","text":"hello"}</tool_call>',
@@ -64,6 +70,46 @@ class TestMobileForgeParser:
         with pytest.raises(ValueError, match="Unsupported"):
             parser.parse('{"action":"shell"}')
 
+    @pytest.mark.parametrize(
+        ("arguments", "expected"),
+        [
+            (
+                {
+                    "action": "swipe",
+                    "coordinate": [500, 750],
+                    "coordinate2": [500, 250],
+                },
+                {
+                    "_metadata": "do",
+                    "action": "Swipe",
+                    "start": [500, 750],
+                    "end": [500, 250],
+                },
+            ),
+            (
+                {"action": "open", "text": "Settings"},
+                {"_metadata": "do", "action": "Launch", "app": "Settings"},
+            ),
+            (
+                {"action": "wait", "time": 2},
+                {"_metadata": "do", "action": "Wait", "duration": "2 seconds"},
+            ),
+            (
+                {"action": "system_button", "button": "Home"},
+                {"_metadata": "do", "action": "Home"},
+            ),
+            (
+                {"action": "terminate", "status": "failure"},
+                {"_metadata": "finish", "message": "Task infeasible"},
+            ),
+        ],
+    )
+    def test_sanitized_harmonyos_trace_shapes(self, arguments, expected):
+        """Exercise real MobileForge shapes without retaining device trace data."""
+        parser = MobileForgeParser()
+        payload = json.dumps({"name": "mobile_use", "arguments": arguments})
+        assert parser.parse(payload) == expected
+
 
 def test_mobileforge_agent_preserves_native_assistant_context(monkeypatch):
     agent = AsyncMobileForgeAgent(
@@ -72,11 +118,11 @@ def test_mobileforge_agent_preserves_native_assistant_context(monkeypatch):
         device=_FakeDevice(),
     )
     response = (
-        '<thinking>the app is open</thinking>'
+        "<thinking>the app is open</thinking>"
         '<tool_call>{"action":"terminate","status":"success"}</tool_call>'
     )
 
-    async def fake_stream(messages):  # noqa: ARG001
+    async def fake_stream(messages):
         yield {"type": "raw", "content": response}
 
     monkeypatch.setattr(agent, "_stream_openai", fake_stream)

--- a/tests/test_mobileforge_agent.py
+++ b/tests/test_mobileforge_agent.py
@@ -1,0 +1,101 @@
+"""Tests for the MobileForge protocol adapter."""
+
+import asyncio
+
+import pytest
+
+from AutoGLM_GUI.actions import ActionResult
+from AutoGLM_GUI.agents.mobileforge.async_agent import AsyncMobileForgeAgent
+from AutoGLM_GUI.agents.mobileforge.parser import MobileForgeParser
+from AutoGLM_GUI.config import AgentConfig, ModelConfig
+from AutoGLM_GUI.device_protocol import Screenshot
+
+
+class _FakeDevice:
+    device_id = "mobileforge-test"
+
+    def get_screenshot(self, timeout: int = 10) -> Screenshot:  # noqa: ARG002
+        return Screenshot(base64_data="image", width=1080, height=2400)
+
+    def get_current_app(self) -> str:
+        return "com.example.app"
+
+
+class TestMobileForgeParser:
+    @pytest.mark.parametrize(
+        ("content", "expected"),
+        [
+            (
+                '<thinking>tap it</thinking><tool_call>{"action":"click","coordinate":[12,999]}</tool_call>',
+                {"_metadata": "do", "action": "Tap", "element": [12, 999]},
+            ),
+            (
+                '<tool_call>{"action":"swipe","start":[100,200],"end":[300,400]}</tool_call>',
+                {"_metadata": "do", "action": "Swipe", "start": [100, 200], "end": [300, 400]},
+            ),
+            (
+                '<tool_call>{"action":"type","text":"hello"}</tool_call>',
+                {"_metadata": "do", "action": "Type", "text": "hello"},
+            ),
+            (
+                '<tool_call>{"action":"system_button","button":"home"}</tool_call>',
+                {"_metadata": "do", "action": "Home"},
+            ),
+            (
+                '<tool_call>{"action":"terminate","status":"success"}</tool_call>',
+                {"_metadata": "finish", "message": "Task completed"},
+            ),
+        ],
+    )
+    def test_translates_supported_actions(self, content, expected):
+        parser = MobileForgeParser()
+        thinking, action = parser.parse_response(content)
+        assert parser.parse(action) == expected
+        assert isinstance(thinking, str)
+
+    def test_rejects_missing_or_unsafe_calls(self):
+        parser = MobileForgeParser()
+        thinking, action = parser.parse_response("plain text")
+        assert thinking == ""
+        with pytest.raises(ValueError, match="Invalid"):
+            parser.parse(action)
+        with pytest.raises(ValueError, match="two-number"):
+            parser.parse('{"action":"click","coordinate":"bad"}')
+        with pytest.raises(ValueError, match="Unsupported"):
+            parser.parse('{"action":"shell"}')
+
+
+def test_mobileforge_agent_preserves_native_assistant_context(monkeypatch):
+    agent = AsyncMobileForgeAgent(
+        model_config=ModelConfig(),
+        agent_config=AgentConfig(max_steps=2, verbose=False),
+        device=_FakeDevice(),
+    )
+    response = (
+        '<thinking>the app is open</thinking>'
+        '<tool_call>{"action":"terminate","status":"success"}</tool_call>'
+    )
+
+    async def fake_stream(messages):  # noqa: ARG001
+        yield {"type": "raw", "content": response}
+
+    monkeypatch.setattr(agent, "_stream_openai", fake_stream)
+    monkeypatch.setattr(
+        agent.action_handler,
+        "execute",
+        lambda *args, **kwargs: ActionResult(True, True, "done"),
+    )
+
+    async def run() -> None:
+        agent._prepare_initial_context("finish", "image", "com.example.app")
+        async for _ in agent._execute_step():
+            pass
+
+    asyncio.run(run())
+    assert agent._context[-1]["content"] == response
+
+
+def test_mobileforge_agent_is_registered():
+    from AutoGLM_GUI.agents import is_agent_type_registered
+
+    assert is_agent_type_registered("mobileforge")


### PR DESCRIPTION
## Summary

- Add a MobileForge-compatible agent, parser, prompt, GUI preset, and registration.
- Align parsing with the actual `mobile_use` wrapper (`name` + `arguments`) while retaining the earlier flat JSON form for compatibility.
- Support MobileForge field names for swipe, app launch, wait, system buttons, and task termination.
- Add a Qwen3-VL-4B LoRA SFT recipe, optional training dependencies, vLLM serving helper, and usage documentation.
- Add offline tests using synthetic action shapes derived from privacy-reviewed HarmonyOS 6 experiments.

## Device compatibility

AutoGLM-GUI still uses its existing Android ADB device backend. This PR adds the MobileForge model protocol and training recipe; it does **not** add or claim a HarmonyOS/HDC transport backend.

## Privacy

No raw HDC/ADB traces, screenshots, prompts, task text, chat content, device identifiers, private network addresses, credentials, checkpoints, or local training logs are included. The regression cases retain only synthetic protocol/action shapes.

## Validation

- `uv run python scripts/lint.py --backend --check-only`
- `python -m pytest tests/test_mobileforge_agent.py -v` - 13 passed
- `python examples/mobileforge/smoke_test.py` - passed (with the project on `PYTHONPATH`)
- `python -m py_compile` for the parser, prompts, smoke test, and training script
- `git diff --check`