### PR TITLE
fix: wait for ADB Keyboard IME registration before enable

### DIFF
--- a/AutoGLM_GUI/adb/input.py
+++ b/AutoGLM_GUI/adb/input.py
@@ -4,7 +4,10 @@ import base64
 import subprocess
 from collections.abc import Sequence
 
-from AutoGLM_GUI.adb_plus.keyboard_installer import ADB_KEYBOARD_IME
+from AutoGLM_GUI.adb_plus.keyboard_installer import (
+    ADB_KEYBOARD_IME,
+    ADB_KEYBOARD_PACKAGE,
+)
 from AutoGLM_GUI.platform_utils import build_adb_command, run_cmd_silently
 from AutoGLM_GUI.trace import trace_span
 
@@ -108,13 +111,42 @@ def _read_default_ime(adb_prefix: Sequence[str]) -> str:
     return _combined_output(result)
 
 
-def _enable_and_set_adb_keyboard(adb_prefix: Sequence[str]) -> None:
-    enable = subprocess.run(
-        list(adb_prefix) + ["shell", "ime", "enable", ADB_KEYBOARD_IME],
+def _is_adb_ime_enabled(adb_prefix: Sequence[str]) -> bool:
+    """Return True if ADB Keyboard is already in the enabled IME list.
+
+    Reads ``enabled_input_methods`` first. ``ime list -s`` is only a
+    fallback because some OEM ROMs raise SecurityException on it.
+    """
+    result = subprocess.run(
+        list(adb_prefix)
+        + ["shell", "settings", "get", "secure", "enabled_input_methods"],
         capture_output=True,
         text=True,
         check=False,
     )
+    enabled_imes = result.stdout.strip()
+    if enabled_imes and enabled_imes != "null" and result.returncode == 0:
+        return ADB_KEYBOARD_PACKAGE in enabled_imes or ADB_KEYBOARD_IME in enabled_imes
+
+    listed = subprocess.run(
+        list(adb_prefix) + ["shell", "ime", "list", "-s"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return ADB_KEYBOARD_IME in _combined_output(listed)
+
+
+def _enable_and_set_adb_keyboard(adb_prefix: Sequence[str]) -> None:
+    enable_out = "skipped, already enabled"
+    if not _is_adb_ime_enabled(adb_prefix):
+        enable = subprocess.run(
+            list(adb_prefix) + ["shell", "ime", "enable", ADB_KEYBOARD_IME],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        enable_out = _combined_output(enable)
     set_ime = subprocess.run(
         list(adb_prefix) + ["shell", "ime", "set", ADB_KEYBOARD_IME],
         capture_output=True,
@@ -124,7 +156,7 @@ def _enable_and_set_adb_keyboard(adb_prefix: Sequence[str]) -> None:
     current_ime = _read_default_ime(adb_prefix)
     _require_adb_ime_current(
         current_ime,
-        f"enable={_combined_output(enable)!r}, set={_combined_output(set_ime)!r}",
+        f"enable={enable_out!r}, set={_combined_output(set_ime)!r}",
     )
 
 
@@ -136,17 +168,35 @@ async def _read_default_ime_async(adb_prefix: Sequence[str]) -> str:
     return _combined_output(result)
 
 
-async def _enable_and_set_adb_keyboard_async(adb_prefix: Sequence[str]) -> None:
-    enable = await run_cmd_silently(
-        list(adb_prefix) + ["shell", "ime", "enable", ADB_KEYBOARD_IME],
+async def _is_adb_ime_enabled_async(adb_prefix: Sequence[str]) -> bool:
+    result = await run_cmd_silently(
+        list(adb_prefix)
+        + ["shell", "settings", "get", "secure", "enabled_input_methods"],
     )
+    enabled_imes = result.stdout.strip()
+    if enabled_imes and enabled_imes != "null" and result.returncode == 0:
+        return ADB_KEYBOARD_PACKAGE in enabled_imes or ADB_KEYBOARD_IME in enabled_imes
+
+    listed = await run_cmd_silently(
+        list(adb_prefix) + ["shell", "ime", "list", "-s"],
+    )
+    return ADB_KEYBOARD_IME in _combined_output(listed)
+
+
+async def _enable_and_set_adb_keyboard_async(adb_prefix: Sequence[str]) -> None:
+    enable_out = "skipped, already enabled"
+    if not await _is_adb_ime_enabled_async(adb_prefix):
+        enable = await run_cmd_silently(
+            list(adb_prefix) + ["shell", "ime", "enable", ADB_KEYBOARD_IME],
+        )
+        enable_out = _combined_output(enable)
     set_ime = await run_cmd_silently(
         list(adb_prefix) + ["shell", "ime", "set", ADB_KEYBOARD_IME],
     )
     current_ime = await _read_default_ime_async(adb_prefix)
     _require_adb_ime_current(
         current_ime,
-        f"enable={_combined_output(enable)!r}, set={_combined_output(set_ime)!r}",
+        f"enable={enable_out!r}, set={_combined_output(set_ime)!r}",
     )
 
 

--- a/AutoGLM_GUI/adb/input.py
+++ b/AutoGLM_GUI/adb/input.py
@@ -2,9 +2,22 @@
 
 import base64
 import subprocess
+from collections.abc import Sequence
 
+from AutoGLM_GUI.adb_plus.keyboard_installer import ADB_KEYBOARD_IME
 from AutoGLM_GUI.platform_utils import build_adb_command, run_cmd_silently
 from AutoGLM_GUI.trace import trace_span
+
+
+def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
+    return f"{result.stdout}{result.stderr}".strip()
+
+
+def _require_adb_ime_current(current_ime: str, detail: str) -> None:
+    if ADB_KEYBOARD_IME not in current_ime:
+        raise RuntimeError(
+            f"Failed to switch to ADB Keyboard (current={current_ime!r}; {detail})"
+        )
 
 
 def type_text(text: str, device_id: str | None = None) -> None:
@@ -84,6 +97,59 @@ async def clear_text_async(device_id: str | None = None) -> None:
         )
 
 
+def _read_default_ime(adb_prefix: Sequence[str]) -> str:
+    result = subprocess.run(
+        list(adb_prefix)
+        + ["shell", "settings", "get", "secure", "default_input_method"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return _combined_output(result)
+
+
+def _enable_and_set_adb_keyboard(adb_prefix: Sequence[str]) -> None:
+    enable = subprocess.run(
+        list(adb_prefix) + ["shell", "ime", "enable", ADB_KEYBOARD_IME],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    set_ime = subprocess.run(
+        list(adb_prefix) + ["shell", "ime", "set", ADB_KEYBOARD_IME],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    current_ime = _read_default_ime(adb_prefix)
+    _require_adb_ime_current(
+        current_ime,
+        f"enable={_combined_output(enable)!r}, set={_combined_output(set_ime)!r}",
+    )
+
+
+async def _read_default_ime_async(adb_prefix: Sequence[str]) -> str:
+    result = await run_cmd_silently(
+        list(adb_prefix)
+        + ["shell", "settings", "get", "secure", "default_input_method"],
+    )
+    return _combined_output(result)
+
+
+async def _enable_and_set_adb_keyboard_async(adb_prefix: Sequence[str]) -> None:
+    enable = await run_cmd_silently(
+        list(adb_prefix) + ["shell", "ime", "enable", ADB_KEYBOARD_IME],
+    )
+    set_ime = await run_cmd_silently(
+        list(adb_prefix) + ["shell", "ime", "set", ADB_KEYBOARD_IME],
+    )
+    current_ime = await _read_default_ime_async(adb_prefix)
+    _require_adb_ime_current(
+        current_ime,
+        f"enable={_combined_output(enable)!r}, set={_combined_output(set_ime)!r}",
+    )
+
+
 def detect_and_set_adb_keyboard(device_id: str | None = None) -> str:
     adb_prefix = build_adb_command(device_id)
 
@@ -91,25 +157,14 @@ def detect_and_set_adb_keyboard(device_id: str | None = None) -> str:
         "adb.detect_adb_keyboard",
         attrs={"device_id": device_id},
     ):
-        result = subprocess.run(
-            adb_prefix + ["shell", "settings", "get", "secure", "default_input_method"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    current_ime = (result.stdout + result.stderr).strip()
+        current_ime = _read_default_ime(adb_prefix)
 
-    if "com.android.adbkeyboard/.AdbIME" not in current_ime:
+    if ADB_KEYBOARD_IME not in current_ime:
         with trace_span(
             "adb.set_adb_keyboard",
             attrs={"device_id": device_id},
         ):
-            subprocess.run(
-                adb_prefix + ["shell", "ime", "set", "com.android.adbkeyboard/.AdbIME"],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
+            _enable_and_set_adb_keyboard(adb_prefix)
 
     type_text("", device_id)
 
@@ -123,19 +178,14 @@ async def detect_and_set_adb_keyboard_async(device_id: str | None = None) -> str
         "adb.detect_adb_keyboard",
         attrs={"device_id": device_id},
     ):
-        result = await run_cmd_silently(
-            adb_prefix + ["shell", "settings", "get", "secure", "default_input_method"],
-        )
-    current_ime = (result.stdout + result.stderr).strip()
+        current_ime = await _read_default_ime_async(adb_prefix)
 
-    if "com.android.adbkeyboard/.AdbIME" not in current_ime:
+    if ADB_KEYBOARD_IME not in current_ime:
         with trace_span(
             "adb.set_adb_keyboard",
             attrs={"device_id": device_id},
         ):
-            await run_cmd_silently(
-                adb_prefix + ["shell", "ime", "set", "com.android.adbkeyboard/.AdbIME"],
-            )
+            await _enable_and_set_adb_keyboard_async(adb_prefix)
 
     await type_text_async("", device_id)
 

--- a/AutoGLM_GUI/adb_plus/keyboard_installer.py
+++ b/AutoGLM_GUI/adb_plus/keyboard_installer.py
@@ -5,6 +5,7 @@ without requiring users to manually download and install APK.
 """
 
 import asyncio
+import time
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,12 @@ ADB_KEYBOARD_APK_URL = (
     "https://github.com/senzhk/ADBKeyBoard/raw/master/ADBKeyboard.apk"
 )
 ADB_KEYBOARD_APK_FILENAME = "ADBKeyboard.apk"
+
+# Install can succeed before InputMethodManager lists the new IME.
+IME_REGISTER_TIMEOUT_S = 5.0
+IME_REGISTER_POLL_INTERVAL_S = 0.3
+ENABLE_RETRY_COUNT = 3
+ENABLE_RETRY_DELAY_S = 0.4
 
 # APK file in user cache directory (fallback)
 USER_CACHE_APK_PATH = Path.home() / ".cache" / "autoglm" / ADB_KEYBOARD_APK_FILENAME
@@ -256,25 +263,80 @@ class ADBKeyboardInstaller:
                 )
             )
 
-            if result.returncode == 0:
+            output = f"{result.stdout} {result.stderr}"
+            if result.returncode == 0 and not _ime_unknown(output):
                 success_msg = "ADB Keyboard enabled successfully"
                 logger.info(success_msg)
                 return True, success_msg
-            else:
-                # Some devices return non-zero but still succeed, verify with is_enabled()
-                if self.is_enabled():
-                    success_msg = "ADB Keyboard enabled (verified)"
-                    logger.info(success_msg)
-                    return True, success_msg
-                else:
-                    error_msg = f"Enable failed: {result.stdout} {result.stderr}"
-                    logger.warning(error_msg)
-                    return False, error_msg
+
+            # Some devices return non-zero but still succeed, verify with is_enabled()
+            if self.is_enabled():
+                success_msg = "ADB Keyboard enabled (verified)"
+                logger.info(success_msg)
+                return True, success_msg
+
+            error_msg = f"Enable failed: {result.stdout} {result.stderr}"
+            logger.warning(error_msg)
+            return False, error_msg
 
         except Exception as e:
             error_msg = f"Enable error: {e}"
             logger.exception("Unexpected error during enable")
             return False, error_msg
+
+    def is_ime_registered(self) -> bool:
+        """Return True when InputMethodManager lists ADB Keyboard.
+
+        Uses ``ime list -a`` so disabled-but-registered IMEs count. A failed
+        query returns False; the caller should not spin on command errors.
+        """
+        try:
+            result = asyncio.run(
+                run_cmd_silently(self.adb_prefix + ["shell", "ime", "list", "-a"])
+            )
+        except Exception as e:
+            logger.debug(f"ime list -a failed: {e}")
+            return False
+
+        output = f"{result.stdout} {result.stderr}"
+        if result.returncode != 0 and ADB_KEYBOARD_IME not in output:
+            logger.debug(f"ime list -a returned {result.returncode}: {output.strip()}")
+            return False
+        return ADB_KEYBOARD_IME in output
+
+    def wait_for_ime_registered(
+        self,
+        timeout: float = IME_REGISTER_TIMEOUT_S,
+        interval: float = IME_REGISTER_POLL_INTERVAL_S,
+    ) -> bool:
+        """Poll until the IME is registered, or the timeout elapses."""
+        deadline = time.monotonic() + timeout
+        while True:
+            if self.is_ime_registered():
+                logger.debug("ADB Keyboard IME is registered")
+                return True
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "ADB Keyboard IME was not listed within "
+                    f"{timeout:.1f}s; attempting enable anyway"
+                )
+                return False
+            time.sleep(interval)
+
+    def _enable_after_registered(self) -> tuple[bool, str]:
+        """Wait for IME registration, then enable with a few retries."""
+        self.wait_for_ime_registered()
+        last_result = (False, "Enable not attempted")
+        for attempt in range(ENABLE_RETRY_COUNT):
+            last_result = self.enable()
+            if last_result[0]:
+                return last_result
+            if attempt < ENABLE_RETRY_COUNT - 1:
+                logger.info(
+                    f"Retrying ADB Keyboard enable ({attempt + 1}/{ENABLE_RETRY_COUNT})"
+                )
+                time.sleep(ENABLE_RETRY_DELAY_S)
+        return last_result
 
     def auto_setup(self) -> tuple[bool, str]:
         """
@@ -305,7 +367,7 @@ class ADBKeyboardInstaller:
         # Status 2: Installed but not enabled
         if installed and not enabled:
             logger.info("ADB Keyboard is installed but not enabled, enabling now")
-            return self.enable()
+            return self._enable_after_registered()
 
         # Status 3: Not installed
         if not installed:
@@ -323,8 +385,8 @@ class ADBKeyboardInstaller:
                 logger.error(f"Installation failed: {message}")
                 return False, message
 
-            # Step 3: Enable
-            success, message = self.enable()
+            # Step 3: Wait for IME registration, then enable
+            success, message = self._enable_after_registered()
             if not success:
                 logger.error(f"Enable failed: {message}")
                 return False, message
@@ -394,6 +456,11 @@ def auto_setup_adb_keyboard(device_id: str | None = None) -> tuple[bool, str]:
     """
     installer = ADBKeyboardInstaller(device_id)
     return installer.auto_setup()
+
+
+def _ime_unknown(output: str) -> bool:
+    """Return True if adb ime output says the IME is not registered."""
+    return "unknown input method" in output.lower()
 
 
 def check_and_suggest_installation() -> bool:

--- a/AutoGLM_GUI/device_manager.py
+++ b/AutoGLM_GUI/device_manager.py
@@ -1015,13 +1015,18 @@ class DeviceManager:
     def _ensure_adb_keyboard_once(
         self, device_id: ConnectionDeviceID, managed: ManagedDevice
     ) -> None:
-        """Best-effort ADB Keyboard setup for local ADB devices (once per serial)."""
+        """Best-effort ADB Keyboard setup for local ADB devices.
+
+        Successful setup is remembered per serial. A failed attempt is
+        retried on the next protocol access so a later-registered IME can
+        still be enabled.
+        """
         if managed.connection_type == DeviceConnectionType.REMOTE:
             return
 
         serial = managed.serial
         with self._adb_keyboard_setup_lock:
-            if serial in self._adb_keyboard_attempted_serials:
+            if serial in self._adb_keyboard_ready_serials:
                 return
             self._adb_keyboard_attempted_serials.add(serial)
 

--- a/tests/test_adb_input.py
+++ b/tests/test_adb_input.py
@@ -86,3 +86,52 @@ def test_detect_and_set_adb_keyboard_does_not_broadcast_empty_text(
             "default_input_method",
         ]
     ]
+
+
+def test_detect_and_set_enables_then_sets_keyboard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    current = ["ime.old/.Keyboard"]
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[-4:] == ["settings", "get", "secure", "default_input_method"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=current[0], stderr="")
+        if cmd[-2:] == ["ime", "set"] or (
+            len(cmd) >= 2 and cmd[-2] == "set" and "adbkeyboard" in cmd[-1]
+        ):
+            current[0] = "com.android.adbkeyboard/.AdbIME"
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(adb_input.subprocess, "run", fake_run)
+
+    original_ime = adb_input.detect_and_set_adb_keyboard(device_id="device-1")
+
+    assert original_ime == "ime.old/.Keyboard"
+    flattened = [" ".join(call) for call in calls]
+    assert any(
+        "ime enable com.android.adbkeyboard/.AdbIME" in line for line in flattened
+    )
+    assert any("ime set com.android.adbkeyboard/.AdbIME" in line for line in flattened)
+
+
+def test_detect_and_set_raises_when_ime_does_not_switch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if cmd[-4:] == ["settings", "get", "secure", "default_input_method"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="ime.old/.Keyboard", stderr=""
+            )
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="",
+            stderr="Unknown input method com.android.adbkeyboard/.AdbIME",
+        )
+
+    monkeypatch.setattr(adb_input.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="Failed to switch to ADB Keyboard"):
+        adb_input.detect_and_set_adb_keyboard(device_id="device-1")

--- a/tests/test_adb_input.py
+++ b/tests/test_adb_input.py
@@ -116,6 +116,34 @@ def test_detect_and_set_enables_then_sets_keyboard(
     assert any("ime set com.android.adbkeyboard/.AdbIME" in line for line in flattened)
 
 
+def test_detect_and_set_skips_enable_when_already_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    current = ["ime.old/.Keyboard"]
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[-4:] == ["settings", "get", "secure", "default_input_method"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=current[0], stderr="")
+        if cmd[-4:] == ["settings", "get", "secure", "enabled_input_methods"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="com.android.adbkeyboard/.AdbIME", stderr=""
+            )
+        if len(cmd) >= 2 and cmd[-2] == "set" and "adbkeyboard" in cmd[-1]:
+            current[0] = "com.android.adbkeyboard/.AdbIME"
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(adb_input.subprocess, "run", fake_run)
+
+    original_ime = adb_input.detect_and_set_adb_keyboard(device_id="device-1")
+
+    assert original_ime == "ime.old/.Keyboard"
+    flattened = [" ".join(call) for call in calls]
+    assert not any("ime enable " in line for line in flattened)
+    assert any("ime set com.android.adbkeyboard/.AdbIME" in line for line in flattened)
+
+
 def test_detect_and_set_raises_when_ime_does_not_switch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_adb_keyboard_check.py
+++ b/tests/test_adb_keyboard_check.py
@@ -209,7 +209,7 @@ class TestAutoSetup:
                 assert "already installed" in msg
 
     def test_installed_not_enabled_enables(self) -> None:
-        """When installed but not enabled, should call enable."""
+        """When installed but not enabled, should wait then enable."""
         with patch(
             "AutoGLM_GUI.adb_plus.keyboard_installer.run_cmd_silently"
         ) as mock_run:
@@ -219,10 +219,114 @@ class TestAutoSetup:
             installer = _make_installer()
             with patch.object(installer, "is_enabled", return_value=False):
                 with patch.object(
-                    installer,
-                    "enable",
-                    return_value=(True, "ADB Keyboard enabled successfully"),
-                ) as mock_enable:
-                    success, msg = installer.auto_setup()
-                    assert success is True
-                    mock_enable.assert_called_once()
+                    installer, "wait_for_ime_registered", return_value=True
+                ):
+                    with patch.object(
+                        installer,
+                        "enable",
+                        return_value=(True, "ADB Keyboard enabled successfully"),
+                    ) as mock_enable:
+                        success, msg = installer.auto_setup()
+                        assert success is True
+                        mock_enable.assert_called_once()
+
+
+class TestImeRegistrationWait:
+    def test_is_ime_registered_true(self) -> None:
+        with patch(
+            "AutoGLM_GUI.adb_plus.keyboard_installer.run_cmd_silently"
+        ) as mock_run:
+            mock_run.return_value = _fake_result(stdout=f"{ADB_KEYBOARD_IME}\n")
+            assert _make_installer().is_ime_registered() is True
+            assert mock_run.call_args[0][0][-2:] == ["list", "-a"]
+
+    def test_is_ime_registered_false(self) -> None:
+        with patch(
+            "AutoGLM_GUI.adb_plus.keyboard_installer.run_cmd_silently"
+        ) as mock_run:
+            mock_run.return_value = _fake_result(
+                stdout="com.google.android.inputmethod.latin/.LatinIME\n"
+            )
+            assert _make_installer().is_ime_registered() is False
+
+    def test_is_ime_registered_command_error_is_false(self) -> None:
+        with patch(
+            "AutoGLM_GUI.adb_plus.keyboard_installer.run_cmd_silently"
+        ) as mock_run:
+            mock_run.side_effect = OSError("device offline")
+            assert _make_installer().is_ime_registered() is False
+
+    def test_wait_returns_immediately_when_registered(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sleeps: list[float] = []
+        monkeypatch.setattr(
+            "AutoGLM_GUI.adb_plus.keyboard_installer.time.sleep",
+            sleeps.append,
+        )
+        installer = _make_installer()
+        with patch.object(installer, "is_ime_registered", return_value=True):
+            assert installer.wait_for_ime_registered(timeout=5, interval=0.3) is True
+        assert sleeps == []
+
+    def test_wait_polls_until_registered(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleeps: list[float] = []
+        monkeypatch.setattr(
+            "AutoGLM_GUI.adb_plus.keyboard_installer.time.sleep",
+            sleeps.append,
+        )
+        installer = _make_installer()
+        with patch.object(installer, "is_ime_registered", side_effect=[False, True]):
+            assert installer.wait_for_ime_registered(timeout=5, interval=0.3) is True
+        assert sleeps == [0.3]
+
+    def test_wait_times_out(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "AutoGLM_GUI.adb_plus.keyboard_installer.time.sleep",
+            lambda _delay: None,
+        )
+        installer = _make_installer()
+        with patch.object(installer, "is_ime_registered", return_value=False):
+            assert installer.wait_for_ime_registered(timeout=0, interval=0.3) is False
+
+    def test_enable_after_registered_retries(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "AutoGLM_GUI.adb_plus.keyboard_installer.time.sleep",
+            lambda _delay: None,
+        )
+        installer = _make_installer()
+        with (
+            patch.object(installer, "wait_for_ime_registered", return_value=False),
+            patch.object(
+                installer,
+                "enable",
+                side_effect=[
+                    (False, "Enable failed: Unknown input method"),
+                    (True, "ADB Keyboard enabled successfully"),
+                ],
+            ) as mock_enable,
+        ):
+            success, message = installer._enable_after_registered()
+        assert success is True
+        assert "enabled" in message
+        assert mock_enable.call_count == 2
+
+    def test_enable_rejects_unknown_ime_even_with_zero_exit(self) -> None:
+        installer = _make_installer()
+        with patch(
+            "AutoGLM_GUI.adb_plus.keyboard_installer.run_cmd_silently"
+        ) as mock_run:
+            mock_run.return_value = _fake_result(
+                stdout="",
+                stderr=(
+                    "Unknown input method com.android.adbkeyboard/.AdbIME "
+                    "cannot be enabled for user #0"
+                ),
+                returncode=0,
+            )
+            with patch.object(installer, "is_enabled", return_value=False):
+                success, message = installer.enable()
+        assert success is False
+        assert "Unknown input method" in message

--- a/tests/test_device_manager_keyboard_init.py
+++ b/tests/test_device_manager_keyboard_init.py
@@ -148,3 +148,18 @@ def test_setup_failure_does_not_raise_and_still_returns_local_protocol(
     assert "SER-3" in manager._adb_keyboard_attempted_serials
     assert "SER-3" not in manager._adb_keyboard_ready_serials
     assert _FakeInstaller.calls.count(("setup", "dev-3")) == 1
+
+
+def test_setup_failure_retries_on_next_protocol_access(
+    manager: device_manager_module.DeviceManager,
+) -> None:
+    managed = _build_local_managed(serial="SER-4", device_id="dev-4")
+    manager._devices["SER-4"] = managed
+    manager._device_id_to_serial["dev-4"] = "SER-4"
+    _FakeInstaller.setup_result = (False, "Enable failed")
+
+    manager.get_device_protocol("dev-4")
+    manager.get_device_protocol("dev-4")
+
+    assert _FakeInstaller.calls.count(("setup", "dev-4")) == 2
+    assert "SER-4" not in manager._adb_keyboard_ready_serials

--- a/tests/test_hardware_boundary_coverage.py
+++ b/tests/test_hardware_boundary_coverage.py
@@ -555,13 +555,14 @@ def test_platform_utils_adb_input_apps_and_version_helpers(
     assert asyncio.run(platform_utils.spawn_process(["spawn-win"])).cmd == ["spawn-win"]
 
     input_calls: list[list[str]] = []
+    current_ime = ["ime.old/.Keyboard"]
 
     def fake_input_run(cmd, **kwargs):
         input_calls.append(cmd)
         if "default_input_method" in cmd:
-            return subprocess.CompletedProcess(
-                cmd, 0, stdout="ime.old/.Keyboard", stderr=""
-            )
+            return subprocess.CompletedProcess(cmd, 0, stdout=current_ime[0], stderr="")
+        if len(cmd) >= 2 and cmd[-2] == "set" and "adbkeyboard" in cmd[-1]:
+            current_ime[0] = "com.android.adbkeyboard/.AdbIME"
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
     monkeypatch.setattr(adb_input.subprocess, "run", fake_input_run)
@@ -573,6 +574,9 @@ def test_platform_utils_adb_input_apps_and_version_helpers(
     flattened = [" ".join(call) for call in input_calls]
     assert any("ADB_INPUT_B64" in call for call in flattened)
     assert any("ADB_CLEAR_TEXT" in call for call in flattened)
+    assert any(
+        "ime enable com.android.adbkeyboard/.AdbIME" in call for call in flattened
+    )
     assert any("ime set com.android.adbkeyboard/.AdbIME" in call for call in flattened)
     assert any("ime set ime.old/.Keyboard" in call for call in flattened)
 
@@ -1025,6 +1029,7 @@ def test_mdns_pair_touch_version_and_keyboard(monkeypatch: pytest.MonkeyPatch) -
     )
     monkeypatch.setattr(installer, "is_installed", lambda: True)
     monkeypatch.setattr(installer, "is_enabled", lambda: False)
+    monkeypatch.setattr(installer, "wait_for_ime_registered", lambda *a, **k: True)
     monkeypatch.setattr(installer, "enable", lambda: (True, "enabled"))
     assert installer.auto_setup() == (True, "enabled")
     status = installer.get_status()
@@ -1044,6 +1049,7 @@ def test_adb_keyboard_installer_download_install_enable_and_auto_setup(
         lambda package: (_ for _ in ()).throw(RuntimeError("no bundle")),
     )
     installer = keyboard.ADBKeyboardInstaller("serial")
+    monkeypatch.setattr(installer, "wait_for_ime_registered", lambda *a, **k: True)
 
     run_results = iter(
         [


### PR DESCRIPTION
## Summary

- `auto_setup()` no longer calls `ime enable` immediately after `adb install`. It polls `ime list -a` until the IME is registered, then enables with a few retries.
- `ime enable` treats `Unknown input method` as failure even when adb returns 0.
- Type path now `ime enable` then `ime set`, and raises if the current IME is still not AdbIME, so the agent no longer pretends input succeeded.
- DeviceManager only skips keyboard setup after a successful ready state; a failed attempt is retried on the next protocol access.

Fixes the Pixel 4 case from #479: install reported success, then `ime enable` immediately failed with `Unknown input method com.android.adbkeyboard/.AdbIME cannot be enabled for user #0`, after which Type broadcasts were ignored.

## Test plan

- [x] `uv run pytest tests/test_adb_keyboard_check.py tests/test_adb_input.py tests/test_device_manager_keyboard_init.py tests/test_hardware_boundary_coverage.py -v`
- [x] `uv run python scripts/lint.py --backend --check-only`

Closes #479