### PR TITLE
ci: skip Claude auto-review on bot pull requests

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -8,7 +8,12 @@ on:
 jobs:
   review:
     # Forked pull_request runs are read-only and cannot access OIDC/secrets.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Bot dependency PRs (dependabot/renovate) fail this Action with
+    # "Workflow initiated by non-human actor" unless allowed_bots is set.
+    # Skip them instead of spending a review slot on lockfile bumps.
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Claude Auto Review currently runs on every same-repo PR, including Dependabot and Renovate.
- Those bot PRs fail the Action with `Workflow initiated by non-human actor` (seen on #478, #448, and the rest of the open dep PRs).
- Skip the review job when `pull_request.user.type == Bot`. Human PRs are unchanged.
- Do not set `allowed_bots: '*'`; that would spend review quota on lockfile bumps.

## Test plan
- [ ] This PR (human-authored) still triggers Claude Auto Review.
- [ ] After merge, rebase a Dependabot/Renovate PR onto main and confirm Claude Auto Review is **skipped**, not failed.
- [ ] Required checks (`Lint & Format Check`, `Build Summary`) still run on dep PRs.