### PR TITLE
fix(ci): stop installing droidrun extra in release-gate

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -28,10 +28,11 @@ jobs:
         with:
           frozen: "true"
 
-      - name: Install optional dependencies
-        run: |
-          echo "📦 Installing optional dependencies..."
-          uv pip install -e ".[droidrun]"
+      # Do not install the droidrun extra here. Those packages pull
+      # arize-phoenix / llama-index, and phoenix's import graph currently
+      # crashes pytest during plugin autoload
+      # (`ModuleNotFoundError: phoenix.evals.models`). No release_gate test
+      # imports the real droidrun package; adapter tests mock it.
 
       - name: Backend lint (check-only)
         run: |


### PR DESCRIPTION
## Summary

- Release-gate 在跑 `pytest -m release_gate` 之前会 `uv pip install -e \".[droidrun]\"`。这个 extra 会带上 `mobilerun` → `arize-phoenix>=12.3.0`（以及 llama-index）。
- 当前最新 phoenix 在 `import phoenix` 时会走到 `phoenix.evals.models.rate_limiters`，该模块已拆走，pytest 加载 setuptools 插件时直接 `ModuleNotFoundError`，测试一行都没跑到。
- 这和业务测试无关。同一次 PR 里不装 droidrun 的 `Run Python Tests` 是绿的；这条 workflow 最近在 renovate PR 上也连续失败。
- `release_gate` 测试不 import 真正的 `droidrun` 包（adapter 测试是 mock，且不在这个 mark 里），所以这个 job 不必装 extra。

## 为什么不选其他修法

- **补 `arize-phoenix-evals` / 钉 phoenix 版本**：在追上游拆包，CI 每次仍要装一整棵 llama-index + phoenix，且 extra 不在 lock 里，下次还会漂。
- **`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`**：能挡住插件爆炸，但仍会为用不到的 optional 依赖花时间和带宽；也容易误伤以后真正需要的 pytest 插件。
- **留在 pr-lint**：那个 job 只跑 ruff/pyright，不跑 pytest，装 droidrun 目前是绿的。这次不动。

## Test plan

- [x] `uv run pytest -m release_gate --collect-only -q`：197 collected，不需要 droidrun
- [ ] CI `Contract + Critical Integration Gate` 应变绿